### PR TITLE
docs: add Sovereign Crew manifesto

### DIFF
--- a/MANIFESTO.md
+++ b/MANIFESTO.md
@@ -1,0 +1,155 @@
+# The Sovereign Crew Manifesto
+
+> **Models are replaceable. User data is not.**
+
+AI agents are leaving the chat box.
+
+They can read email, change code, contact customers, operate infrastructure, handle contracts, and influence money. That makes them useful. It also makes a familiar software failure into a failure of authority.
+
+The industry often asks: *How much autonomy can we give an agent?*
+
+We ask a more important set of questions:
+
+- Who gave it authority?
+- Who can take that authority away?
+- What evidence remains after it acts?
+- Can the owner recover when the model, machine, plugin, or provider fails?
+
+Sovereign Crew is our answer. It is the design philosophy behind Sovereign Agent Runtime and Sovereign Founder OS.
+
+> **A Sovereign Crew is not merely a collection of agents. It is a constitutional arrangement of humans, models, tools, policies, and recovery systems that cooperate without allowing any one of them to become the master.**
+
+We are not against capable AI. We are against invisible, permanent, and unrecoverable authority.
+
+## Intelligence Is Not Trust
+
+A model can be intelligent without being reliable. It can be helpful without being accountable. It can follow the wrong instruction perfectly.
+
+High-privilege agents operate in a world of prompt injection, poisoned context, compromised dependencies, ambiguous intent, provider outages, policy changes, software defects, and ordinary mistakes. None of these require a malicious superintelligence. A plausible answer combined with excessive permission is enough.
+
+Trust therefore cannot come from a model saying that it is safe, from a system prompt telling it to behave, or from a vendor calling it aligned.
+
+Prompts are instructions, not security boundaries.
+
+A model may propose an action. It must not be able to grant itself the permission required to perform that action. It must not be able to execute a sensitive action and then erase or rewrite the evidence. It must not receive the full keys to a business merely because it is convenient.
+
+**AI must not authorize itself.**
+
+## Continuity Cannot Be Rented from One Provider
+
+A company is more than the model currently serving it. It is its customer history, contracts, decisions, credentials, workflows, evidence, and ability to continue tomorrow.
+
+If one model change can break every workflow, the model is a single point of failure. If one cloud account can remove access to company state, the platform is a single point of failure. If one official server is required for recovery, the owner is not sovereign. If one plugin can reach every secret, isolation has already failed.
+
+Convenient dependencies are still dependencies. Providers can experience outages, change prices, alter policies, withdraw models, restrict jurisdictions, or disappear. A serious operating system must expect components to fail and make replacement a normal operation rather than a catastrophe.
+
+Sovereignty does not mean refusing every cloud service. It means retaining the practical ability to inspect, export, replace, revoke, and recover without asking a platform for permission.
+
+**Models are replaceable. User data is not.**
+
+## Mutually Constrained Autonomy
+
+We reject the choice between powerless assistants and all-powerful agents.
+
+Our alternative is **Mutually Constrained Autonomy**: useful autonomy created through separation of powers.
+
+Planning, authorization, execution, auditing, recovery, and ownership are distinct responsibilities. A Planner can propose. A Policy Guard can permit within explicit rules. An Executor can act only within granted capability. An Auditor can preserve evidence. A Recovery Controller can restore valid state. The Human Owner defines the ultimate boundaries and can revoke authority.
+
+No participant should be able to propose a sensitive action, approve it, execute it, declare it successful, and destroy the evidence alone.
+
+This is not autonomy by blind trust. It is autonomy made possible by limits.
+
+## Our Principles
+
+### 1. Models are replaceable. User data is not.
+
+Business state must outlive any model, vendor, API, or orchestration framework. Models consume portable contracts and authorized context; they do not become the canonical home of the company.
+
+### 2. Authority must expire.
+
+Permission should be narrow, time-bound, resource-bound, purpose-bound, and revocable. Standing privilege turns yesterday's approval into tomorrow's breach.
+
+### 3. AI must not authorize itself.
+
+The component requesting power cannot be the sole component granting it. Sensitive authority must come from independently enforced policy, explicit human approval, or both.
+
+### 4. Autonomy must be mutually constrained.
+
+No model, agent, plugin, server, or operator should hold every critical power. Separation of duties is not bureaucratic overhead; it is the architecture that makes meaningful autonomy possible.
+
+### 5. There must be no single point of failure.
+
+Model failure, node failure, key loss, data corruption, policy failure, and provider revocation require distinct recovery paths. Redundancy is incomplete when every fallback depends on the same control plane.
+
+### 6. Local-first means user-controlled.
+
+The owner should control the authoritative state, encryption keys, exports, and recovery material. Cloud services may extend the system, but they must not become the only doorway to the owner's company.
+
+### 7. Plugins are untrusted by default.
+
+Installed does not mean trusted. Popular does not mean safe. Official does not mean infallible. Plugins, tools, external content, and model output must receive only the minimum access their declared task requires.
+
+### 8. Policy is code, not a prompt.
+
+Security rules must be deterministic, inspectable, testable, versioned, and enforced outside the model. Natural-language explanations can help people understand a decision; they cannot replace the mechanism that enforces it.
+
+### 9. Every important action leaves evidence.
+
+Sensitive actions must produce durable, tamper-evident, human-understandable records: what was requested, what policy allowed it, what authority was used, what changed, and what result followed. Logs are not decoration. They are part of accountability and recovery.
+
+### 10. Recovery comes before autonomy.
+
+Before a system is allowed to act more freely, it must prove that the owner can stop it, restore valid state, rotate compromised authority, and continue without the failed component. An action that cannot be recovered from deserves a higher threshold than one that can.
+
+### 11. Security is not a premium feature.
+
+Core isolation, permission enforcement, local ownership, export, audit, and recovery must not be held hostage by a subscription. Paid services may offer convenience and managed infrastructure; they must not own the user's sovereignty.
+
+### 12. We will not claim absolute security.
+
+Every system has assumptions, defects, and limits. We will describe ours. Security claims should be tied to public threat models, reproducible tests, disclosed failures, and evidence that others can challenge.
+
+## What We Commit To
+
+We will design for the owner's right to exit.
+
+We will prefer open contracts and replaceable components over hidden lock-in. We will keep the critical local runtime usable without official servers. We will treat model output, plugins, remote services, and imported content as constrained inputs rather than sources of authority. We will make high-risk actions visible and revocable. We will publish the boundaries of what has and has not been proven.
+
+We will not trade away these principles merely to make a demo look more autonomous.
+
+When convenience and sovereignty conflict, the user must be shown the tradeoff. When automation and recoverability conflict, recovery comes first. When a security claim cannot be demonstrated, it must be presented as an aspiration rather than a fact.
+
+## How to Judge Us
+
+Do not judge Sovereign Crew by the number of agents in a demo. Ask instead:
+
+- Can the owner replace the model without losing the company?
+- Can a permission be understood, limited, and revoked?
+- Can a malicious plugin reach anything it was not explicitly granted?
+- Can an important decision be reconstructed from evidence?
+- Can the system recover without an official server?
+- Can the owner export their state and keys in usable form?
+- Can a failed component be removed without collapsing the whole system?
+- Are security limitations stated as clearly as security features?
+
+These questions turn a manifesto into an engineering standard.
+
+## The Future We Want
+
+We want AI that expands human agency without quietly absorbing human authority.
+
+We want founders and small teams to benefit from powerful automation without surrendering their company to a model provider, cloud account, plugin marketplace, or opaque orchestration layer.
+
+We want systems that continue when components fail, explain themselves when actions matter, and return control when the owner demands it.
+
+The goal is not an agent that can do everything.
+
+The goal is a company that remains yours while agents help operate it.
+
+> **Your company. Your data. Your keys.**
+>
+> **Built on many models. Dependent on none.**
+
+---
+
+This manifesto states the project's position and non-negotiable principles. Technical architecture, threat analysis, implementation decisions, and delivery status belong in the [Architecture](ARCHITECTURE.md), [Threat Model](THREAT_MODEL.md), [RFCs](rfcs/), and [Roadmap](ROADMAP.md). A dedicated technical whitepaper will connect those mechanisms into a complete argument.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ When a single AI provider, cloud vendor, or platform fails — or revokes access
 
 > We killed the model, the server and the plugin. **The company kept running.**
 
+Read **[The Sovereign Crew Manifesto →](MANIFESTO.md)** for the principles we will not compromise.
+
 ## How It Works
 
 Users describe what they want to achieve. The system handles the rest:
@@ -55,10 +57,15 @@ Users see **what to do next** — not agent parameters, token counts, or tool sc
 
 ## Documentation
 
+### Recommended Reading Path
+
+[README](README.md) → [MANIFESTO](MANIFESTO.md) → `WHITEPAPER` *(planned)* → [ARCHITECTURE](ARCHITECTURE.md) → [THREAT MODEL](THREAT_MODEL.md) → [RFCs](rfcs/) → [ROADMAP](ROADMAP.md) → `DEMO` *(planned)*
+
 ### Quick Start (English)
 
 | Document | Description |
 | --- | --- |
+| [MANIFESTO.md](MANIFESTO.md) | The Sovereign Crew position and non-negotiable principles |
 | [VISION.md](VISION.md) | Product vision and design principles |
 | [ARCHITECTURE.md](ARCHITECTURE.md) | System architecture |
 | [THREAT_MODEL.md](THREAT_MODEL.md) | Threat model v0.1 |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -6,11 +6,22 @@ Complete documentation for Sovereign Founder OS. All design intent is public and
 
 English root docs for international contributors; complete Chinese blueprint in `docs/zh/`. See [LANGUAGE.md](LANGUAGE.md).
 
+## Document Roles
+
+| Document | Purpose |
+| --- | --- |
+| [MANIFESTO.md](../MANIFESTO.md) | Position, principles, and the future we want |
+| `WHITEPAPER.md` *(planned)* | Technical architecture, threat model, protocols, and supporting argument |
+| [`rfcs/`](../rfcs/) | One concrete design per RFC |
+| [ARCHITECTURE.md](../ARCHITECTURE.md) | Structure of the current implementation |
+| [THREAT_MODEL.md](../THREAT_MODEL.md) | Attackers, assets, trust boundaries, and defenses |
+
 ## Start Here
 
 | Document | Language | Description |
 | --- | --- | --- |
 | [README.md](../README.md) | EN + 中文 link | Project entry point |
+| [MANIFESTO.md](../MANIFESTO.md) | English | Sovereign Crew's position and non-negotiable principles |
 | [VISION.md](../VISION.md) | English | Product vision and principles |
 | [ROADMAP.md](../ROADMAP.md) | English | Development stages and milestones |
 | [docs/zh/README.md](zh/README.md) | 中文 | Complete design specifications |
@@ -55,7 +66,8 @@ See [zh/README.md](zh/README.md) for the Chinese documentation guide.
 ```text
 README.md ───────────── Entry & quick overview
     │
-    ├── VISION.md ───── What and why
+    ├── MANIFESTO.md ── Position and non-negotiable principles
+    ├── VISION.md ───── Product vision
     ├── ARCHITECTURE.md ─ How it works
     ├── THREAT_MODEL.md ─ What we defend against
     ├── PRIVACY_MODEL.md ─ How data is protected
@@ -69,9 +81,9 @@ README.md ───────────── Entry & quick overview
             └── 04 界面设计
 ```
 
-## RFCs (Planned)
+## RFCs
 
-Architectural decision records will live in `rfcs/` as the implementation begins.
+Architectural decision records live in [`rfcs/`](../rfcs/). They specify individual designs and evolve through implementation and review.
 
 ## Security Artifacts (Planned)
 


### PR DESCRIPTION
## Summary

- add the Sovereign Crew Manifesto as the project's top-level statement of position and non-negotiable principles
- define Mutually Constrained Autonomy and twelve commitments for trustworthy, recoverable agent systems
- add the recommended reading path to the README
- clarify document roles and RFC status in the documentation index

## Why

Sovereign Founder OS needs a concise, quotable document that explains why high-privilege AI agents cannot be trusted by default, why business continuity cannot depend on a single provider, and which principles the project will not compromise.

## Impact

Readers now have a clear entry point from project philosophy to the future whitepaper, architecture, threat model, RFCs, roadmap, and demo. The change is documentation-only and does not alter runtime behavior.

## Validation

- `git diff --cached --check`
- verified all new links target existing repository files or directories
- deliberately marked the future whitepaper and demo as planned instead of adding broken links
