### PR TITLE
feat(app): add local drafting assistant wired to the model gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,9 +186,12 @@ tampering) — every denial is a real enforcement path, not a mock.
 
 - **Workspace** — the first usable product slice: create your company profile,
   add customers, generate offer and invoice drafts (local templates, no model),
-  request to send a document — which always stops in the Approval Center for
-  the human owner — and export every byte of your business state as one JSON
-  file. State lives in the encrypted vault; every change passes the policy
+  ask the local drafting assistant (deterministic, not an LLM, routed through
+  the resilient model gateway) to suggest outreach text — a suggestion that is
+  never saved to authoritative state and whose only footprint is an audited
+  disclosure — request to send a document (which always stops in the Approval
+  Center for the human owner), and export every byte of your business state as
+  one JSON file. State lives in the encrypted vault; every change passes the policy
   engine and appends a signed audit event. Approving a send only records the
   decision: Stage 1 performs no external effects.
 - **Security Center** — device identity, vault entries, admitted plugins

--- a/apps/cli/assets/ui.html
+++ b/apps/cli/assets/ui.html
@@ -150,9 +150,18 @@
       <div class="toolbar">
         <button class="primary" id="d-offer" data-i18n="ws_gen_offer"></button>
         <button class="primary" id="d-invoice" data-i18n="ws_gen_invoice"></button>
+        <button class="ghost" id="d-assist" data-i18n="ws_assist"></button>
         <span class="status-line" id="d-status"></span>
       </div>
       <div class="status-line" data-i18n="ws_doc_note"></div>
+      <div id="assist-box" hidden>
+        <div class="toolbar" style="justify-content:space-between">
+          <span class="badge warn" id="assist-label"></span>
+          <button class="ghost small" id="assist-copy" data-i18n="ws_assist_copy"></button>
+        </div>
+        <textarea id="assist-text" readonly style="min-height:120px"></textarea>
+        <div class="status-line" id="assist-meta"></div>
+      </div>
     </div>
     <div class="panel" style="margin-top:10px"><div id="documents" class="empty" data-i18n="ws_no_documents"></div></div>
   </section>
@@ -222,6 +231,11 @@ const STRINGS = {
     ws_documents_title: "Documents",
     ws_for_customer: "For customer", ws_amount: "Amount",
     ws_gen_offer: "Generate offer draft", ws_gen_invoice: "Generate invoice draft",
+    ws_assist: "Draft outreach with assistant",
+    ws_assist_label: "model suggestion · not saved · untrusted",
+    ws_assist_copy: "Copy",
+    ws_assist_meta: (s) => "served by " + s.provider_id + " (" + s.provider_trust + ") · this is a suggestion, not authoritative state; copy it into a field to keep it",
+    ws_assist_copied: "copied",
     ws_doc_note: "Drafts are generated locally from templates — no model touches your business records in this stage.",
     ws_no_documents: "No documents yet — add a customer, then generate an offer or invoice.",
     ws_view_content: "View content",
@@ -278,6 +292,11 @@ const STRINGS = {
     ws_documents_title: "文档",
     ws_for_customer: "目标客户", ws_amount: "金额",
     ws_gen_offer: "生成报价单草稿", ws_gen_invoice: "生成发票草稿",
+    ws_assist: "用助手起草开发信",
+    ws_assist_label: "模型建议 · 未保存 · 不可信",
+    ws_assist_copy: "复制",
+    ws_assist_meta: (s) => "由 " + s.provider_id + "(" + s.provider_trust + ")生成 · 这是建议,不是权威数据;需复制到字段才会保存",
+    ws_assist_copied: "已复制",
     ws_doc_note: "草稿由本地模板生成——本阶段没有任何模型接触你的业务记录。",
     ws_no_documents: "暂无文档——先添加客户,再生成报价单或发票。",
     ws_view_content: "查看内容",
@@ -490,6 +509,21 @@ async function addCustomer() {
   else $("d-status").textContent = result.error;
 }
 
+async function draftAssist() {
+  const customer_id = $("d-customer").value;
+  if (!customer_id) { $("d-status").textContent = t("ws_no_customers"); return; }
+  $("d-status").textContent = "…";
+  const result = await api("/api/workspace/assist", { customer_id });
+  if (!result.ok) { $("d-status").textContent = result.error; return; }
+  $("d-status").textContent = "";
+  const s = result.suggestion;
+  $("assist-box").hidden = false;
+  $("assist-label").textContent = t("ws_assist_label");
+  $("assist-text").value = s.text;
+  $("assist-meta").textContent = t("ws_assist_meta")(s);
+  loadState();
+}
+
 async function createDocument(kind) {
   const body = { customer_id: $("d-customer").value };
   if (kind === "invoice") body.amount = $("d-amount").value;
@@ -623,6 +657,14 @@ $("tab-workspace").addEventListener("click", () => setView("workspace"));
 $("tab-security").addEventListener("click", () => setView("security"));
 $("v-save").addEventListener("click", saveVenture);
 $("c-add").addEventListener("click", addCustomer);
+$("d-assist").addEventListener("click", draftAssist);
+$("assist-copy").addEventListener("click", () => {
+  const text = $("assist-text").value;
+  if (navigator.clipboard) navigator.clipboard.writeText(text).catch(() => {});
+  else { $("assist-text").select(); document.execCommand("copy"); }
+  $("assist-copy").textContent = t("ws_assist_copied");
+  setTimeout(() => { $("assist-copy").textContent = t("ws_assist_copy"); }, 1500);
+});
 $("d-offer").addEventListener("click", () => createDocument("offer"));
 $("d-invoice").addEventListener("click", () => createDocument("invoice"));
 $("run").addEventListener("click", runGauntlet);

--- a/apps/cli/src/ui.rs
+++ b/apps/cli/src/ui.rs
@@ -106,6 +106,10 @@ fn route(request: &mut tiny_http::Request, port: u16, root: &Path) -> UiResponse
             Ok(_) => json_response(&gauntlet_json()),
             Err(error) => bad_request(&error),
         },
+        (Method::Post, "/api/workspace/assist") => match read_json_body(request) {
+            Ok(body) => json_response(&workspace_assist(&body, root)),
+            Err(error) => bad_request(&error),
+        },
         (Method::Post, path) if path.starts_with("/api/workspace/") => {
             match read_json_body(request) {
                 Ok(body) => json_response(&workspace_post(path, &body, root)),
@@ -213,6 +217,17 @@ fn workspace_post(path: &str, body: &serde_json::Value, root: &Path) -> serde_js
     })();
     match result {
         Ok(state) => serde_json::json!({ "ok": true, "workspace": state }),
+        Err(error) => serde_json::json!({ "ok": false, "error": error.to_string() }),
+    }
+}
+
+fn workspace_assist(body: &serde_json::Value, root: &Path) -> serde_json::Value {
+    let result = (|| {
+        let store = workspace::Store::open(root)?;
+        store.draft_assistant(uuid_field(body, "customer_id")?, lang_field(body))
+    })();
+    match result {
+        Ok(suggestion) => serde_json::json!({ "ok": true, "suggestion": suggestion }),
         Err(error) => serde_json::json!({ "ok": false, "error": error.to_string() }),
     }
 }

--- a/apps/cli/src/workspace.rs
+++ b/apps/cli/src/workspace.rs
@@ -13,8 +13,11 @@
 //!   the human owner, and only the owner's signed approval unlocks the effect;
 //! - the founder can export every byte of their business state at any time.
 //!
-//! Honest labels: documents are template-generated (no model is involved)
-//! and the graph schema is a prototype. Approving a send runs the real RFC
+//! Honest labels: documents are template-generated and the graph schema is a
+//! prototype. A local drafting assistant (deterministic, not an LLM) can
+//! suggest outreach text through the resilient model gateway, but its output
+//! is untrusted, is never written to authoritative state, and holds no keys —
+//! only the disclosure is audited. Approving a send runs the real RFC
 //! 0003 chain — owner-signed approval evidence, a Capability V2 token issued
 //! from it, a pure-compute preparation step in the verified sandbox, and then
 //! the first real host effect: the approved document is written to the local
@@ -43,6 +46,7 @@ use sovereign_identity::{
     AdmissionRole, ApprovalRole, AuthorityRole, DeviceIdentity, KeyValidity, PublisherRole,
     RoleTrustStore, TypedSigner,
 };
+use sovereign_model::{DeterministicProvider, Health as ModelHealth, ModelGateway, ModelRequest};
 use sovereign_policy::{AuthenticatedPolicyContextV2, PolicyEngine};
 use sovereign_sandbox::{VerifiedExecutionRequest, VerifiedSandboxExecutor};
 use sovereign_vault::Vault;
@@ -174,6 +178,17 @@ pub struct OutboxWrite {
     pub relative_path: String,
     pub content_sha256: String,
     pub bytes: usize,
+}
+
+/// An untrusted model suggestion. `saved` is always false: the assistant never
+/// writes authoritative state, so the founder must copy this into a real field
+/// for it to persist. It carries no authority and no keys.
+#[derive(Debug, Clone, Serialize)]
+pub struct DraftSuggestion {
+    pub text: String,
+    pub provider_id: String,
+    pub provider_trust: String,
+    pub saved: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -351,6 +366,81 @@ impl Store {
             serde_json::json!({ "name": name }),
         )?;
         Ok(workspace)
+    }
+
+    /// Ask the local drafting assistant for a suggested outreach note. This is
+    /// the model layer in action, and it is deliberately powerless: the
+    /// suggestion is untrusted model output routed through the resilient
+    /// gateway, it is **never written to authoritative state**, it holds no
+    /// keys, and the founder must copy it into a real field to keep it. Only
+    /// the disclosure (which provider saw Amber data) is audited.
+    ///
+    /// The provider is a deterministic local drafter, not an LLM. The gateway
+    /// gives it health-aware failover and a data-disclosure record; Red data
+    /// would never be routed to a non-local provider.
+    pub fn draft_assistant(
+        &self,
+        customer_id: Uuid,
+        lang: &str,
+    ) -> Result<DraftSuggestion, WorkspaceError> {
+        let workspace = self.load()?;
+        let venture = workspace
+            .venture
+            .clone()
+            .ok_or_else(|| WorkspaceError::Invalid("create the venture profile first".into()))?;
+        let customer = workspace
+            .customers
+            .iter()
+            .find(|customer| customer.id == customer_id)
+            .cloned()
+            .ok_or_else(|| WorkspaceError::NotFound("customer".into()))?;
+
+        let note = draft_outreach_note(&venture, &customer, lang.starts_with("zh"));
+        let gateway = ModelGateway::new(vec![
+            Box::new(DeterministicProvider::local_echo(
+                "local-drafter",
+                ModelHealth::Healthy,
+            )),
+            Box::new(DeterministicProvider::local_echo(
+                "local-drafter-backup",
+                ModelHealth::Healthy,
+            )),
+        ]);
+        let (response, disclosure) = gateway
+            .complete(&ModelRequest {
+                task: "draft_outreach".into(),
+                prompt: note,
+                // Business outreach about a named customer is Amber; it stays
+                // local here, and would never be routed to a cloud provider.
+                data_class: DataClass::Amber,
+                max_output_chars: 8192,
+            })
+            .map_err(|error| WorkspaceError::Invalid(format!("drafting assistant: {error}")))?;
+
+        // Record only the disclosure — never the suggestion — as evidence.
+        self.record(
+            "model.drafted",
+            &format!("customer:{customer_id}"),
+            serde_json::json!({
+                "task": disclosure.task,
+                "provider": disclosure.provider_id,
+                "provider_trust": format!("{:?}", disclosure.provider_trust).to_lowercase(),
+                "data_class": "amber",
+                "output_chars": disclosure.output_chars,
+                "failover_from": disclosure
+                    .skipped
+                    .iter()
+                    .map(|entry| entry.provider_id.clone())
+                    .collect::<Vec<_>>(),
+            }),
+        )?;
+
+        Ok(DraftSuggestion {
+            text: response.text,
+            provider_id: response.provider_id,
+            provider_trust: format!("{:?}", response.provider_trust).to_lowercase(),
+            saved: false,
+        })
     }
 
     pub fn create_document(
@@ -903,6 +993,27 @@ fn kernel(error: impl std::fmt::Display) -> WorkspaceError {
     WorkspaceError::Storage(format!("kernel chain failed closed: {error}"))
 }
 
+fn draft_outreach_note(venture: &Venture, customer: &Customer, zh: bool) -> String {
+    // Deterministic local drafting logic — this is the "assistant" content.
+    // It composes from known facts only; it invents nothing and cites no
+    // numbers, so an unreviewed copy is safe.
+    if zh {
+        format!(
+            "你好 {customer},\n\n我是 {venture} 的负责人。{service}——如果这正是你们现在需要的,我很乐意约个简短的通话,聊聊你们的目标和时间安排。\n\n期待回音。\n\n(本地起草助手草拟 · 未保存 · 请审阅后再使用)",
+            customer = customer.name,
+            venture = venture.name,
+            service = venture.service,
+        )
+    } else {
+        format!(
+            "Hi {customer},\n\nI'm the founder of {venture}. {service} — if that's useful to you right now, I'd be glad to set up a short call to understand your goals and timeline.\n\nLooking forward to hearing from you.\n\n(drafted by the local assistant · not saved · review before use)",
+            customer = customer.name,
+            venture = venture.name,
+            service = venture.service,
+        )
+    }
+}
+
 fn render_document(
     kind: DocumentKind,
     venture: &Venture,
@@ -1165,5 +1276,33 @@ mod tests {
         assert_eq!(export["format"], "sovereign-founder-os-export");
         assert_eq!(export["audit_chain_verified"], true);
         assert_eq!(export["workspace"]["venture"]["name"], "Acme");
+    }
+
+    #[test]
+    fn draft_assistant_never_touches_authoritative_state() {
+        let (_dir, store) = store();
+        store.set_venture("Acme", "Landing pages").unwrap();
+        let workspace = store.add_customer("Dr. Tan", "").unwrap();
+        let customer_id = workspace.customers[0].id;
+        let before = store.load().unwrap();
+
+        let suggestion = store.draft_assistant(customer_id, "en").unwrap();
+        assert!(!suggestion.saved);
+        assert_eq!(suggestion.provider_trust, "local");
+        assert!(suggestion.text.contains("Dr. Tan"));
+
+        // The graph is byte-for-byte unchanged: the suggestion created nothing.
+        let after = store.load().unwrap();
+        assert_eq!(
+            serde_json::to_value(&before).unwrap(),
+            serde_json::to_value(&after).unwrap()
+        );
+        assert!(after.documents.is_empty());
+
+        // Only a disclosure event was recorded.
+        let device = DeviceIdentity::load(&_dir.path().join("device.json")).unwrap();
+        let ledger =
+            AuditLedger::load(&_dir.path().join("ledger.json"), device.public_key_b64()).unwrap();
+        assert_eq!(ledger.events().last().unwrap().action, "model.drafted");
     }
 }

--- a/crates/model/src/lib.rs
+++ b/crates/model/src/lib.rs
@@ -280,6 +280,19 @@ impl DeterministicProvider {
         }
     }
 
+    /// A local provider that returns the request prompt verbatim. Used when
+    /// the caller has already composed the draft deterministically and wants
+    /// the gateway only for resilient routing and disclosure recording.
+    pub fn local_echo(id: impl Into<String>, health: Health) -> Self {
+        Self {
+            id: id.into(),
+            trust: ProviderTrust::Local,
+            health,
+            fail_on_call: false,
+            template: echo_template,
+        }
+    }
+
     pub fn cloud(id: impl Into<String>, health: Health) -> Self {
         Self {
             id: id.into(),
@@ -294,6 +307,10 @@ impl DeterministicProvider {
         self.fail_on_call = true;
         self
     }
+}
+
+fn echo_template(request: &ModelRequest, _provider_id: &str) -> String {
+    request.prompt.clone()
 }
 
 fn default_template(request: &ModelRequest, provider_id: &str) -> String {


### PR DESCRIPTION
## What

Adds a local **drafting assistant** to the Founder Workspace, wired end-to-end
through the Stage 2 model gateway. When a founder asks for help drafting an
outreach note to a customer, the app composes a deterministic note, routes it
through `ModelGateway` (with health-aware failover across two local providers),
records a `model.drafted` disclosure audit event, and returns the result as a
**suggestion only**.

## Security posture (the point of this slice)

The model's output is **untrusted and powerless** by construction:

- The suggestion is **never written to authoritative state** (`saved: false`).
  Creating a document remains a separate, explicit, human-decided action.
- Data class is capped at **Amber** — Red customer data never reaches a model
  boundary (enforced by the gateway's `disclosure` guard).
- Every draft emits a `model.drafted` audit event recording which provider and
  trust tier produced the text.
- The UI labels the output box `model suggestion · not saved · untrusted` /
  `模型建议 · 未保存 · 不可信` and offers copy, not auto-apply.

## Changes

- `sovereign-model`: `DeterministicProvider::local_echo` (echoes prompt via a
  template) so the gateway has a real local drafter to route to.
- `apps/cli` workspace: `DraftSuggestion`, `draft_assistant()`,
  `draft_outreach_note()` template.
- `apps/cli` UI + `/api/workspace/assist` route: bilingual button, read-only
  labelled suggestion box, copy button.
- Test: `draft_assistant_never_touches_authoritative_state` asserts 0 documents
  created and the suggestion is unsaved.

## Validation

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`,
and `cargo test --workspace` (139 tests / 36 suites) all pass locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNaAoHftuMyML3uwCZHEYx)_