### PR TITLE
feat(app): add read-only Founder Command Center view

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,14 @@ gauntlet (supply-chain tampering, token replay, input substitution, greedy
 manifests, infinite loops, red-data exfiltration, approval bypass, and audit
 tampering) — every denial is a real enforcement path, not a mock.
 
-`ui` serves the local app on 127.0.0.1 only (English/中文). It has two views:
+`ui` serves the local app on 127.0.0.1 only (English/中文). It has three views:
 
+- **Command Center** — the product face: your business at a glance (company,
+  customers, documents), the decisions waiting only on you (approve or reject in
+  place), and a kernel-evidence panel (audit-chain health, signed approvals,
+  model disclosures, admitted plugins). It is strictly read-only aggregation —
+  every number is re-derivable from your export, and opening the view writes
+  nothing and makes no new claim.
 - **Workspace** — the first usable product slice: create your company profile,
   add customers, generate offer and invoice drafts (local templates, no model),
   ask the local drafting assistant (deterministic, not an LLM, routed through
@@ -192,8 +198,10 @@ tampering) — every denial is a real enforcement path, not a mock.
   disclosure — request to send a document (which always stops in the Approval
   Center for the human owner), and export every byte of your business state as
   one JSON file. State lives in the encrypted vault; every change passes the policy
-  engine and appends a signed audit event. Approving a send only records the
-  decision: Stage 1 performs no external effects.
+  engine and appends a signed audit event. Approving a send authorizes one
+  exact sandboxed execution that writes the document to a local `outbox/` file
+  (a real, audited host effect) and records the signed evidence; Stage 1
+  performs no *network* effects — nothing leaves the device.
 - **Security Center** — device identity, vault entries, admitted plugins
   (verified from the content-addressed store), the signed audit chain, and a
   one-click in-memory run of the attack gauntlet.

--- a/apps/cli/assets/ui.html
+++ b/apps/cli/assets/ui.html
@@ -110,9 +110,40 @@
 </div>
 
 <nav class="tabs">
+  <button id="tab-command" data-i18n="tab_command"></button>
   <button id="tab-workspace" data-i18n="tab_workspace"></button>
   <button id="tab-security" data-i18n="tab_security"></button>
 </nav>
+
+<!-- ══════════════════ COMMAND CENTER VIEW ══════════════════ -->
+<div id="view-command" hidden>
+  <section>
+    <h2 data-i18n="cc_business_title"></h2>
+    <div class="panel pad" id="cc-venture"><span class="empty" data-i18n="cc_no_venture"></span></div>
+    <div class="tiles" style="margin-top:10px">
+      <div class="tile"><div class="label" data-i18n="cc_customers"></div><div class="value" id="cc-customers">–</div><div class="meta" data-i18n="cc_customers_meta"></div></div>
+      <div class="tile"><div class="label" data-i18n="cc_documents"></div><div class="value" id="cc-documents">–</div><div class="meta" id="cc-documents-meta"></div></div>
+      <div class="tile"><div class="label" data-i18n="cc_pending"></div><div class="value" id="cc-pending">–</div><div class="meta" data-i18n="cc_pending_meta"></div></div>
+      <div class="tile"><div class="label" data-i18n="cc_effects"></div><div class="value" id="cc-effects">–</div><div class="meta" id="cc-effects-meta"></div></div>
+    </div>
+  </section>
+
+  <section>
+    <h2 data-i18n="cc_decisions_title"></h2>
+    <div class="panel"><div id="cc-decisions" class="empty" data-i18n="cc_no_decisions"></div></div>
+  </section>
+
+  <section>
+    <h2 data-i18n="cc_evidence_title"></h2>
+    <div class="honest" data-i18n="cc_evidence_note"></div>
+    <div class="tiles" style="margin-top:10px">
+      <div class="tile"><div class="label" data-i18n="cc_chain"></div><div class="value" id="cc-chain">–</div><div class="meta" id="cc-chain-meta"></div></div>
+      <div class="tile"><div class="label" data-i18n="cc_signed"></div><div class="value" id="cc-signed">–</div><div class="meta" data-i18n="cc_signed_meta"></div></div>
+      <div class="tile"><div class="label" data-i18n="cc_disclosures"></div><div class="value" id="cc-disclosures">–</div><div class="meta" data-i18n="cc_disclosures_meta"></div></div>
+      <div class="tile"><div class="label" data-i18n="cc_plugins"></div><div class="value" id="cc-plugins">–</div><div class="meta" data-i18n="cc_plugins_meta"></div></div>
+    </div>
+  </section>
+</div>
 
 <!-- ══════════════════ WORKSPACE VIEW ══════════════════ -->
 <div id="view-workspace" hidden>
@@ -220,7 +251,25 @@ const STRINGS = {
     title: "SOVEREIGN FOUNDER OS",
     stage: "Stage 1 · minimal usable workspace on the secure kernel",
     honest_intro: "Runs entirely on your machine at 127.0.0.1 — no cloud, no account, no telemetry. Your business state lives in a local encrypted vault; every change passes the policy engine and leaves a signed audit event.",
-    tab_workspace: "Workspace", tab_security: "Security Center",
+    tab_command: "Command Center", tab_workspace: "Workspace", tab_security: "Security Center",
+    cc_business_title: "Your business at a glance",
+    cc_no_venture: "No company set yet — open Workspace to name your venture.",
+    cc_venture_line: (v) => v.name + " · " + v.service,
+    cc_customers: "Customers", cc_customers_meta: "in your local vault",
+    cc_documents: "Documents", cc_documents_meta: (c) => c.drafts + " draft · " + c.approved_pending_delivery + " sent",
+    cc_pending: "Awaiting you", cc_pending_meta: "decisions only you can make",
+    cc_effects: "Signed effects", cc_effects_meta: (s) => s.last_effect_path ? "last: outbox/" + s.last_effect_path : "no real effects yet",
+    cc_decisions_title: "Needs your decision",
+    cc_no_decisions: "Nothing is waiting on you. The assistant can draft, but only you approve — nothing leaves without this step.",
+    cc_decision_line: (d) => d.action + " · " + (d.customer_name || "—") + " · " + d.document_title,
+    cc_evidence_title: "Kernel evidence",
+    cc_evidence_note: "Every number below is re-derivable from your export. This view only reports what the kernel already proved — it makes no new claim and writes nothing.",
+    cc_chain: "Audit chain", cc_signed: "Signed approvals", cc_signed_meta: "with RFC 0003 evidence",
+    cc_disclosures: "Model disclosures", cc_disclosures_meta: "times a model was consulted",
+    cc_plugins: "Admitted plugins", cc_plugins_meta: "owner-signed admissions",
+    cc_chain_verified: "verified", cc_chain_broken: "BROKEN", cc_chain_none: "none yet",
+    cc_events: (n) => n + " events",
+    cc_approve: "Approve", cc_reject: "Reject",
     ws_venture_title: "Your company",
     ws_company_name: "Company name", ws_service_desc: "What service do you sell?",
     ws_save: "Save", saved: "saved ✓",
@@ -281,7 +330,25 @@ const STRINGS = {
     title: "SOVEREIGN FOUNDER OS",
     stage: "第一阶段 · 安全内核之上的最小可用工作台",
     honest_intro: "完全运行在你自己的设备上(127.0.0.1)——无云端、无账号、无遥测。你的业务数据保存在本地加密保险库中;每一次变更都先经过策略引擎,并留下签名审计记录。",
-    tab_workspace: "工作台", tab_security: "安全中心",
+    tab_command: "指挥中心", tab_workspace: "工作台", tab_security: "安全中心",
+    cc_business_title: "你的业务一览",
+    cc_no_venture: "尚未设置公司 — 打开工作台为你的业务命名。",
+    cc_venture_line: (v) => v.name + " · " + v.service,
+    cc_customers: "客户", cc_customers_meta: "存于本地加密保险库",
+    cc_documents: "文档", cc_documents_meta: (c) => c.drafts + " 份草稿 · " + c.approved_pending_delivery + " 份已发送",
+    cc_pending: "等你决定", cc_pending_meta: "只有你能做的决定",
+    cc_effects: "已签名副作用", cc_effects_meta: (s) => s.last_effect_path ? "最近:outbox/" + s.last_effect_path : "尚无真实副作用",
+    cc_decisions_title: "需要你的决定",
+    cc_no_decisions: "没有等待你处理的事项。助手可以起草,但只有你能批准 —— 没有这一步,任何东西都不会发出。",
+    cc_decision_line: (d) => d.action + " · " + (d.customer_name || "—") + " · " + d.document_title,
+    cc_evidence_title: "内核证据",
+    cc_evidence_note: "下方每个数字都可从你的导出文件中重新验证。此视图只报告内核已证明的事实 —— 不作任何新声明,也不写入任何内容。",
+    cc_chain: "审计链", cc_signed: "已签名批准", cc_signed_meta: "含 RFC 0003 证据",
+    cc_disclosures: "模型披露", cc_disclosures_meta: "模型被调用的次数",
+    cc_plugins: "已准入插件", cc_plugins_meta: "所有者签名的准入记录",
+    cc_chain_verified: "已验证", cc_chain_broken: "已损坏", cc_chain_none: "暂无",
+    cc_events: (n) => n + " 条事件",
+    cc_approve: "批准", cc_reject: "拒绝",
     ws_venture_title: "你的公司",
     ws_company_name: "公司名称", ws_service_desc: "你提供什么服务?",
     ws_save: "保存", saved: "已保存 ✓",
@@ -351,9 +418,10 @@ const STRINGS = {
 
 let lang = localStorage.getItem("sovereign-ui-lang")
   || (navigator.language && navigator.language.toLowerCase().startsWith("zh") ? "zh" : "en");
-let view = localStorage.getItem("sovereign-ui-view") || "workspace";
+let view = localStorage.getItem("sovereign-ui-view") || "command";
 let lastState = null;
 let lastGauntlet = null;
+let lastCommand = null;
 let ws = null;
 
 const $ = (id) => document.getElementById(id);
@@ -621,6 +689,74 @@ async function runGauntlet() {
   }
 }
 
+/* ─────────────── Command Center ─────────────── */
+
+async function loadCommandCenter() {
+  try {
+    lastCommand = await (await fetch("/api/command-center")).json();
+    renderCommandCenter();
+  } catch (error) { /* leave placeholders; other views still work */ }
+}
+
+function renderCommandCenter() {
+  if (!lastCommand || !lastCommand.ok) return;
+  const s = lastCommand.summary;
+  const k = lastCommand.kernel;
+
+  const vbox = $("cc-venture");
+  if (s.venture) vbox.replaceChildren(el("div", "mono", t("cc_venture_line")(s.venture)));
+  else vbox.replaceChildren(el("span", "empty", t("cc_no_venture")));
+
+  $("cc-customers").textContent = s.counts.customers;
+  $("cc-documents").textContent = s.counts.documents;
+  $("cc-documents-meta").textContent = t("cc_documents_meta")(s.counts);
+  $("cc-pending").textContent = s.pending_decisions.length;
+  $("cc-effects").textContent = s.evidence.outbox_effects;
+  $("cc-effects-meta").textContent = t("cc_effects_meta")(s.evidence);
+
+  const chainEl = $("cc-chain");
+  if (!k.audit_chain_present) { chainEl.textContent = t("cc_chain_none"); chainEl.style.color = ""; }
+  else if (k.audit_chain_ok) { chainEl.textContent = t("cc_chain_verified"); chainEl.style.color = "var(--good)"; }
+  else { chainEl.textContent = t("cc_chain_broken"); chainEl.style.color = "var(--critical)"; }
+  $("cc-chain-meta").textContent = t("cc_events")(k.audit_events);
+  $("cc-signed").textContent = s.evidence.signed_approvals;
+  $("cc-disclosures").textContent = k.model_disclosures;
+  $("cc-plugins").textContent = k.admitted_plugins;
+
+  renderCommandDecisions(s.pending_decisions);
+}
+
+function renderCommandDecisions(decisions) {
+  const box = $("cc-decisions");
+  if (!decisions.length) {
+    box.className = "empty";
+    box.replaceChildren(document.createTextNode(t("cc_no_decisions")));
+    return;
+  }
+  box.className = "";
+  box.replaceChildren(...decisions.map(d => {
+    const row = el("div", "pad");
+    row.appendChild(el("div", null, t("cc_decision_line")(d)));
+    if (d.policy_reason) row.appendChild(el("div", "status-line", d.policy_reason));
+    const bar = el("div", "toolbar");
+    const approve = el("button", "primary small", t("cc_approve"));
+    approve.addEventListener("click", () => commandDecide(d.approval_id, true));
+    const reject = el("button", "ghost small", t("cc_reject"));
+    reject.addEventListener("click", () => commandDecide(d.approval_id, false));
+    bar.appendChild(approve);
+    bar.appendChild(reject);
+    row.appendChild(bar);
+    return row;
+  }));
+}
+
+async function commandDecide(approvalId, approve) {
+  const result = await api("/api/workspace/decide", { approval_id: approvalId, approve });
+  if (result.ok) { ws = result.workspace; renderWorkspace(); }
+  await loadCommandCenter();
+  await loadState();
+}
+
 /* ─────────────── Shell ─────────────── */
 
 function applyLanguage() {
@@ -634,6 +770,7 @@ function applyLanguage() {
   renderState();
   renderGauntlet();
   renderWorkspace();
+  renderCommandCenter();
 }
 
 function setLanguage(next) {
@@ -645,14 +782,18 @@ function setLanguage(next) {
 function setView(next) {
   view = next;
   localStorage.setItem("sovereign-ui-view", next);
+  $("view-command").hidden = next !== "command";
   $("view-workspace").hidden = next !== "workspace";
   $("view-security").hidden = next !== "security";
+  $("tab-command").classList.toggle("active", next === "command");
   $("tab-workspace").classList.toggle("active", next === "workspace");
   $("tab-security").classList.toggle("active", next === "security");
+  if (next === "command") loadCommandCenter();
 }
 
 $("lang-en").addEventListener("click", () => setLanguage("en"));
 $("lang-zh").addEventListener("click", () => setLanguage("zh"));
+$("tab-command").addEventListener("click", () => setView("command"));
 $("tab-workspace").addEventListener("click", () => setView("workspace"));
 $("tab-security").addEventListener("click", () => setView("security"));
 $("v-save").addEventListener("click", saveVenture);
@@ -674,6 +815,7 @@ applyLanguage();
 setView(view);
 loadState();
 loadWorkspace();
+loadCommandCenter();
 </script>
 </body>
 </html>

--- a/apps/cli/src/ui.rs
+++ b/apps/cli/src/ui.rs
@@ -8,8 +8,8 @@
 //!   admission-record claims — never vault plaintext or private keys;
 //! - the gauntlet runs entirely in memory with the hard-coded demo trust
 //!   anchors; it performs no external effects and touches no stored state;
-//! - this page is a Stage 1 preview of the future Founder Command Center, not
-//!   the product UI.
+//! - this page hosts an early Founder Command Center: a read-only, at-a-glance
+//!   view of the business joined with the kernel evidence that backs it.
 
 use std::io::Read as _;
 use std::path::{Path, PathBuf};
@@ -100,6 +100,7 @@ fn route(request: &mut tiny_http::Request, port: u16, root: &Path) -> UiResponse
     match (request.method().clone(), url.as_str()) {
         (Method::Get, "/") => html_response(UI_HTML),
         (Method::Get, "/api/state") => json_response(&state_json(root)),
+        (Method::Get, "/api/command-center") => json_response(&command_center_json(root)),
         (Method::Get, "/api/workspace") => json_response(&workspace_get(root)),
         (Method::Get, "/api/export") => export_response(root),
         (Method::Post, "/api/gauntlet") => match read_json_body(request) {
@@ -180,6 +181,51 @@ fn workspace_get(root: &Path) -> serde_json::Value {
         Ok(state) => serde_json::json!({ "ok": true, "workspace": state }),
         Err(error) => serde_json::json!({ "ok": false, "error": error.to_string() }),
     }
+}
+
+/// The Founder Command Center: the business at a glance joined with the kernel
+/// evidence that backs it. Read-only; it composes two honest sources — the
+/// workspace aggregation and the on-disk audit signals — and invents nothing.
+fn command_center_json(root: &Path) -> serde_json::Value {
+    let result = workspace::Store::open(root).and_then(|store| store.command_center());
+    match result {
+        Ok(summary) => serde_json::json!({
+            "ok": true,
+            "summary": summary,
+            "kernel": kernel_evidence_json(root),
+        }),
+        Err(error) => serde_json::json!({ "ok": false, "error": error.to_string() }),
+    }
+}
+
+/// Compact, verifiable kernel signals for the Command Center header: the audit
+/// chain's health, how many model disclosures happened, and how many plugins
+/// were admitted. Every number here is re-derivable from the export.
+fn kernel_evidence_json(root: &Path) -> serde_json::Value {
+    let device = DeviceIdentity::load(&root.join("device.json")).ok();
+    let ledger_path = root.join("ledger.json");
+    let (present, chain_ok, count, model_disclosures) = match (&device, ledger_path.exists()) {
+        (Some(device), true) => match AuditLedger::load(&ledger_path, device.public_key_b64()) {
+            Ok(ledger) => {
+                let disclosures = ledger
+                    .events()
+                    .iter()
+                    .filter(|event| event.action == "model.drafted")
+                    .count();
+                let chain_ok = ledger.verify_chain().is_ok();
+                (true, chain_ok, ledger.events().len(), disclosures)
+            }
+            Err(_) => (true, false, 0, 0),
+        },
+        _ => (false, true, 0, 0),
+    };
+    serde_json::json!({
+        "audit_chain_present": present,
+        "audit_chain_ok": chain_ok,
+        "audit_events": count,
+        "model_disclosures": model_disclosures,
+        "admitted_plugins": admitted_plugins_json(root).len(),
+    })
 }
 
 fn workspace_post(path: &str, body: &serde_json::Value, root: &Path) -> serde_json::Value {
@@ -347,7 +393,7 @@ fn state_json(root: &Path) -> serde_json::Value {
         "vault_entries": vault_entries,
         "ledger": ledger,
         "plugins": admitted_plugins_json(root),
-        "stage": "Stage 1 · Secure Kernel (preview UI, not the Founder Command Center)",
+        "stage": "Stage 1 · Secure Kernel · Founder Command Center (early)",
     })
 }
 

--- a/apps/cli/src/workspace.rs
+++ b/apps/cli/src/workspace.rs
@@ -200,6 +200,51 @@ pub struct Workspace {
     pub approvals: Vec<Approval>,
 }
 
+/// At-a-glance product view: the founder's whole business plus the security
+/// evidence that backs it, derived purely from stored state. It is read-only
+/// and adds no new claims — it only surfaces what the workspace already proved.
+#[derive(Debug, Clone, Serialize)]
+pub struct CommandCenter {
+    pub venture: Option<Venture>,
+    pub counts: CommandCenterCounts,
+    /// Approvals still waiting on the owner — the only actionable items here.
+    pub pending_decisions: Vec<PendingDecision>,
+    pub evidence: EvidenceRollup,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CommandCenterCounts {
+    pub customers: usize,
+    pub documents: usize,
+    pub drafts: usize,
+    pub pending_approval: usize,
+    pub approved_pending_delivery: usize,
+    pub rejected: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PendingDecision {
+    pub approval_id: Uuid,
+    pub document_id: Uuid,
+    pub document_title: String,
+    pub customer_name: String,
+    pub action: String,
+    pub policy_reason: String,
+    pub requested_at: i64,
+}
+
+/// Counts of the tamper-evident evidence already on disk. These are facts the
+/// owner can re-verify from the export, not aspirational security claims.
+#[derive(Debug, Clone, Serialize)]
+pub struct EvidenceRollup {
+    /// Approvals carrying RFC 0003 signed evidence.
+    pub signed_approvals: usize,
+    /// Approvals whose sandboxed execution wrote a real audited outbox file.
+    pub outbox_effects: usize,
+    /// Relative path of the most recent real host effect, if any.
+    pub last_effect_path: Option<String>,
+}
+
 /// Storage + evidence context for one workspace operation.
 pub struct Store {
     root: PathBuf,
@@ -921,6 +966,85 @@ impl Store {
         }
     }
 
+    /// Aggregate the whole workspace into the Founder Command Center view.
+    /// Pure over stored state: it reads nothing new and writes nothing, so it
+    /// leaves no audit event and makes no security claim of its own.
+    pub fn command_center(&self) -> Result<CommandCenter, WorkspaceError> {
+        let workspace = self.load()?;
+
+        let count_status = |status: DocumentStatus| {
+            workspace
+                .documents
+                .iter()
+                .filter(|document| document.status == status)
+                .count()
+        };
+        let counts = CommandCenterCounts {
+            customers: workspace.customers.len(),
+            documents: workspace.documents.len(),
+            drafts: count_status(DocumentStatus::Draft),
+            pending_approval: count_status(DocumentStatus::PendingApproval),
+            approved_pending_delivery: count_status(DocumentStatus::ApprovedPendingDelivery),
+            rejected: count_status(DocumentStatus::Rejected),
+        };
+
+        let pending_decisions = workspace
+            .approvals
+            .iter()
+            .filter(|approval| approval.status == ApprovalStatus::Pending)
+            .map(|approval| {
+                let document = workspace
+                    .documents
+                    .iter()
+                    .find(|document| document.id == approval.document_id);
+                let customer_name = document
+                    .and_then(|document| {
+                        workspace
+                            .customers
+                            .iter()
+                            .find(|customer| customer.id == document.customer_id)
+                    })
+                    .map(|customer| customer.name.clone())
+                    .unwrap_or_default();
+                PendingDecision {
+                    approval_id: approval.id,
+                    document_id: approval.document_id,
+                    document_title: document
+                        .map(|document| document.title.clone())
+                        .unwrap_or_default(),
+                    customer_name,
+                    action: approval.action.clone(),
+                    policy_reason: approval.policy_reason.clone(),
+                    requested_at: approval.requested_at,
+                }
+            })
+            .collect();
+
+        let signed_approvals = workspace
+            .approvals
+            .iter()
+            .filter(|approval| approval.evidence.is_some())
+            .count();
+        let effects: Vec<&OutboxWrite> = workspace
+            .approvals
+            .iter()
+            .filter_map(|approval| approval.evidence.as_ref())
+            .filter_map(|evidence| evidence.outbox.as_ref())
+            .collect();
+        let evidence = EvidenceRollup {
+            signed_approvals,
+            outbox_effects: effects.len(),
+            last_effect_path: effects.last().map(|effect| effect.relative_path.clone()),
+        };
+
+        Ok(CommandCenter {
+            venture: workspace.venture,
+            counts,
+            pending_decisions,
+            evidence,
+        })
+    }
+
     /// Full data export: the founder's right to leave with everything.
     pub fn export(&self) -> Result<serde_json::Value, WorkspaceError> {
         let workspace = self.load()?;
@@ -1304,5 +1428,59 @@ mod tests {
         let ledger =
             AuditLedger::load(&_dir.path().join("ledger.json"), device.public_key_b64()).unwrap();
         assert_eq!(ledger.events().last().unwrap().action, "model.drafted");
+    }
+
+    #[test]
+    fn command_center_aggregates_state_and_evidence_read_only() {
+        let (_dir, store) = store();
+        store.set_venture("Acme", "Landing pages").unwrap();
+        let workspace = store.add_customer("Dr. Tan", "").unwrap();
+        let customer_id = workspace.customers[0].id;
+        let workspace = store
+            .create_document(DocumentKind::Invoice, customer_id, Some(250_000), "en")
+            .unwrap();
+        let document_id = workspace.documents[0].id;
+
+        // A pending decision shows up as actionable, with no evidence yet.
+        let workspace = store.request_send(document_id).unwrap();
+        let approval_id = workspace.approvals[0].id;
+        let cc = store.command_center().unwrap();
+        assert_eq!(cc.venture.as_ref().unwrap().name, "Acme");
+        assert_eq!(cc.counts.customers, 1);
+        assert_eq!(cc.counts.pending_approval, 1);
+        assert_eq!(cc.pending_decisions.len(), 1);
+        assert_eq!(cc.pending_decisions[0].customer_name, "Dr. Tan");
+        assert_eq!(cc.evidence.signed_approvals, 0);
+        assert_eq!(cc.evidence.outbox_effects, 0);
+
+        // After approval the evidence rollup reflects the real signed effect,
+        // and the decision is no longer pending.
+        let ledger_before = {
+            let device = DeviceIdentity::load(&_dir.path().join("device.json")).unwrap();
+            AuditLedger::load(&_dir.path().join("ledger.json"), device.public_key_b64())
+                .unwrap()
+                .events()
+                .len()
+        };
+        store.decide(approval_id, true).unwrap();
+        let cc = store.command_center().unwrap();
+        assert!(cc.pending_decisions.is_empty());
+        assert_eq!(cc.counts.approved_pending_delivery, 1);
+        assert_eq!(cc.evidence.signed_approvals, 1);
+        assert_eq!(cc.evidence.outbox_effects, 1);
+        assert!(cc.evidence.last_effect_path.is_some());
+
+        // The view is genuinely read-only: computing it twice appends no audit
+        // events beyond the ones the approval itself created.
+        let _ = store.command_center().unwrap();
+        let device = DeviceIdentity::load(&_dir.path().join("device.json")).unwrap();
+        let ledger_after =
+            AuditLedger::load(&_dir.path().join("ledger.json"), device.public_key_b64())
+                .unwrap()
+                .events()
+                .len();
+        // Approval added exactly its own events (granted, executed, effect);
+        // the two command_center calls added none.
+        assert_eq!(ledger_after, ledger_before + 3);
     }
 }


### PR DESCRIPTION
## What

Adds the **Founder Command Center** — the product face the roadmap has been
pointing at, and which the code previously labelled "not yet built". It joins
the business at a glance with the kernel evidence that backs it, in one
read-only view set as the app's default tab.

The view has three parts:

1. **Business at a glance** — company, customers, documents (with draft/sent
   breakdown), how many decisions await you, and how many real signed effects
   have happened.
2. **Needs your decision** — every pending send, with customer, document, and
   the policy reason it stopped here; approve or reject in place.
3. **Kernel evidence** — audit-chain health, count of RFC 0003 signed
   approvals, model disclosures, and admitted plugins.

## Honesty posture

- `Store::command_center()` is **pure over stored state**: it reads the
  workspace, writes nothing, and leaves **no audit event**, so it makes no new
  security claim. Every number it shows is re-derivable from the export.
- The kernel panel re-verifies the audit chain (`verify_chain`) rather than
  asserting health — a broken chain renders as `BROKEN` in red.
- Corrects a now-stale README claim: approving a send authorizes a sandboxed
  execution that writes a **real audited local `outbox/` file**; Stage 1
  performs no *network* effects (nothing leaves the device).

## Changes

- `apps/cli` workspace: `CommandCenter`/`CommandCenterCounts`/`PendingDecision`/
  `EvidenceRollup` types and the `command_center()` aggregation.
- `apps/cli` UI + `GET /api/command-center`: bilingual (EN/中文) Command Center
  tab, default view, in-place approve/reject wired to the existing decide API.
- Test `command_center_aggregates_state_and_evidence_read_only` asserts the
  counts, pending decisions, evidence rollup, and that computing the view twice
  appends zero audit events.

## Validation

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`,
and `cargo test --workspace` (140 tests) all pass. Verified end-to-end at
runtime (endpoint through the full approve → signed-effect lifecycle) and in a
headless browser (renders in EN/中文, no JS errors).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNaAoHftuMyML3uwCZHEYx)_