### PR TITLE
feat(app): compose approved sends as RFC 5322 .eml in the outbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,11 @@ tampering) — every denial is a real enforcement path, not a mock.
   signed it, and full re-computation of the signed chain). State lives in the
   encrypted vault; every change passes the policy engine and appends a signed
   audit event. Approving a send authorizes one exact sandboxed execution that
-  writes the document to a local `outbox/` file (a real, audited host effect)
-  and records the signed evidence; Stage 1 performs no *network* effects —
+  composes the document into a well-formed RFC 5322 email and writes it to a
+  local `outbox/*.eml` file (a real, audited host effect) — addressed to the
+  customer's email if set, otherwise an RFC 2606 placeholder, and always marked
+  "composed locally, not transmitted" — and records the signed evidence;
+  Stage 1 performs no *network* effects —
   nothing leaves the device.
 - **Security Center** — device identity, vault entries, admitted plugins
   (verified from the content-addressed store), the signed audit chain, and a

--- a/apps/cli/assets/ui.html
+++ b/apps/cli/assets/ui.html
@@ -166,6 +166,7 @@
         <div><label data-i18n="ws_customer_name"></label><input type="text" id="c-name" maxlength="200"></div>
         <button class="primary" id="c-add" data-i18n="ws_add_customer"></button>
       </div>
+      <div><label data-i18n="ws_customer_email"></label><input type="text" id="c-email" maxlength="254" placeholder="name@example.com"></div>
       <div><label data-i18n="ws_customer_notes"></label><input type="text" id="c-notes" maxlength="500"></div>
     </div>
     <div class="panel" style="margin-top:10px"><div id="customers" class="empty" data-i18n="ws_no_customers"></div></div>
@@ -284,9 +285,9 @@ const STRINGS = {
     ws_company_name: "Company name", ws_service_desc: "What service do you sell?",
     ws_save: "Save", saved: "saved ✓",
     ws_customers_title: "Customers",
-    ws_customer_name: "Customer name", ws_customer_notes: "Notes (optional)", ws_add_customer: "Add customer",
+    ws_customer_name: "Customer name", ws_customer_email: "Email (optional)", ws_customer_notes: "Notes (optional)", ws_add_customer: "Add customer",
     ws_no_customers: "No customers yet.",
-    th_customer: "Customer", th_notes: "Notes", th_added: "Added",
+    th_customer: "Customer", th_email: "Email", th_notes: "Notes", th_added: "Added",
     ws_documents_title: "Documents",
     ws_for_customer: "For customer", ws_amount: "Amount",
     ws_gen_offer: "Generate offer draft", ws_gen_invoice: "Generate invoice draft",
@@ -375,9 +376,9 @@ const STRINGS = {
     ws_company_name: "公司名称", ws_service_desc: "你提供什么服务?",
     ws_save: "保存", saved: "已保存 ✓",
     ws_customers_title: "客户",
-    ws_customer_name: "客户名称", ws_customer_notes: "备注(可选)", ws_add_customer: "添加客户",
+    ws_customer_name: "客户名称", ws_customer_email: "邮箱(可选)", ws_customer_notes: "备注(可选)", ws_add_customer: "添加客户",
     ws_no_customers: "暂无客户。",
-    th_customer: "客户", th_notes: "备注", th_added: "添加时间",
+    th_customer: "客户", th_email: "邮箱", th_notes: "备注", th_added: "添加时间",
     ws_documents_title: "文档",
     ws_for_customer: "目标客户", ws_amount: "金额",
     ws_gen_offer: "生成报价单草稿", ws_gen_invoice: "生成发票草稿",
@@ -522,8 +523,8 @@ function renderWorkspace() {
     customers.replaceChildren(el("div", "empty", t("ws_no_customers")));
   } else {
     customers.replaceChildren(table(
-      [t("th_customer"), t("th_notes"), t("th_added")],
-      ws.customers.map(c => [c.name, c.notes, fmtTime(c.created_at)])));
+      [t("th_customer"), t("th_email"), t("th_notes"), t("th_added")],
+      ws.customers.map(c => [c.name, c.email || "—", c.notes, fmtTime(c.created_at)])));
   }
 
   const select = $("d-customer");
@@ -606,8 +607,8 @@ async function saveVenture() {
 }
 
 async function addCustomer() {
-  const result = await api("/api/workspace/customer", { name: $("c-name").value, notes: $("c-notes").value });
-  if (result.ok) { $("c-name").value = ""; $("c-notes").value = ""; ws = result.workspace; renderWorkspace(); loadState(); }
+  const result = await api("/api/workspace/customer", { name: $("c-name").value, email: $("c-email").value, notes: $("c-notes").value });
+  if (result.ok) { $("c-name").value = ""; $("c-email").value = ""; $("c-notes").value = ""; ws = result.workspace; renderWorkspace(); loadState(); }
   else $("d-status").textContent = result.error;
 }
 

--- a/apps/cli/src/ui.rs
+++ b/apps/cli/src/ui.rs
@@ -241,6 +241,7 @@ fn workspace_post(path: &str, body: &serde_json::Value, root: &Path) -> serde_js
             }
             "/api/workspace/customer" => store.add_customer(
                 str_field(body, "name")?,
+                body.get("email").and_then(|v| v.as_str()).unwrap_or(""),
                 body.get("notes").and_then(|v| v.as_str()).unwrap_or(""),
             ),
             "/api/workspace/offer" => store.create_document(

--- a/apps/cli/src/workspace.rs
+++ b/apps/cli/src/workspace.rs
@@ -97,6 +97,12 @@ pub struct Venture {
 pub struct Customer {
     pub id: Uuid,
     pub name: String,
+    /// Optional contact address. When present, a composed outreach email
+    /// addresses it directly; when empty, the email uses an RFC 2606
+    /// placeholder the founder must replace before sending. Defaulted so
+    /// vaults written before this field deserialize unchanged.
+    #[serde(default)]
+    pub email: String,
     pub notes: String,
     pub created_at: i64,
 }
@@ -405,8 +411,14 @@ impl Store {
         Ok(workspace)
     }
 
-    pub fn add_customer(&self, name: &str, notes: &str) -> Result<Workspace, WorkspaceError> {
+    pub fn add_customer(
+        &self,
+        name: &str,
+        email: &str,
+        notes: &str,
+    ) -> Result<Workspace, WorkspaceError> {
         let name = clean_text("name", name)?;
+        let email = clean_email(email)?;
         let notes = clean_optional_text("notes", notes)?;
         let (allowed, _, reason) = self.check_policy(
             "workspace",
@@ -425,6 +437,7 @@ impl Store {
         let customer = Customer {
             id: Uuid::new_v4(),
             name: name.clone(),
+            email,
             notes,
             created_at: now(),
         };
@@ -648,7 +661,12 @@ impl Store {
             .ok_or_else(|| WorkspaceError::NotFound("document".into()))?;
 
         let evidence = if approve {
-            Some(self.execute_signed_approval(&document)?)
+            let customer = workspace
+                .customers
+                .iter()
+                .find(|customer| customer.id == document.customer_id);
+            let message = compose_email(workspace.venture.as_ref(), customer, &document);
+            Some(self.execute_signed_approval(&document, message.as_bytes())?)
         } else {
             None
         };
@@ -735,6 +753,7 @@ impl Store {
     fn execute_signed_approval(
         &self,
         document: &Document,
+        delivery: &[u8],
     ) -> Result<SignedApprovalRecord, WorkspaceError> {
         let approval_secret = self.owner_secret("owner_approval_key")?;
         let authority_secret = self.owner_secret("runtime_authority_key")?;
@@ -941,16 +960,17 @@ impl Store {
             .map_err(kernel)?;
 
         // The first real host effect: with the whole chain verified and the
-        // capability durably consumed, write the approved document to the
-        // owner's local outbox. This is audited and revocable; delivery to the
+        // capability durably consumed, write the composed outreach message to
+        // the owner's local outbox as an RFC 5322 `.eml`. This is audited and
+        // revocable; the message is composed, not transmitted — delivery to the
         // customer remains the founder's own action.
         let outbox =
             sovereign_effects::OutboxBroker::open(self.root.join("outbox")).map_err(kernel)?;
         let receipt = outbox
-            .write_document(
+            .write_message(
                 &document.id.simple().to_string(),
                 sovereign_effects::EffectDataClass::Amber,
-                document.body.as_bytes(),
+                delivery,
             )
             .map_err(kernel)?;
 
@@ -1390,6 +1410,115 @@ fn clean_optional_text(field: &str, value: &str) -> Result<String, WorkspaceErro
     Ok(value.to_owned())
 }
 
+/// Compose a well-formed RFC 5322 message for an approved document. The result
+/// is written to the local outbox and never transmitted — an `X-Sovereign`
+/// header says so, and a missing recipient becomes an RFC 2606 `.invalid`
+/// placeholder the founder must replace before sending. Header values come from
+/// validated fields (names carry no control characters, emails no CR/LF or
+/// separators), and are re-sanitized here, so no field can inject a header.
+fn compose_email(
+    venture: Option<&Venture>,
+    customer: Option<&Customer>,
+    document: &Document,
+) -> String {
+    let sender_name = venture
+        .map(|venture| venture.name.as_str())
+        .unwrap_or("Sovereign Founder");
+    let recipient_name = customer
+        .map(|customer| customer.name.as_str())
+        .unwrap_or("Customer");
+    let recipient_addr = customer
+        .map(|customer| customer.email.trim())
+        .filter(|email| !email.is_empty())
+        .map(|email| email.to_owned())
+        .unwrap_or_else(|| "recipient@example.invalid".to_owned());
+    let placeholder = recipient_addr.ends_with(".invalid");
+
+    let mut message = String::new();
+    message.push_str(&format!(
+        "From: {} <founder@example.invalid>\r\n",
+        encode_display_name(sender_name)
+    ));
+    message.push_str(&format!(
+        "To: {} <{}>\r\n",
+        encode_display_name(recipient_name),
+        header_safe(&recipient_addr)
+    ));
+    message.push_str(&format!("Subject: {}\r\n", header_safe(&document.title)));
+    message.push_str(&format!("Date: {}\r\n", chrono::Utc::now().to_rfc2822()));
+    message.push_str(&format!(
+        "Message-ID: <{}@sovereign-founder-os.invalid>\r\n",
+        document.id.simple()
+    ));
+    message.push_str("MIME-Version: 1.0\r\n");
+    message.push_str("Content-Type: text/plain; charset=utf-8\r\n");
+    message.push_str(
+        "X-Sovereign-Composed: composed locally by Sovereign Founder OS; not transmitted\r\n",
+    );
+    if placeholder {
+        message.push_str(
+            "X-Sovereign-Note: recipient address is a placeholder — set the customer's email before sending\r\n",
+        );
+    }
+    message.push_str("\r\n");
+    for line in document.body.split('\n') {
+        message.push_str(line.trim_end_matches('\r'));
+        message.push_str("\r\n");
+    }
+    message
+}
+
+/// Render an RFC 5322 display-name: kept bare when it is a safe atom, otherwise
+/// a quoted-string with `\\` and `"` escaped. CR/LF are stripped defensively.
+fn encode_display_name(name: &str) -> String {
+    let sanitized: String = name
+        .chars()
+        .filter(|ch| *ch != '\r' && *ch != '\n')
+        .collect();
+    let needs_quoting = sanitized.is_empty()
+        || sanitized
+            .chars()
+            .any(|ch| !(ch.is_ascii_alphanumeric() || " !#$%&'*+-/=?^_`{|}~".contains(ch)));
+    if needs_quoting {
+        let escaped = sanitized.replace('\\', "\\\\").replace('"', "\\\"");
+        format!("\"{escaped}\"")
+    } else {
+        sanitized
+    }
+}
+
+/// Collapse any CR/LF in a single-line header value to spaces — defense in
+/// depth against header injection on top of upstream field validation.
+fn header_safe(value: &str) -> String {
+    value.replace(['\r', '\n'], " ")
+}
+
+/// Validate an optional contact email. Empty is allowed (the founder can add
+/// it later). A non-empty value must be a single-line, single-`@` address with
+/// no spaces or header-injection characters — enough to place safely in an
+/// RFC 5322 `To:` header without claiming full RFC 5321 validation.
+fn clean_email(value: &str) -> Result<String, WorkspaceError> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Ok(String::new());
+    }
+    if value.len() > 254 {
+        return Err(WorkspaceError::Invalid("email is too long".into()));
+    }
+    let at_count = value.bytes().filter(|byte| *byte == b'@').count();
+    let structural =
+        at_count == 1 && !value.starts_with('@') && !value.ends_with('@') && value.contains('.');
+    let no_injection = value
+        .bytes()
+        .all(|byte| !byte.is_ascii_control() && !matches!(byte, b' ' | b'\t' | b',' | b'<' | b'>'));
+    if !structural || !no_injection {
+        return Err(WorkspaceError::Invalid(
+            "email is not a valid address".into(),
+        ));
+    }
+    Ok(value.to_owned())
+}
+
 fn now() -> i64 {
     chrono::Utc::now().timestamp()
 }
@@ -1415,7 +1544,9 @@ mod tests {
         store
             .set_venture("Acme Consulting", "Landing pages for clinics")
             .unwrap();
-        let workspace = store.add_customer("Dr. Tan", "met at expo").unwrap();
+        let workspace = store
+            .add_customer("Dr. Tan", "dr.tan@example.com", "met at expo")
+            .unwrap();
         let customer_id = workspace.customers[0].id;
 
         let workspace = store
@@ -1477,23 +1608,93 @@ mod tests {
         ));
 
         // The real host effect happened: the approved document is a genuine
-        // file in the local outbox, matching the receipt.
+        // file in the local outbox, matching the receipt. It is a composed
+        // RFC 5322 message (.eml): real headers, the recipient's address, the
+        // document body, and an explicit "not transmitted" marker.
         let outbox_receipt = evidence.outbox.as_ref().unwrap();
+        assert!(outbox_receipt.relative_path.ends_with(".eml"));
         let written = std::fs::read(
             dir.path()
                 .join("outbox")
                 .join(&outbox_receipt.relative_path),
         )
         .unwrap();
-        assert_eq!(written, workspace.documents[0].body.as_bytes());
+        let message = String::from_utf8(written.clone()).unwrap();
+        assert!(message.contains("To: \"Dr. Tan\" <dr.tan@example.com>"));
+        assert!(message.contains("Subject: "));
+        assert!(message.contains("X-Sovereign-Composed:"));
+        // The body is present (line endings are normalized to CRLF in the .eml,
+        // so match on a body line rather than the raw string).
+        let body_line = workspace.documents[0].body.lines().next().unwrap();
+        assert!(message.contains(body_line));
+        // A real recipient means no placeholder note.
+        assert!(!message.contains("placeholder"));
         assert_eq!(outbox_receipt.bytes, written.len());
+    }
+
+    #[test]
+    fn compose_email_is_wellformed_and_injection_safe() {
+        let venture = Venture {
+            name: "Acme".into(),
+            service: "Landing pages".into(),
+            updated_at: 0,
+        };
+        let document = Document {
+            id: Uuid::new_v4(),
+            kind: DocumentKind::Offer,
+            customer_id: Uuid::new_v4(),
+            title: "Offer — Acme".into(),
+            body: "Hello,\nHere is the offer.\n".into(),
+            amount_cents: None,
+            status: DocumentStatus::PendingApproval,
+            created_at: 0,
+        };
+
+        // With a real address the To header resolves and there is no placeholder.
+        let with_email = Customer {
+            id: document.customer_id,
+            name: "Dr. Tan".into(),
+            email: "dr.tan@example.com".into(),
+            notes: String::new(),
+            created_at: 0,
+        };
+        let message = compose_email(Some(&venture), Some(&with_email), &document);
+        assert!(message.contains("From: Acme <founder@example.invalid>"));
+        assert!(message.contains("To: \"Dr. Tan\" <dr.tan@example.com>"));
+        assert!(message.contains("Subject: Offer — Acme"));
+        assert!(message.contains("Message-ID: <"));
+        assert!(message.contains("X-Sovereign-Composed:"));
+        assert!(!message.contains("placeholder"));
+        assert!(message.contains("Here is the offer."));
+        // Headers are CRLF-separated and end before the body.
+        assert!(message.contains("\r\n\r\n"));
+
+        // With no address the recipient is an RFC 2606 placeholder, flagged.
+        let no_email = Customer {
+            email: String::new(),
+            ..with_email.clone()
+        };
+        let message = compose_email(Some(&venture), Some(&no_email), &document);
+        assert!(message.contains("<recipient@example.invalid>"));
+        assert!(message.contains("X-Sovereign-Note: recipient address is a placeholder"));
+
+        // A hostile display name cannot inject headers: it is quoted/stripped,
+        // never allowed to introduce a bare CRLF + header.
+        let hostile = Customer {
+            name: "Bad\r\nBcc: victim@example.com".into(),
+            email: "x@example.com".into(),
+            ..with_email.clone()
+        };
+        let message = compose_email(Some(&venture), Some(&hostile), &document);
+        let header_block = message.split("\r\n\r\n").next().unwrap();
+        assert!(!header_block.to_ascii_lowercase().contains("\r\nbcc:"));
     }
 
     #[test]
     fn double_decision_and_unknown_ids_fail_closed() {
         let (_dir, store) = store();
         store.set_venture("Acme", "Service").unwrap();
-        let workspace = store.add_customer("Customer", "").unwrap();
+        let workspace = store.add_customer("Customer", "", "").unwrap();
         let customer_id = workspace.customers[0].id;
         let workspace = store
             .create_document(DocumentKind::Offer, customer_id, None, "zh")
@@ -1547,7 +1748,7 @@ mod tests {
     fn draft_assistant_never_touches_authoritative_state() {
         let (_dir, store) = store();
         store.set_venture("Acme", "Landing pages").unwrap();
-        let workspace = store.add_customer("Dr. Tan", "").unwrap();
+        let workspace = store.add_customer("Dr. Tan", "", "").unwrap();
         let customer_id = workspace.customers[0].id;
         let before = store.load().unwrap();
 
@@ -1575,7 +1776,7 @@ mod tests {
     fn verify_export_accepts_genuine_bundle_and_rejects_tampering() {
         let (_dir, store) = store();
         store.set_venture("Acme", "Landing pages").unwrap();
-        let workspace = store.add_customer("Dr. Tan", "expo").unwrap();
+        let workspace = store.add_customer("Dr. Tan", "", "expo").unwrap();
         let customer_id = workspace.customers[0].id;
         let workspace = store
             .create_document(DocumentKind::Invoice, customer_id, Some(250_000), "en")
@@ -1633,7 +1834,7 @@ mod tests {
     fn command_center_aggregates_state_and_evidence_read_only() {
         let (_dir, store) = store();
         store.set_venture("Acme", "Landing pages").unwrap();
-        let workspace = store.add_customer("Dr. Tan", "").unwrap();
+        let workspace = store.add_customer("Dr. Tan", "", "").unwrap();
         let customer_id = workspace.customers[0].id;
         let workspace = store
             .create_document(DocumentKind::Invoice, customer_id, Some(250_000), "en")

--- a/crates/effects/src/lib.rs
+++ b/crates/effects/src/lib.rs
@@ -97,13 +97,36 @@ impl OutboxBroker {
         data_class: EffectDataClass,
         contents: &[u8],
     ) -> Result<OutboxReceipt, EffectError> {
+        self.write_with_extension(key, "txt", data_class, contents)
+    }
+
+    /// Write a composed RFC 5322 message to `<outbox>/<key>.eml` atomically.
+    /// Identical safety posture to [`write_document`]; only the extension
+    /// differs, so a mail client recognizes the file. The message is composed
+    /// locally and never transmitted — sending stays the founder's own action.
+    pub fn write_message(
+        &self,
+        key: &str,
+        data_class: EffectDataClass,
+        contents: &[u8],
+    ) -> Result<OutboxReceipt, EffectError> {
+        self.write_with_extension(key, "eml", data_class, contents)
+    }
+
+    fn write_with_extension(
+        &self,
+        key: &str,
+        extension: &str,
+        data_class: EffectDataClass,
+        contents: &[u8],
+    ) -> Result<OutboxReceipt, EffectError> {
         if data_class == EffectDataClass::Red {
             return Err(EffectError::RedDataForbidden);
         }
         if contents.len() > MAX_OUTBOX_BYTES {
             return Err(EffectError::ContentTooLarge);
         }
-        let file_name = safe_file_name(key)?;
+        let file_name = safe_file_name(key, extension)?;
         let final_path = self.root.join(&file_name);
 
         // Refuse to write through an existing symlink or non-regular file.
@@ -127,10 +150,11 @@ impl OutboxBroker {
     }
 }
 
-/// Derive a safe `.txt` filename from an opaque key. Only ASCII alphanumerics,
-/// `-`, and `_` survive; anything else is rejected. The result is guaranteed
-/// to be a single path component.
-fn safe_file_name(key: &str) -> Result<String, EffectError> {
+/// Derive a safe `<key>.<extension>` filename from an opaque key. Only ASCII
+/// alphanumerics, `-`, and `_` survive in the key; the extension must be a
+/// short lowercase-ASCII tag. The result is guaranteed to be a single path
+/// component.
+fn safe_file_name(key: &str, extension: &str) -> Result<String, EffectError> {
     if key.is_empty() || key.len() > 128 {
         return Err(EffectError::UnsafeName);
     }
@@ -140,7 +164,15 @@ fn safe_file_name(key: &str) -> Result<String, EffectError> {
     {
         return Err(EffectError::UnsafeName);
     }
-    let name = format!("{key}.txt");
+    // The extension is host-supplied (never user-supplied), but validate it
+    // anyway so no call site can smuggle a dot or separator into the name.
+    if extension.is_empty()
+        || extension.len() > 8
+        || !extension.bytes().all(|byte| byte.is_ascii_lowercase())
+    {
+        return Err(EffectError::UnsafeName);
+    }
+    let name = format!("{key}.{extension}");
     // Defense in depth: the derived name must still be exactly one normal
     // component, matching the vault's traversal guard.
     let mut components = Path::new(&name).components();
@@ -224,6 +256,29 @@ mod tests {
         let written =
             std::fs::read(dir.path().join("outbox").join("invoice-2026-001.txt")).unwrap();
         assert_eq!(written, b"INVOICE DRAFT");
+    }
+
+    #[test]
+    fn writes_message_with_eml_extension() {
+        let dir = tempdir().unwrap();
+        let broker = OutboxBroker::open(dir.path().join("outbox")).unwrap();
+        let message = b"From: a\r\nTo: b\r\nSubject: hi\r\n\r\nbody";
+        let receipt = broker
+            .write_message("doc-42", EffectDataClass::Amber, message)
+            .unwrap();
+        assert_eq!(receipt.relative_path, "doc-42.eml");
+        let written = std::fs::read(dir.path().join("outbox").join("doc-42.eml")).unwrap();
+        assert_eq!(written, message);
+    }
+
+    #[test]
+    fn message_write_still_refuses_red_data() {
+        let dir = tempdir().unwrap();
+        let broker = OutboxBroker::open(dir.path().join("outbox")).unwrap();
+        assert_eq!(
+            broker.write_message("secret", EffectDataClass::Red, b"pii"),
+            Err(EffectError::RedDataForbidden)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Turns the first host effect from "write the raw document body" into "compose a
real, send-ready email." On approval, the existing RFC 0003 → Capability V2 →
sandbox → effect chain now writes `outbox/<id>.eml` — a well-formed RFC 5322
message with `From`/`To`/`Subject`/`Date`/`Message-ID`/`MIME-Version`/
`Content-Type` headers, the document body normalized to CRLF, and an explicit
`X-Sovereign-Composed: … not transmitted` marker.

**Nothing about the security chain changes** — only the bytes handed to the
already-audited broker and the file extension. The message is composed locally
and never sent; delivery stays the founder's own action, and Stage 1 still
performs **no network effects**.

## Honesty & safety

- **Composed, not sent.** Every message carries the `X-Sovereign-Composed`
  marker; with no recipient address it uses an RFC 2606 `.invalid` placeholder
  plus an `X-Sovereign-Note` telling the founder to set the address first.
- **No header injection.** Customer email is validated (single `@`, dotted, no
  CR/LF, spaces, commas, or angle brackets); display names that would inject
  headers are quoted/escaped per RFC 5322 and stripped of CR/LF. A test feeds a
  `"Bad\r\nBcc: victim@…"` name and asserts no `Bcc:` header appears.
- **Backward compatible.** The new `Customer.email` is `#[serde(default)]`, so
  vaults written before this field deserialize unchanged.

## Changes

- `sovereign-effects`: `write_message` (`.eml`) beside `write_document` (`.txt`),
  sharing one core — same Red-data refusal, path-safety, symlink refusal, atomic
  write; the extension itself is validated.
- `apps/cli` workspace: `compose_email()` + helpers; `Customer.email` (optional,
  validated); delivery composes the `.eml`.
- `apps/cli` UI: optional email in the customer form + table (EN/中文).
- Tests: composition (real vs placeholder recipient, injection safety), broker
  `.eml` path + Red refusal, end-to-end flow updated to assert the composed message.

## Validation

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`,
and `cargo test --workspace` (144 tests) all pass. Verified end to end at
runtime (the composed `.eml` shows real headers, real recipient, the invoice
body, and the not-transmitted marker; an invalid email is rejected) and in a
headless browser (customer email captured and shown, no JS errors).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNaAoHftuMyML3uwCZHEYx)_