### PR TITLE
feat(app): add deterministic next-steps and risks to the Command Center

### DIFF
--- a/apps/cli/assets/ui.html
+++ b/apps/cli/assets/ui.html
@@ -129,6 +129,12 @@
   </section>
 
   <section>
+    <h2 data-i18n="cc_guidance_title"></h2>
+    <div class="honest" data-i18n="cc_guidance_note"></div>
+    <div class="panel" style="margin-top:10px"><div id="cc-guidance" class="empty" data-i18n="loading"></div></div>
+  </section>
+
+  <section>
     <h2 data-i18n="cc_decisions_title"></h2>
     <div class="panel"><div id="cc-decisions" class="empty" data-i18n="cc_no_decisions"></div></div>
   </section>
@@ -270,6 +276,19 @@ const STRINGS = {
     cc_documents: "Documents", cc_documents_meta: (c) => c.drafts + " draft · " + c.approved_pending_delivery + " sent",
     cc_pending: "Awaiting you", cc_pending_meta: "decisions only you can make",
     cc_effects: "Signed effects", cc_effects_meta: (s) => s.last_effect_path ? "last: outbox/" + s.last_effect_path : "no real effects yet",
+    cc_guidance_title: "Suggested next steps",
+    cc_guidance_note: "Read from your current state — not predictions, and no model is involved. The same state always yields the same list.",
+    cc_no_guidance: "Nothing to suggest yet.",
+    cc_step_word: "step", cc_risk_word: "risk",
+    cc_guidance: (g) => ({
+      set_venture: "Name your venture — everything else builds on it.",
+      add_customer: "Add your first customer.",
+      draft_for: "Draft an offer or invoice for " + g.subject + ".",
+      send_drafts: g.count === 1 ? "You have 1 draft ready to send." : "You have " + g.count + " drafts ready to send.",
+      decide_pending: g.count === 1 ? "1 send is waiting for your approval." : g.count + " sends are waiting for your approval.",
+      add_email: "Add an email for " + g.subject + " — sends currently use a placeholder address.",
+      all_clear: "You're all caught up. Nothing is waiting on you.",
+    }[g.kind] || g.kind),
     cc_decisions_title: "Needs your decision",
     cc_no_decisions: "Nothing is waiting on you. The assistant can draft, but only you approve — nothing leaves without this step.",
     cc_decision_line: (d) => d.action + " · " + (d.customer_name || "—") + " · " + d.document_title,
@@ -361,6 +380,19 @@ const STRINGS = {
     cc_documents: "文档", cc_documents_meta: (c) => c.drafts + " 份草稿 · " + c.approved_pending_delivery + " 份已发送",
     cc_pending: "等你决定", cc_pending_meta: "只有你能做的决定",
     cc_effects: "已签名副作用", cc_effects_meta: (s) => s.last_effect_path ? "最近:outbox/" + s.last_effect_path : "尚无真实副作用",
+    cc_guidance_title: "建议的下一步",
+    cc_guidance_note: "根据你当前的状态得出 —— 不是预测,也不涉及任何模型。相同的状态始终给出相同的清单。",
+    cc_no_guidance: "暂无建议。",
+    cc_step_word: "步骤", cc_risk_word: "风险",
+    cc_guidance: (g) => ({
+      set_venture: "为你的业务命名 —— 其他一切都以此为基础。",
+      add_customer: "添加你的第一位客户。",
+      draft_for: "为 " + g.subject + " 起草一份报价或发票。",
+      send_drafts: "你有 " + g.count + " 份草稿可以发送。",
+      decide_pending: "有 " + g.count + " 项发送正在等待你的批准。",
+      add_email: "为 " + g.subject + " 添加邮箱 —— 目前发送使用的是占位地址。",
+      all_clear: "一切就绪,没有等待你处理的事项。",
+    }[g.kind] || g.kind),
     cc_decisions_title: "需要你的决定",
     cc_no_decisions: "没有等待你处理的事项。助手可以起草,但只有你能批准 —— 没有这一步,任何东西都不会发出。",
     cc_decision_line: (d) => d.action + " · " + (d.customer_name || "—") + " · " + d.document_title,
@@ -813,7 +845,27 @@ function renderCommandCenter() {
   $("cc-disclosures").textContent = k.model_disclosures;
   $("cc-plugins").textContent = k.admitted_plugins;
 
+  renderCommandGuidance(s.guidance);
   renderCommandDecisions(s.pending_decisions);
+}
+
+function renderCommandGuidance(items) {
+  const box = $("cc-guidance");
+  if (!items || !items.length) {
+    box.className = "empty";
+    box.replaceChildren(document.createTextNode(t("cc_no_guidance")));
+    return;
+  }
+  box.className = "";
+  box.replaceChildren(...items.map(g => {
+    const row = el("div", "pad");
+    const bar = el("div", "toolbar");
+    const risk = g.kind_class === "risk";
+    bar.appendChild(badge(risk ? "warn" : "neutral", risk ? t("cc_risk_word") : t("cc_step_word")));
+    bar.appendChild(el("span", null, t("cc_guidance")(g)));
+    row.appendChild(bar);
+    return row;
+  }));
 }
 
 function renderCommandDecisions(decisions) {

--- a/apps/cli/src/workspace.rs
+++ b/apps/cli/src/workspace.rs
@@ -218,6 +218,46 @@ pub struct CommandCenter {
     /// Approvals still waiting on the owner — the only actionable items here.
     pub pending_decisions: Vec<PendingDecision>,
     pub evidence: EvidenceRollup,
+    /// Deterministic next steps and risks read straight from state — ordered
+    /// most-important first. These are observations, not predictions: no model
+    /// is involved, and the same state always yields the same list.
+    pub guidance: Vec<Guidance>,
+}
+
+/// One suggested next step or surfaced risk. `kind` is a stable machine code
+/// the UI localizes; `count`/`subject` fill in its parameters.
+#[derive(Debug, Clone, Serialize)]
+pub struct Guidance {
+    pub kind: String,
+    /// "action" (something to do) or "risk" (something to be aware of).
+    pub kind_class: String,
+    pub count: usize,
+    pub subject: String,
+}
+
+impl Guidance {
+    fn action(kind: &str) -> Self {
+        Self {
+            kind: kind.to_owned(),
+            kind_class: "action".to_owned(),
+            count: 0,
+            subject: String::new(),
+        }
+    }
+    fn with_count(mut self, count: usize) -> Self {
+        self.count = count;
+        self
+    }
+    fn with_subject(mut self, subject: impl Into<String>) -> Self {
+        self.subject = subject.into();
+        self
+    }
+    fn risk(kind: &str) -> Self {
+        Self {
+            kind_class: "risk".to_owned(),
+            ..Self::action(kind)
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1034,7 +1074,7 @@ impl Store {
             rejected: count_status(DocumentStatus::Rejected),
         };
 
-        let pending_decisions = workspace
+        let pending_decisions: Vec<PendingDecision> = workspace
             .approvals
             .iter()
             .filter(|approval| approval.status == ApprovalStatus::Pending)
@@ -1083,11 +1123,14 @@ impl Store {
             last_effect_path: effects.last().map(|effect| effect.relative_path.clone()),
         };
 
+        let guidance = derive_guidance(&workspace, &counts, pending_decisions.len());
+
         Ok(CommandCenter {
             venture: workspace.venture,
             counts,
             pending_decisions,
             evidence,
+            guidance,
         })
     }
 
@@ -1408,6 +1451,63 @@ fn clean_optional_text(field: &str, value: &str) -> Result<String, WorkspaceErro
         )));
     }
     Ok(value.to_owned())
+}
+
+/// Derive the Command Center's next-steps and risks from state alone. Ordered
+/// most-important first and capped, so the founder sees a short, actionable
+/// list. Deterministic: the same workspace always produces the same guidance,
+/// and no model is consulted — these are observations, not predictions.
+fn derive_guidance(
+    workspace: &Workspace,
+    counts: &CommandCenterCounts,
+    pending: usize,
+) -> Vec<Guidance> {
+    // Before a venture exists nothing else is meaningful — name it first.
+    if workspace.venture.is_none() {
+        return vec![Guidance::action("set_venture")];
+    }
+
+    let mut out = Vec::new();
+
+    // The founder is the bottleneck for pending decisions: surface them first.
+    if pending > 0 {
+        out.push(Guidance::action("decide_pending").with_count(pending));
+    }
+    if workspace.customers.is_empty() {
+        out.push(Guidance::action("add_customer"));
+    }
+    if counts.drafts > 0 {
+        out.push(Guidance::action("send_drafts").with_count(counts.drafts));
+    }
+
+    // Risk: a customer who already has documents but no email — a send would be
+    // addressed to a placeholder the founder must fix before delivering.
+    if let Some(customer) = workspace.customers.iter().find(|customer| {
+        customer.email.trim().is_empty()
+            && workspace
+                .documents
+                .iter()
+                .any(|document| document.customer_id == customer.id)
+    }) {
+        out.push(Guidance::risk("add_email").with_subject(customer.name.clone()));
+    }
+
+    // A customer with no documents yet — an obvious next draft.
+    if let Some(customer) = workspace.customers.iter().find(|customer| {
+        !workspace
+            .documents
+            .iter()
+            .any(|document| document.customer_id == customer.id)
+    }) {
+        out.push(Guidance::action("draft_for").with_subject(customer.name.clone()));
+    }
+
+    if out.is_empty() {
+        out.push(Guidance::action("all_clear"));
+    }
+
+    out.truncate(5);
+    out
 }
 
 /// Compose a well-formed RFC 5322 message for an approved document. The result
@@ -1770,6 +1870,92 @@ mod tests {
         let ledger =
             AuditLedger::load(&_dir.path().join("ledger.json"), device.public_key_b64()).unwrap();
         assert_eq!(ledger.events().last().unwrap().action, "model.drafted");
+    }
+
+    #[test]
+    fn command_center_guidance_tracks_state_deterministically() {
+        let kinds = |store: &Store| -> Vec<String> {
+            store
+                .command_center()
+                .unwrap()
+                .guidance
+                .into_iter()
+                .map(|item| item.kind)
+                .collect()
+        };
+
+        let (_dir, store) = store();
+        // Empty: the only meaningful step is naming the venture.
+        assert_eq!(kinds(&store), vec!["set_venture"]);
+
+        // Venture but no customers.
+        store.set_venture("Acme", "Landing pages").unwrap();
+        assert_eq!(kinds(&store), vec!["add_customer"]);
+
+        // A customer with no documents → draft_for that customer.
+        let workspace = store.add_customer("Dr. Tan", "", "").unwrap();
+        let customer_id = workspace.customers[0].id;
+        assert_eq!(kinds(&store), vec!["draft_for"]);
+
+        // A document exists but the customer has no email → add_email risk
+        // surfaces, and there is now a draft to send.
+        store
+            .create_document(DocumentKind::Invoice, customer_id, Some(250_000), "en")
+            .unwrap();
+        let guidance = store.command_center().unwrap().guidance;
+        let kinds_now: Vec<&str> = guidance.iter().map(|item| item.kind.as_str()).collect();
+        assert!(kinds_now.contains(&"send_drafts"));
+        assert!(kinds_now.contains(&"add_email"));
+        let email_item = guidance
+            .iter()
+            .find(|item| item.kind == "add_email")
+            .unwrap();
+        assert_eq!(email_item.kind_class, "risk");
+        assert_eq!(email_item.subject, "Dr. Tan");
+        let send_item = guidance
+            .iter()
+            .find(|item| item.kind == "send_drafts")
+            .unwrap();
+        assert_eq!(send_item.count, 1);
+
+        // Determinism: recomputing yields the identical list.
+        assert_eq!(
+            serde_json::to_value(&guidance).unwrap(),
+            serde_json::to_value(&store.command_center().unwrap().guidance).unwrap()
+        );
+    }
+
+    #[test]
+    fn command_center_guidance_reports_pending_and_all_clear() {
+        let (_dir, store) = store();
+        store.set_venture("Acme", "Landing pages").unwrap();
+        let workspace = store
+            .add_customer("Dr. Tan", "dr.tan@example.com", "")
+            .unwrap();
+        let customer_id = workspace.customers[0].id;
+        let workspace = store
+            .create_document(DocumentKind::Invoice, customer_id, Some(250_000), "en")
+            .unwrap();
+        let document_id = workspace.documents[0].id;
+
+        // A pending decision is the top action.
+        let workspace = store.request_send(document_id).unwrap();
+        let approval_id = workspace.approvals[0].id;
+        let guidance = store.command_center().unwrap().guidance;
+        assert_eq!(guidance[0].kind, "decide_pending");
+        assert_eq!(guidance[0].count, 1);
+
+        // Once decided, with an emailed customer and no drafts left, the founder
+        // is caught up.
+        store.decide(approval_id, true).unwrap();
+        let kinds: Vec<String> = store
+            .command_center()
+            .unwrap()
+            .guidance
+            .into_iter()
+            .map(|item| item.kind)
+            .collect();
+        assert_eq!(kinds, vec!["all_clear"]);
     }
 
     #[test]


### PR DESCRIPTION
## What

Delivers the "current risks + most important next actions" the roadmap names
for the Founder Command Center (README line 41). A `derive_guidance` pass reads
the workspace and returns an ordered, capped list of concrete steps and risks:

- **Steps** — name your venture · add your first customer · draft for a
  customer who has none · send N drafts · decide N pending sends.
- **Risks** — a customer who already has documents but no email address (a send
  would be addressed to an RFC 2606 placeholder until it's fixed).

## Honesty

- **Deterministic and model-free.** The same state always yields the same list;
  these are observations, not predictions, and no model is consulted.
- **Read-only.** Guidance is computed inside the existing `command_center()`
  aggregation, which writes nothing and leaves no audit event — so this adds no
  new security claim.
- Ordered most-important-first (pending decisions surface first — the founder is
  the bottleneck there) and capped at 5 so the panel stays actionable.

## Changes

- `apps/cli` workspace: `Guidance` type + `derive_guidance()`, added to the
  `CommandCenter` aggregation.
- `apps/cli` UI: bilingual (EN/中文) "Suggested next steps" panel with a
  risk/step badge.
- Tests: state progression (`set_venture` → `add_customer` → `draft_for` →
  `send_drafts`+`add_email` risk), the pending-decision and all-clear cases, and
  determinism.

## Validation

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`,
and `cargo test --workspace` (146 tests) all pass. Verified in a headless
browser: the panel renders in EN and 中文 with the correct step/risk badges and
no JS errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNaAoHftuMyML3uwCZHEYx)_