### PR TITLE
test(kernel): add adversarial coverage for the Stage 2/3 crates

### DIFF
--- a/crates/authority/src/lib.rs
+++ b/crates/authority/src/lib.rs
@@ -386,6 +386,38 @@ mod tests {
     }
 
     #[test]
+    fn purged_idempotency_key_can_be_rebound_without_false_conflict() {
+        // An idempotency key that has expired and been purged must not haunt a
+        // later, unrelated invocation as a phantom conflict — otherwise expired
+        // keys would wedge new work forever. After purge, the same key rebinds
+        // to a different fingerprint cleanly.
+        let dir = tempdir().unwrap();
+        let store = AuthorityStore::open(dir.path()).unwrap();
+        let key = Uuid::new_v4();
+        let first = [1u8; 32];
+        let second = [2u8; 32];
+
+        store.bind_idempotency(key, &first, NOW, NOW + 10).unwrap();
+        // While live, a different fingerprint is a real conflict.
+        assert_eq!(
+            store.bind_idempotency(key, &second, NOW + 1, NOW + 10),
+            Err(AuthorityError::IdempotencyConflict)
+        );
+
+        // After expiry + purge the record is gone, and the key is free again.
+        assert_eq!(store.purge_expired(NOW + 100).unwrap(), 1);
+        assert_eq!(
+            store.bind_idempotency(key, &second, NOW + 101, NOW + 200),
+            Ok(())
+        );
+        // And it is once more a live one-use binding.
+        assert_eq!(
+            store.bind_idempotency(key, &second, NOW + 102, NOW + 200),
+            Err(AuthorityError::IdempotencyReplay)
+        );
+    }
+
+    #[test]
     fn corrupt_records_fail_closed() {
         let dir = tempdir().unwrap();
         let store = AuthorityStore::open(dir.path()).unwrap();

--- a/crates/execution/src/lib.rs
+++ b/crates/execution/src/lib.rs
@@ -367,6 +367,50 @@ mod tests {
     }
 
     #[test]
+    fn garbage_line_before_terminal_is_skipped_and_terminal_wins() {
+        let dir = tempdir().unwrap();
+        let journal = ExecutionJournal::open(dir.path()).unwrap();
+        let guard = journal.begin(intent(41)).unwrap();
+        guard.started().unwrap();
+        drop(guard);
+        // Inject a complete-but-unparseable line, then a valid terminal after
+        // it. The garbage must be skipped, not poison the whole record.
+        let path = dir.path().join(format!("{}.jsonl", Uuid::from_u128(41)));
+        let mut file = OpenOptions::new().append(true).open(&path).unwrap();
+        file.write_all(b"{\"record\":\"nonsense\",\"bad\":true}\n")
+            .unwrap();
+        let terminal = JournalRecord::Terminal(ExecutionOutcome::Completed {
+            result_hash_hex: "cc".repeat(32),
+        });
+        file.write_all(serde_json::to_string(&terminal).unwrap().as_bytes())
+            .unwrap();
+        file.write_all(b"\n").unwrap();
+        drop(file);
+
+        let recovered = ExecutionJournal::open(dir.path())
+            .unwrap()
+            .recover()
+            .unwrap();
+        assert_eq!(
+            recovered[0].state,
+            ExecutionState::Completed {
+                result_hash_hex: "cc".repeat(32)
+            }
+        );
+    }
+
+    #[test]
+    fn non_utf8_journal_fails_closed() {
+        let dir = tempdir().unwrap();
+        let journal = ExecutionJournal::open(dir.path()).unwrap();
+        // A journal file that is not valid UTF-8 is corruption, not an empty
+        // recovery: recover must surface an error rather than silently drop it.
+        std::fs::write(dir.path().join("corrupt.jsonl"), [0xff, 0xfe, 0x00, 0x01]).unwrap();
+        let result = journal.recover();
+        assert!(matches!(result, Err(JournalError::CorruptRecord)));
+    }
+
+    #[test]
     fn finished_guard_records_terminal_and_reopen_agrees() {
         let dir = tempdir().unwrap();
         let journal = ExecutionJournal::open(dir.path()).unwrap();

--- a/crates/model/src/lib.rs
+++ b/crates/model/src/lib.rs
@@ -374,6 +374,53 @@ mod tests {
     }
 
     #[test]
+    fn amber_data_may_use_a_cloud_provider() {
+        // The confidentiality guard is Red-specific: it must not over-block
+        // Amber. With no local provider available, Amber routes to the cloud.
+        let gateway = ModelGateway::new(vec![
+            Box::new(DeterministicProvider::local("local", Health::Down)),
+            Box::new(DeterministicProvider::cloud("cloud", Health::Healthy)),
+        ]);
+        let (response, disclosure) = gateway.complete(&request(DataClass::Amber)).unwrap();
+        assert_eq!(response.provider_id, "cloud");
+        assert_eq!(response.provider_trust, ProviderTrust::Cloud);
+        assert_eq!(disclosure.data_class, DataClass::Amber);
+    }
+
+    #[test]
+    fn disclosure_names_serving_provider_and_records_failover() {
+        // A failing primary and a healthy backup: the disclosure must name the
+        // provider that actually served, its index, and record the skip.
+        let gateway = ModelGateway::new(vec![
+            Box::new(DeterministicProvider::local("primary", Health::Healthy).failing()),
+            Box::new(DeterministicProvider::local("backup", Health::Healthy)),
+        ]);
+        let (response, disclosure) = gateway.complete(&request(DataClass::Amber)).unwrap();
+        assert_eq!(response.provider_id, "backup");
+        assert_eq!(disclosure.provider_id, "backup");
+        assert_eq!(disclosure.provider_index, 1);
+        assert!(disclosure
+            .skipped
+            .iter()
+            .any(|skip| skip.provider_id == "primary" && skip.reason == SkipCause::Failed));
+    }
+
+    #[test]
+    fn output_exceeding_the_limit_fails_closed() {
+        // An echo provider returns the prompt verbatim; a prompt longer than
+        // the caller's ceiling must be refused, not silently truncated or
+        // passed through.
+        let gateway = ModelGateway::new(vec![Box::new(DeterministicProvider::local_echo(
+            "echo",
+            Health::Healthy,
+        ))]);
+        let mut request = request(DataClass::Amber);
+        request.max_output_chars = 4;
+        request.prompt = "this prompt is far longer than four characters".into();
+        assert_eq!(gateway.complete(&request), Err(ModelError::OutputTooLarge));
+    }
+
+    #[test]
     fn removing_primary_does_not_stop_the_workflow() {
         // Stage 2 exit criterion: primary down → backup serves the request.
         let gateway = ModelGateway::new(vec![

--- a/crates/workflow/src/lib.rs
+++ b/crates/workflow/src/lib.rs
@@ -444,6 +444,30 @@ mod tests {
     }
 
     #[test]
+    fn resuming_with_fewer_steps_than_completed_fails_closed() {
+        let dir = tempdir().unwrap();
+        let runs = Arc::new(AtomicUsize::new(0));
+        // Complete a four-step workflow.
+        WorkflowRunner::open(dir.path(), "wf")
+            .unwrap()
+            .run(&steps(&["a", "b", "c", "d"], &runs))
+            .unwrap();
+        assert_eq!(runs.load(Ordering::SeqCst), 4);
+
+        // Reopen with a truncated definition — fewer steps than already
+        // completed. That can only mean the definition changed under a live
+        // checkpoint; the runner must refuse rather than silently drop history.
+        let resume_runs = Arc::new(AtomicUsize::new(0));
+        let error = WorkflowRunner::open(dir.path(), "wf")
+            .unwrap()
+            .run(&steps(&["a", "b"], &resume_runs))
+            .unwrap_err();
+        assert!(matches!(error, WorkflowError::StepDivergence(_)));
+        // It failed closed before running anything.
+        assert_eq!(resume_runs.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
     fn changed_step_name_under_a_live_checkpoint_fails_closed() {
         let dir = tempdir().unwrap();
         let runs = Arc::new(AtomicUsize::new(0));


### PR DESCRIPTION
## What

Raises real assurance on the newer kernel crates by locking behaviors the
security story depends on but that had no test. **No production code changes** —
tests only.

- **model** (8→11): Amber data may route to a **cloud** provider (the
  confidentiality guard is Red-specific and must not over-block); a disclosure
  record names the provider that **actually served** plus the failover skip
  trail; output exceeding the caller's ceiling **fails closed** (`OutputTooLarge`)
  rather than truncating or passing through.
- **authority** (6→7): a purged (expired) idempotency key **rebinds cleanly** to
  a new fingerprint — expired keys must not wedge later work as phantom
  conflicts — and is immediately a live one-use binding again.
- **execution** (6→8): a complete-but-unparseable line **mid-journal** is skipped
  while a valid terminal after it still wins; a **non-UTF-8** journal fails
  closed with `CorruptRecord` instead of a silent empty recovery.
- **workflow** (7→8): resuming with **fewer steps than already completed** fails
  closed as `StepDivergence` and runs nothing.

## Validation

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`,
and `cargo test --workspace` (153 tests) all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNaAoHftuMyML3uwCZHEYx)_