### PR TITLE
feat(app): make approved sends revocable — delete .eml + signed effect.revoked

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,8 +207,10 @@ tampering) — every denial is a real enforcement path, not a mock.
   local `outbox/*.eml` file (a real, audited host effect) — addressed to the
   customer's email if set, otherwise an RFC 2606 placeholder, and always marked
   "composed locally, not transmitted" — and records the signed evidence;
-  Stage 1 performs no *network* effects —
-  nothing leaves the device.
+  Stage 1 performs no *network* effects — nothing leaves the device. The effect
+  is genuinely revocable: revoking an approved send deletes the `.eml` and
+  records a signed `effect.revoked` event, while the approval evidence is kept
+  as history.
 - **Security Center** — device identity, vault entries, admitted plugins
   (verified from the content-addressed store), the signed audit chain, and a
   one-click in-memory run of the attack gauntlet.

--- a/apps/cli/assets/ui.html
+++ b/apps/cli/assets/ui.html
@@ -319,8 +319,10 @@ const STRINGS = {
     ws_no_documents: "No documents yet — add a customer, then generate an offer or invoice.",
     ws_view_content: "View content",
     ws_submit_send: "Request to send",
+    ws_revoke: "Revoke",
     status_draft: "draft", status_pending_approval: "awaiting your approval",
-    status_approved_pending_delivery: "approved — delivery deferred (no external effects in Stage 1)",
+    status_approved_pending_delivery: "approved — .eml composed in outbox, not sent (delivery is yours)",
+    status_revoked: "revoked — outbox file deleted",
     ws_evidence: (e) => "✓ signed approval " + e.evidence_digest.slice(0, 12) + "… · approver key " + e.approver_key_id.slice(0, 12) + "… · sandboxed run exit " + e.guest_exit_code,
     ws_outbox: (o) => "→ written to outbox/" + o.relative_path + " · sha256 " + o.content_sha256.slice(0, 12) + "… · " + o.bytes + " bytes",
     status_rejected: "rejected",
@@ -423,8 +425,10 @@ const STRINGS = {
     ws_no_documents: "暂无文档——先添加客户,再生成报价单或发票。",
     ws_view_content: "查看内容",
     ws_submit_send: "申请发送",
+    ws_revoke: "撤销",
     status_draft: "草稿", status_pending_approval: "等待你的审批",
-    status_approved_pending_delivery: "已批准 — 发送延后(第一阶段无外部副作用)",
+    status_approved_pending_delivery: "已批准 — .eml 已在发件箱生成,尚未发送(发送由你完成)",
+    status_revoked: "已撤销 — 发件箱文件已删除",
     ws_evidence: (e) => "✓ 签名审批 " + e.evidence_digest.slice(0, 12) + "… · 审批人密钥 " + e.approver_key_id.slice(0, 12) + "… · 沙箱执行返回 " + e.guest_exit_code,
     ws_outbox: (o) => "→ 已写入 outbox/" + o.relative_path + " · sha256 " + o.content_sha256.slice(0, 12) + "… · " + o.bytes + " 字节",
     status_rejected: "已拒绝",
@@ -577,7 +581,7 @@ function renderWorkspace() {
       const head = el("div", "doc-head");
       head.appendChild(el("span", "badge neutral", t(d.kind === "offer" ? "kind_offer" : "kind_invoice")));
       head.appendChild(el("span", "title", d.title));
-      const statusKind = { draft: "neutral", pending_approval: "warn", approved_pending_delivery: "good", rejected: "bad" }[d.status] || "neutral";
+      const statusKind = { draft: "neutral", pending_approval: "warn", approved_pending_delivery: "good", rejected: "bad", revoked: "neutral" }[d.status] || "neutral";
       head.appendChild(badge(statusKind, t("status_" + d.status)));
       if (d.status === "draft") {
         const submit = el("button", "ghost small", t("ws_submit_send"));
@@ -587,6 +591,15 @@ function renderWorkspace() {
           else $("d-status").textContent = result.error;
         });
         head.appendChild(submit);
+      }
+      if (d.status === "approved_pending_delivery") {
+        const revoke = el("button", "ghost small", t("ws_revoke"));
+        revoke.addEventListener("click", async () => {
+          const result = await api("/api/workspace/revoke", { document_id: d.id });
+          if (result.ok) { ws = result.workspace; renderWorkspace(); loadState(); }
+          else $("d-status").textContent = result.error;
+        });
+        head.appendChild(revoke);
       }
       wrap.appendChild(head);
       const approvalWithEvidence = ws.approvals.find(a => a.document_id === d.id && a.evidence);

--- a/apps/cli/src/ui.rs
+++ b/apps/cli/src/ui.rs
@@ -263,6 +263,7 @@ fn workspace_post(path: &str, body: &serde_json::Value, root: &Path) -> serde_js
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false),
             ),
+            "/api/workspace/revoke" => store.revoke_delivery(uuid_field(body, "document_id")?),
             _ => Err(workspace::WorkspaceError::NotFound("route".into())),
         }
     })();

--- a/apps/cli/src/workspace.rs
+++ b/apps/cli/src/workspace.rs
@@ -121,6 +121,10 @@ pub enum DocumentStatus {
     PendingApproval,
     ApprovedPendingDelivery,
     Rejected,
+    /// An approved send whose composed outbox file the owner later revoked.
+    /// The signed approval evidence remains; the local effect was undone and
+    /// the revocation is itself audited.
+    Revoked,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -780,6 +784,64 @@ impl Store {
                 )?;
             }
         }
+        Ok(workspace)
+    }
+
+    /// Revoke an approved send: delete the composed `.eml` from the local
+    /// outbox and record a signed `effect.revoked` event. This makes the
+    /// "revocable" property real — the local effect is undone and the
+    /// revocation is itself audited. The signed approval evidence is kept: it
+    /// is history, and revoking the file does not rewrite the fact that the
+    /// owner approved. Fails closed if the document is not awaiting delivery.
+    pub fn revoke_delivery(&self, document_id: Uuid) -> Result<Workspace, WorkspaceError> {
+        let mut workspace = self.load()?;
+        let document = workspace
+            .documents
+            .iter()
+            .find(|document| document.id == document_id)
+            .ok_or_else(|| WorkspaceError::NotFound("document".into()))?;
+        if document.status != DocumentStatus::ApprovedPendingDelivery {
+            return Err(WorkspaceError::Invalid(
+                "only an approved, undelivered document can be revoked".into(),
+            ));
+        }
+
+        // Locate the outbox receipt from this document's approval evidence.
+        let outbox = workspace
+            .approvals
+            .iter()
+            .filter(|approval| approval.document_id == document_id)
+            .filter_map(|approval| approval.evidence.as_ref())
+            .filter_map(|evidence| evidence.outbox.as_ref())
+            .next_back()
+            .cloned()
+            .ok_or_else(|| WorkspaceError::Invalid("no outbox effect to revoke".into()))?;
+
+        // Delete the file. "Already gone" is an acceptable end state — the goal
+        // is that the file no longer exists — but any other error fails closed.
+        let broker =
+            sovereign_effects::OutboxBroker::open(self.root.join("outbox")).map_err(kernel)?;
+        match broker.revoke(&outbox.relative_path) {
+            Ok(()) | Err(sovereign_effects::EffectError::NotFound) => {}
+            Err(error) => return Err(kernel(error)),
+        }
+
+        let document_entry = workspace
+            .documents
+            .iter_mut()
+            .find(|document| document.id == document_id)
+            .ok_or_else(|| WorkspaceError::NotFound("document".into()))?;
+        document_entry.status = DocumentStatus::Revoked;
+        self.save(&workspace)?;
+
+        self.record(
+            "effect.revoked",
+            &format!("document:{document_id}"),
+            serde_json::json!({
+                "outbox_path": outbox.relative_path,
+                "content_sha256": outbox.content_sha256,
+            }),
+        )?;
         Ok(workspace)
     }
 
@@ -1730,6 +1792,58 @@ mod tests {
         // A real recipient means no placeholder note.
         assert!(!message.contains("placeholder"));
         assert_eq!(outbox_receipt.bytes, written.len());
+    }
+
+    #[test]
+    fn revoke_delivery_deletes_outbox_and_audits() {
+        let (dir, store) = store();
+        store.set_venture("Acme", "Landing pages").unwrap();
+        let workspace = store
+            .add_customer("Dr. Tan", "dr.tan@example.com", "")
+            .unwrap();
+        let customer_id = workspace.customers[0].id;
+        let workspace = store
+            .create_document(DocumentKind::Invoice, customer_id, Some(250_000), "en")
+            .unwrap();
+        let document_id = workspace.documents[0].id;
+        let workspace = store.request_send(document_id).unwrap();
+        let workspace = store.decide(workspace.approvals[0].id, true).unwrap();
+        let outbox_path = workspace.approvals[0]
+            .evidence
+            .as_ref()
+            .unwrap()
+            .outbox
+            .as_ref()
+            .unwrap()
+            .relative_path
+            .clone();
+        let file = dir.path().join("outbox").join(&outbox_path);
+        assert!(file.exists());
+
+        let workspace = store.revoke_delivery(document_id).unwrap();
+        assert_eq!(workspace.documents[0].status, DocumentStatus::Revoked);
+        assert!(!file.exists(), "revoke deletes the composed .eml");
+
+        // The revocation is audited on the same signed chain, and the prior
+        // approval evidence is kept — revoking the file does not rewrite the
+        // fact that the owner approved.
+        let device = DeviceIdentity::load(&dir.path().join("device.json")).unwrap();
+        let ledger =
+            AuditLedger::load(&dir.path().join("ledger.json"), device.public_key_b64()).unwrap();
+        assert_eq!(ledger.events().last().unwrap().action, "effect.revoked");
+        ledger.verify_chain().unwrap();
+        assert!(workspace.approvals[0].evidence.is_some());
+
+        // A second revoke fails closed (no longer awaiting delivery), and an
+        // unknown document is refused.
+        assert!(matches!(
+            store.revoke_delivery(document_id),
+            Err(WorkspaceError::Invalid(_))
+        ));
+        assert!(matches!(
+            store.revoke_delivery(Uuid::new_v4()),
+            Err(WorkspaceError::NotFound(_))
+        ));
     }
 
     #[test]

--- a/crates/effects/src/lib.rs
+++ b/crates/effects/src/lib.rs
@@ -61,6 +61,8 @@ pub enum EffectError {
     ContentTooLarge,
     #[error("outbox target already exists and is not a regular file")]
     UnsafeExistingTarget,
+    #[error("outbox file not found")]
+    NotFound,
     #[error("outbox effect I/O failed: {0}")]
     Io(String),
 }
@@ -143,6 +145,34 @@ impl OutboxBroker {
             content_sha256_hex: hex::encode(Sha256::digest(contents)),
             bytes: contents.len(),
         })
+    }
+
+    /// Delete a file previously written to the outbox, addressed by the exact
+    /// relative path from its receipt. The name is re-validated as a single
+    /// safe component, and only a regular file is removed — never a symlink or
+    /// directory. A missing file is reported so the caller can distinguish
+    /// "revoked now" from "already gone".
+    pub fn revoke(&self, relative_path: &str) -> Result<(), EffectError> {
+        // Re-derive the name from key+extension so a caller cannot pass an
+        // arbitrary path: split the receipt's `<key>.<ext>` and re-validate.
+        let (key, extension) = relative_path
+            .rsplit_once('.')
+            .ok_or(EffectError::UnsafeName)?;
+        let file_name = safe_file_name(key, extension)?;
+        if file_name != relative_path {
+            return Err(EffectError::UnsafeName);
+        }
+        let target = self.root.join(&file_name);
+        match std::fs::symlink_metadata(&target) {
+            Ok(metadata) if metadata.file_type().is_file() => {
+                std::fs::remove_file(&target).map_err(io)
+            }
+            Ok(_) => Err(EffectError::UnsafeExistingTarget),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                Err(EffectError::NotFound)
+            }
+            Err(error) => Err(io(error)),
+        }
     }
 
     pub fn root(&self) -> &Path {
@@ -279,6 +309,35 @@ mod tests {
             broker.write_message("secret", EffectDataClass::Red, b"pii"),
             Err(EffectError::RedDataForbidden)
         );
+    }
+
+    #[test]
+    fn revoke_deletes_the_file_and_reports_missing() {
+        let dir = tempdir().unwrap();
+        let broker = OutboxBroker::open(dir.path().join("outbox")).unwrap();
+        let receipt = broker
+            .write_message("doc-9", EffectDataClass::Amber, b"hello")
+            .unwrap();
+        let path = dir.path().join("outbox").join(&receipt.relative_path);
+        assert!(path.exists());
+
+        broker.revoke(&receipt.relative_path).unwrap();
+        assert!(!path.exists(), "revoke removes the file");
+
+        // A second revoke reports it is already gone, not a silent success.
+        assert_eq!(
+            broker.revoke(&receipt.relative_path),
+            Err(EffectError::NotFound)
+        );
+    }
+
+    #[test]
+    fn revoke_refuses_unsafe_paths() {
+        let dir = tempdir().unwrap();
+        let broker = OutboxBroker::open(dir.path().join("outbox")).unwrap();
+        for bad in ["../secret.txt", "a/b.txt", "noext", "sub/../x.eml"] {
+            assert_eq!(broker.revoke(bad), Err(EffectError::UnsafeName), "{bad}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What

Backs the **"revocable"** property the docs already claim but nothing
implemented. Revoking an approved, undelivered document:

1. deletes its composed `.eml` from the local outbox (path-safe),
2. records a signed `effect.revoked` event on the same hash chain,
3. moves the document to a new `Revoked` status.

The prior RFC 0003 approval evidence is **kept as history** — revoking the file
undoes the *effect*, it does not rewrite the fact that the owner approved.

## Safety

- `OutboxBroker::revoke()` re-splits the receipt's relative path and re-validates
  it as `<key>.<ext>`; only a **regular file** is removed (never a symlink or
  directory); a missing file is reported as `NotFound` so the caller can tell
  "revoked now" from "already gone". Tests refuse `../secret.txt`, `a/b.txt`,
  `noext`, `sub/../x.eml`.
- `revoke_delivery` treats already-gone as success (the goal is the file is
  absent) but **fails closed** on any other error and on documents not awaiting
  delivery.

## Also

- Corrects a now-stale status label: "no external effects in Stage 1" →
  "approved — .eml composed in outbox, not sent (delivery is yours)", plus a new
  "revoked — outbox file deleted" (EN/中文).
- Revoke button on approved documents.

## Tests

Broker revoke (delete, missing→NotFound, unsafe-path refusal) and end-to-end
revoke (file deleted, status `Revoked`, `effect.revoked` audited, chain
verifies, approval evidence retained, double-revoke and unknown-doc fail
closed).

## Validation

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`,
and `cargo test --workspace` (156 tests) all pass. Verified end to end in a
headless browser: the `.eml` exists after approval, Revoke deletes it, the
status flips to "revoked", and the approval evidence stays visible.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNaAoHftuMyML3uwCZHEYx)_