### PR TITLE
feat(app): add delivery confirmation to complete the document lifecycle

### DIFF
--- a/apps/cli/assets/ui.html
+++ b/apps/cli/assets/ui.html
@@ -319,10 +319,11 @@ const STRINGS = {
     ws_no_documents: "No documents yet — add a customer, then generate an offer or invoice.",
     ws_view_content: "View content",
     ws_submit_send: "Request to send",
-    ws_revoke: "Revoke",
+    ws_revoke: "Revoke", ws_mark_delivered: "Mark delivered",
     status_draft: "draft", status_pending_approval: "awaiting your approval",
     status_approved_pending_delivery: "approved — .eml composed in outbox, not sent (delivery is yours)",
     status_revoked: "revoked — outbox file deleted",
+    status_delivered: "delivered — you confirmed you sent it",
     ws_evidence: (e) => "✓ signed approval " + e.evidence_digest.slice(0, 12) + "… · approver key " + e.approver_key_id.slice(0, 12) + "… · sandboxed run exit " + e.guest_exit_code,
     ws_outbox: (o) => "→ written to outbox/" + o.relative_path + " · sha256 " + o.content_sha256.slice(0, 12) + "… · " + o.bytes + " bytes",
     status_rejected: "rejected",
@@ -425,10 +426,11 @@ const STRINGS = {
     ws_no_documents: "暂无文档——先添加客户,再生成报价单或发票。",
     ws_view_content: "查看内容",
     ws_submit_send: "申请发送",
-    ws_revoke: "撤销",
+    ws_revoke: "撤销", ws_mark_delivered: "标记为已送达",
     status_draft: "草稿", status_pending_approval: "等待你的审批",
     status_approved_pending_delivery: "已批准 — .eml 已在发件箱生成,尚未发送(发送由你完成)",
     status_revoked: "已撤销 — 发件箱文件已删除",
+    status_delivered: "已送达 — 你已确认自行发送",
     ws_evidence: (e) => "✓ 签名审批 " + e.evidence_digest.slice(0, 12) + "… · 审批人密钥 " + e.approver_key_id.slice(0, 12) + "… · 沙箱执行返回 " + e.guest_exit_code,
     ws_outbox: (o) => "→ 已写入 outbox/" + o.relative_path + " · sha256 " + o.content_sha256.slice(0, 12) + "… · " + o.bytes + " 字节",
     status_rejected: "已拒绝",
@@ -581,7 +583,7 @@ function renderWorkspace() {
       const head = el("div", "doc-head");
       head.appendChild(el("span", "badge neutral", t(d.kind === "offer" ? "kind_offer" : "kind_invoice")));
       head.appendChild(el("span", "title", d.title));
-      const statusKind = { draft: "neutral", pending_approval: "warn", approved_pending_delivery: "good", rejected: "bad", revoked: "neutral" }[d.status] || "neutral";
+      const statusKind = { draft: "neutral", pending_approval: "warn", approved_pending_delivery: "good", rejected: "bad", revoked: "neutral", delivered: "good" }[d.status] || "neutral";
       head.appendChild(badge(statusKind, t("status_" + d.status)));
       if (d.status === "draft") {
         const submit = el("button", "ghost small", t("ws_submit_send"));
@@ -593,6 +595,13 @@ function renderWorkspace() {
         head.appendChild(submit);
       }
       if (d.status === "approved_pending_delivery") {
+        const delivered = el("button", "ghost small", t("ws_mark_delivered"));
+        delivered.addEventListener("click", async () => {
+          const result = await api("/api/workspace/confirm-delivery", { document_id: d.id });
+          if (result.ok) { ws = result.workspace; renderWorkspace(); loadState(); }
+          else $("d-status").textContent = result.error;
+        });
+        head.appendChild(delivered);
         const revoke = el("button", "ghost small", t("ws_revoke"));
         revoke.addEventListener("click", async () => {
           const result = await api("/api/workspace/revoke", { document_id: d.id });

--- a/apps/cli/src/ui.rs
+++ b/apps/cli/src/ui.rs
@@ -264,6 +264,9 @@ fn workspace_post(path: &str, body: &serde_json::Value, root: &Path) -> serde_js
                     .unwrap_or(false),
             ),
             "/api/workspace/revoke" => store.revoke_delivery(uuid_field(body, "document_id")?),
+            "/api/workspace/confirm-delivery" => {
+                store.confirm_delivery(uuid_field(body, "document_id")?)
+            }
             _ => Err(workspace::WorkspaceError::NotFound("route".into())),
         }
     })();

--- a/apps/cli/src/workspace.rs
+++ b/apps/cli/src/workspace.rs
@@ -125,6 +125,10 @@ pub enum DocumentStatus {
     /// The signed approval evidence remains; the local effect was undone and
     /// the revocation is itself audited.
     Revoked,
+    /// The owner has attested they delivered the composed message to the
+    /// customer themselves. Stage 1 sends nothing over the network — this is a
+    /// human attestation, recorded as a signed audit event, not a system send.
+    Delivered,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -841,6 +845,34 @@ impl Store {
                 "outbox_path": outbox.relative_path,
                 "content_sha256": outbox.content_sha256,
             }),
+        )?;
+        Ok(workspace)
+    }
+
+    /// Record the owner's attestation that they delivered the composed message
+    /// to the customer themselves. This is deliberately honest: Stage 1 sends
+    /// nothing over the network, so the system never claims to have delivered
+    /// anything — it records the owner's own confirmation as a signed audit
+    /// event and moves the document to `Delivered`. Fails closed unless the
+    /// document is approved and awaiting delivery.
+    pub fn confirm_delivery(&self, document_id: Uuid) -> Result<Workspace, WorkspaceError> {
+        let mut workspace = self.load()?;
+        let document = workspace
+            .documents
+            .iter_mut()
+            .find(|document| document.id == document_id)
+            .ok_or_else(|| WorkspaceError::NotFound("document".into()))?;
+        if document.status != DocumentStatus::ApprovedPendingDelivery {
+            return Err(WorkspaceError::Invalid(
+                "only an approved, undelivered document can be confirmed delivered".into(),
+            ));
+        }
+        document.status = DocumentStatus::Delivered;
+        self.save(&workspace)?;
+        self.record(
+            "delivery.confirmed",
+            &format!("document:{document_id}"),
+            serde_json::json!({ "attested_by": "founder", "system_sent": false }),
         )?;
         Ok(workspace)
     }
@@ -1842,6 +1874,49 @@ mod tests {
         ));
         assert!(matches!(
             store.revoke_delivery(Uuid::new_v4()),
+            Err(WorkspaceError::NotFound(_))
+        ));
+    }
+
+    #[test]
+    fn confirm_delivery_is_an_audited_attestation() {
+        let (dir, store) = store();
+        store.set_venture("Acme", "Landing pages").unwrap();
+        let workspace = store
+            .add_customer("Dr. Tan", "dr.tan@example.com", "")
+            .unwrap();
+        let customer_id = workspace.customers[0].id;
+        let workspace = store
+            .create_document(DocumentKind::Invoice, customer_id, Some(250_000), "en")
+            .unwrap();
+        let document_id = workspace.documents[0].id;
+        let workspace = store.request_send(document_id).unwrap();
+        store.decide(workspace.approvals[0].id, true).unwrap();
+
+        let workspace = store.confirm_delivery(document_id).unwrap();
+        assert_eq!(workspace.documents[0].status, DocumentStatus::Delivered);
+
+        // The attestation is on the signed chain and honestly marks that the
+        // system did not send anything.
+        let device = DeviceIdentity::load(&dir.path().join("device.json")).unwrap();
+        let ledger =
+            AuditLedger::load(&dir.path().join("ledger.json"), device.public_key_b64()).unwrap();
+        let last = ledger.events().last().unwrap();
+        assert_eq!(last.action, "delivery.confirmed");
+        ledger.verify_chain().unwrap();
+
+        // A delivered document cannot be confirmed again or revoked, and an
+        // unknown document fails closed.
+        assert!(matches!(
+            store.confirm_delivery(document_id),
+            Err(WorkspaceError::Invalid(_))
+        ));
+        assert!(matches!(
+            store.revoke_delivery(document_id),
+            Err(WorkspaceError::Invalid(_))
+        ));
+        assert!(matches!(
+            store.confirm_delivery(Uuid::new_v4()),
             Err(WorkspaceError::NotFound(_))
         ));
     }


### PR DESCRIPTION
## What

Completes the send lifecycle. From `ApprovedPendingDelivery`, the owner can now
either **confirm delivery** or **revoke** (from the previous PR) — both audited.

Marking a document `Delivered` is the owner **attesting** they sent the composed
`.eml` to the customer themselves. Stage 1 sends nothing over the network, so
the system never claims to have delivered anything: `confirm_delivery` records
the attestation as a signed `delivery.confirmed` event (`system_sent: false`)
and moves the document to `Delivered`. It **fails closed** unless the document
is approved and awaiting delivery.

## Changes

- `apps/cli` workspace: `DocumentStatus::Delivered` + `confirm_delivery()`.
- `apps/cli` UI + `POST /api/workspace/confirm-delivery`: "Mark delivered" button
  and a Delivered status (EN/中文).
- Test: the state transition, the audited attestation on the verified chain, and
  the fail-closed cases (double-confirm, revoke-after-deliver, unknown document).

## Validation

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`,
and `cargo test --workspace` (157 tests) all pass. Verified in a headless
browser: Mark delivered flips the status to "delivered — you confirmed you sent
it" with the approval evidence retained, no JS errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNaAoHftuMyML3uwCZHEYx)_