### PR TITLE
feat(app): add state-integrity self-audit against the signed chain

### DIFF
--- a/apps/cli/assets/ui.html
+++ b/apps/cli/assets/ui.html
@@ -237,6 +237,12 @@
   </div>
 
   <section>
+    <h2 data-i18n="sec_integrity"></h2>
+    <div class="honest" data-i18n="sec_integrity_note"></div>
+    <div class="panel"><div id="integrity" class="empty" data-i18n="loading"></div></div>
+  </section>
+
+  <section>
     <h2 data-i18n="sec_plugins"></h2>
     <div class="panel"><div id="plugins" class="empty" data-i18n="loading"></div></div>
   </section>
@@ -349,6 +355,10 @@ const STRINGS = {
     vault_meta: "encrypted at rest (AES-256-GCM)", plugins_meta: "owner-signed admission records",
     device_ready: "ready", device_none: "none", device_hint: "created automatically on first use",
     chain_ok: "chain verified", chain_broken: "CHAIN BROKEN", no_ledger_tile: "no ledger yet",
+    sec_integrity: "State integrity — self-audit against the signed chain",
+    sec_integrity_note: "Binds your authoritative state to the tamper-evident ledger. It re-verifies the signed chain, then confirms every approved, revoked, or delivered document — and every customer — has the signed event that should back it. It proves signed evidence exists for a state, not that a field's value is unchanged.",
+    integrity_ok: "verified", integrity_bad: "divergence found",
+    integrity_summary: (chain, n) => (chain ? "signed chain re-verified" : "signed chain FAILED") + " · " + n + " events reconciled against state",
     sec_plugins: "Admitted plugins — content-addressed store",
     sec_ledger: "Audit trail — signed hash chain (latest 25)",
     sec_gauntlet: "Security gauntlet — real attacks, run now, in memory",
@@ -456,6 +466,10 @@ const STRINGS = {
     vault_meta: "静态加密(AES-256-GCM)", plugins_meta: "所有者签名的准入记录",
     device_ready: "就绪", device_none: "未创建", device_hint: "首次使用时自动创建",
     chain_ok: "哈希链已验证", chain_broken: "哈希链已损坏", no_ledger_tile: "暂无账本",
+    sec_integrity: "状态完整性 — 对照签名链自我审计",
+    sec_integrity_note: "将你的权威状态与防篡改账本绑定。它会重新验证签名链,然后确认每一份已批准、已撤销或已送达的文档,以及每一位客户,都有应有的签名事件作为支撑。它证明某个状态存在签名证据,而非证明字段值未被改动。",
+    integrity_ok: "已验证", integrity_bad: "发现偏差",
+    integrity_summary: (chain, n) => (chain ? "签名链已重新验证" : "签名链验证失败") + " · 已对照状态核对 " + n + " 条事件",
     sec_plugins: "已准入插件 — 内容寻址存储",
     sec_ledger: "审计记录 — 签名哈希链(最近 25 条)",
     sec_gauntlet: "安全闯关 — 真实攻击,即刻在内存中运行",
@@ -703,6 +717,28 @@ function renderState() {
       : el("span", null, t("no_ledger_tile")));
   $("t-vault").textContent = state.vault_entries.length;
   $("t-plugins").textContent = state.plugins.length;
+
+  const integrity = $("integrity");
+  const ir = state.integrity;
+  if (!ir) {
+    integrity.replaceChildren(el("div", "empty", t("loading")));
+  } else {
+    const wrap = el("div", null);
+    const head = el("div", "gauntlet-row");
+    head.appendChild(badge(ir.ok ? "good" : "bad", ir.ok ? t("integrity_ok") : t("integrity_bad")));
+    head.appendChild(document.createTextNode(" " + t("integrity_summary")(ir.chain_verified, ir.events)));
+    wrap.appendChild(head);
+    if (ir.error) wrap.appendChild(el("div", "mono", ir.error));
+    (ir.findings || []).forEach(f => {
+      const row = el("div", "gauntlet-row");
+      row.appendChild(badge("bad", f.severity));
+      row.appendChild(el("div", "detail", f.resource + " — " + f.detail));
+      wrap.appendChild(row);
+    });
+    wrap.classList.remove("empty");
+    integrity.replaceChildren(wrap);
+    integrity.classList.remove("empty");
+  }
 
   const plugins = $("plugins");
   if (!state.plugins.length) {

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -60,6 +60,8 @@ enum Commands {
         /// Path to a JSON bundle produced by the app's "Export all my data"
         path: PathBuf,
     },
+    /// Self-audit: reconcile local state against the signed audit chain
+    Integrity,
 }
 
 fn data_dir() -> PathBuf {
@@ -79,8 +81,43 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Commands::ModelCheck => cmd_model_check(),
         Commands::WorkflowDemo => cmd_workflow_demo()?,
         Commands::VerifyExport { path } => cmd_verify_export(&path)?,
+        Commands::Integrity => cmd_integrity()?,
     }
     Ok(())
+}
+
+fn cmd_integrity() -> Result<(), Box<dyn std::error::Error>> {
+    let store = workspace::Store::open(&data_dir())?;
+    let report = store.integrity_check()?;
+
+    let check = |ok: bool| if ok { "PASS" } else { "FAIL" };
+    println!("Self-audit — state reconciled against the signed audit chain");
+    println!(
+        "  signed audit chain {}  ({} events)",
+        check(report.chain_verified),
+        report.events
+    );
+    if report.findings.is_empty() {
+        println!("  state vs. evidence  PASS");
+    } else {
+        println!(
+            "  state vs. evidence  FAIL  ({} findings)",
+            report.findings.len()
+        );
+        for finding in &report.findings {
+            println!(
+                "    [{}] {} — {}",
+                finding.severity, finding.resource, finding.detail
+            );
+        }
+    }
+    if report.ok {
+        println!("\nVERIFIED — every state on disk is backed by signed evidence.");
+        Ok(())
+    } else {
+        // Fail closed with a non-zero exit so scripts can trust the verdict.
+        Err("integrity check FAILED — see findings above".into())
+    }
 }
 
 fn cmd_verify_export(path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {

--- a/apps/cli/src/ui.rs
+++ b/apps/cli/src/ui.rs
@@ -415,9 +415,27 @@ fn state_json(root: &Path) -> serde_json::Value {
         "device_id": device_id,
         "vault_entries": vault_entries,
         "ledger": ledger,
+        "integrity": integrity_json(root),
         "plugins": admitted_plugins_json(root),
         "stage": "Stage 1 · Secure Kernel · Founder Command Center (early)",
     })
+}
+
+/// Self-audit for the Security Center: reconcile authoritative state against
+/// the signed audit chain. Reports the verdict and any divergence; on any
+/// internal error it reports that honestly rather than a false "ok".
+fn integrity_json(root: &Path) -> serde_json::Value {
+    match workspace::Store::open(root).and_then(|store| store.integrity_check()) {
+        Ok(report) => serde_json::to_value(report)
+            .unwrap_or_else(|_| serde_json::json!({ "ok": false, "error": "serialize" })),
+        Err(error) => serde_json::json!({
+            "ok": false,
+            "chain_verified": false,
+            "events": 0,
+            "findings": [],
+            "error": error.to_string(),
+        }),
+    }
 }
 
 /// List admission records from the on-disk store, verifying each record

--- a/apps/cli/src/workspace.rs
+++ b/apps/cli/src/workspace.rs
@@ -325,6 +325,41 @@ pub struct ExportVerification {
     pub notes: Vec<String>,
 }
 
+/// The result of reconciling authoritative state against the signed audit
+/// chain. `ok` is the honest bottom line: the chain verifies and every
+/// power-granting state has the signed evidence that should back it.
+#[derive(Debug, Clone, Serialize)]
+pub struct IntegrityReport {
+    /// The signed hash chain recomputed and every device signature checked.
+    pub chain_verified: bool,
+    /// Events on the verified chain.
+    pub events: usize,
+    /// True when `chain_verified` holds and there are no findings.
+    pub ok: bool,
+    /// Each divergence between state and the signed chain, never hidden.
+    pub findings: Vec<IntegrityFinding>,
+}
+
+/// One divergence between authoritative state and the signed audit chain.
+#[derive(Debug, Clone, Serialize)]
+pub struct IntegrityFinding {
+    pub severity: &'static str,
+    pub resource: String,
+    pub detail: String,
+}
+
+/// Short human label for a document status, for honest finding text.
+fn document_status_label(status: DocumentStatus) -> &'static str {
+    match status {
+        DocumentStatus::Draft => "a draft",
+        DocumentStatus::PendingApproval => "pending approval",
+        DocumentStatus::ApprovedPendingDelivery => "approved",
+        DocumentStatus::Rejected => "rejected",
+        DocumentStatus::Revoked => "revoked",
+        DocumentStatus::Delivered => "delivered",
+    }
+}
+
 /// Storage + evidence context for one workspace operation.
 pub struct Store {
     root: PathBuf,
@@ -1228,6 +1263,146 @@ impl Store {
         })
     }
 
+    /// Self-audit: reconcile the authoritative workspace state against the
+    /// signed audit chain and report every divergence.
+    ///
+    /// The audit ledger is tamper-evident for itself — `AuditLedger::load`
+    /// re-verifies the hash chain and every device signature — but the vault
+    /// that holds authoritative state is a *separate* file. Nothing otherwise
+    /// stops someone from hand-editing `workspace.json` to fabricate state
+    /// (flip a document to approved, invent a customer) without a matching
+    /// signed event. This check binds the two: it fails closed if the chain
+    /// does not verify, then confirms that every power-granting state has the
+    /// signed evidence that should exist for it. It is deliberately modest —
+    /// the ledger stores payload *hashes*, not payloads, so this proves that
+    /// signed evidence *exists* for a state, not that a field's value matches.
+    pub fn integrity_check(&self) -> Result<IntegrityReport, WorkspaceError> {
+        let workspace = self.load()?;
+        let ledger_path = self.root.join("ledger.json");
+
+        let (events, chain_verified, load_error) = if ledger_path.exists() {
+            match AuditLedger::load(&ledger_path, self.device.public_key_b64()) {
+                Ok(ledger) => (ledger.events().to_vec(), true, None),
+                Err(error) => (Vec::new(), false, Some(error.to_string())),
+            }
+        } else {
+            (Vec::new(), true, None)
+        };
+
+        let mut findings = Vec::new();
+
+        // A chain that will not verify is a critical failure on its own, and it
+        // makes every downstream cross-check meaningless — so stop here.
+        if !chain_verified {
+            findings.push(IntegrityFinding {
+                severity: "critical",
+                resource: "ledger.json".into(),
+                detail: format!(
+                    "the signed audit chain failed verification: {}",
+                    load_error.unwrap_or_else(|| "unknown error".into())
+                ),
+            });
+            return Ok(IntegrityReport {
+                chain_verified,
+                events: events.len(),
+                ok: false,
+                findings,
+            });
+        }
+
+        let has = |action: &str, resource: &str| {
+            events
+                .iter()
+                .any(|event| event.action == action && event.resource == resource)
+        };
+
+        // Every customer in state must have a signed creation event.
+        for customer in &workspace.customers {
+            let resource = format!("customer:{}", customer.id);
+            if !has("customer.create", &resource) {
+                findings.push(IntegrityFinding {
+                    severity: "critical",
+                    resource,
+                    detail: format!(
+                        "customer \"{}\" exists in state with no signed customer.create event",
+                        customer.name
+                    ),
+                });
+            }
+        }
+
+        // Every state that grants power or records an effect must be backed by
+        // the signed event that should have produced it.
+        for document in &workspace.documents {
+            let resource = format!("document:{}", document.id);
+            let approved = matches!(
+                document.status,
+                DocumentStatus::ApprovedPendingDelivery
+                    | DocumentStatus::Revoked
+                    | DocumentStatus::Delivered
+            );
+            if approved && !has("approval.granted", &resource) {
+                findings.push(IntegrityFinding {
+                    severity: "critical",
+                    resource: resource.clone(),
+                    detail: format!(
+                        "document \"{}\" is {} with no signed approval.granted event",
+                        document.title,
+                        document_status_label(document.status)
+                    ),
+                });
+            }
+            if document.status == DocumentStatus::Revoked && !has("effect.revoked", &resource) {
+                findings.push(IntegrityFinding {
+                    severity: "critical",
+                    resource: resource.clone(),
+                    detail: format!(
+                        "document \"{}\" is revoked with no signed effect.revoked event",
+                        document.title
+                    ),
+                });
+            }
+            if document.status == DocumentStatus::Delivered && !has("delivery.confirmed", &resource)
+            {
+                findings.push(IntegrityFinding {
+                    severity: "critical",
+                    resource,
+                    detail: format!(
+                        "document \"{}\" is delivered with no signed delivery.confirmed event",
+                        document.title
+                    ),
+                });
+            }
+        }
+
+        // Any approval that records an outbox effect must have the signed write.
+        for approval in &workspace.approvals {
+            let claims_outbox = approval
+                .evidence
+                .as_ref()
+                .is_some_and(|evidence| evidence.outbox.is_some());
+            if claims_outbox {
+                let resource = format!("document:{}", approval.document_id);
+                if !has("effect.file_written", &resource) {
+                    findings.push(IntegrityFinding {
+                        severity: "critical",
+                        resource,
+                        detail:
+                            "an approval records an outbox effect with no signed effect.file_written event"
+                                .into(),
+                    });
+                }
+            }
+        }
+
+        Ok(IntegrityReport {
+            chain_verified,
+            events: events.len(),
+            ok: findings.is_empty(),
+            findings,
+        })
+    }
+
     /// Full data export: the founder's right to leave with everything.
     pub fn export(&self) -> Result<serde_json::Value, WorkspaceError> {
         let workspace = self.load()?;
@@ -1919,6 +2094,59 @@ mod tests {
             store.confirm_delivery(Uuid::new_v4()),
             Err(WorkspaceError::NotFound(_))
         ));
+    }
+
+    #[test]
+    fn integrity_check_binds_state_to_the_signed_chain() {
+        let (dir, store) = store();
+        store.set_venture("Acme", "Landing pages").unwrap();
+        let workspace = store
+            .add_customer("Dr. Tan", "dr.tan@example.com", "")
+            .unwrap();
+        let customer_id = workspace.customers[0].id;
+        let workspace = store
+            .create_document(DocumentKind::Invoice, customer_id, Some(250_000), "en")
+            .unwrap();
+        let document_id = workspace.documents[0].id;
+        let workspace = store.request_send(document_id).unwrap();
+        store.decide(workspace.approvals[0].id, true).unwrap();
+
+        // A workspace built only through the audited API reconciles cleanly.
+        let clean = store.integrity_check().unwrap();
+        assert!(clean.ok && clean.chain_verified);
+        assert!(clean.findings.is_empty());
+        assert!(clean.events > 0);
+
+        // Fabricate state the way a hand-edited vault would: flip the delivered
+        // status onto a document that never went through the audited path. The
+        // signed chain has no delivery.confirmed for it, so the check catches it.
+        let mut tampered = store.load().unwrap();
+        tampered.documents[0].status = DocumentStatus::Delivered;
+        store.save(&tampered).unwrap();
+
+        let report = store.integrity_check().unwrap();
+        assert!(!report.ok);
+        assert!(report.chain_verified, "the chain itself is still intact");
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|finding| finding.detail.contains("delivery.confirmed")
+                    && finding.resource == format!("document:{document_id}")),
+            "expected a finding for the fabricated delivered state, got {:?}",
+            report.findings
+        );
+
+        // Corrupting the signed chain itself fails closed before any cross-check.
+        let ledger_path = dir.path().join("ledger.json");
+        let mut events: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&ledger_path).unwrap()).unwrap();
+        events[0]["resource"] = serde_json::json!("document:forged");
+        std::fs::write(&ledger_path, serde_json::to_vec(&events).unwrap()).unwrap();
+
+        let broken = store.integrity_check().unwrap();
+        assert!(!broken.chain_verified && !broken.ok);
+        assert_eq!(broken.findings[0].resource, "ledger.json");
     }
 
     #[test]


### PR DESCRIPTION
## Why

The audit ledger is tamper-evident *for itself* — `AuditLedger::load` re-verifies
the hash chain and every device signature. But the vault holding **authoritative
state** is a separate file, and nothing bound the two. A hand-edited
`workspace.json` could fabricate state (flip a document to approved/delivered,
invent a customer) with **no matching signed event**, and nothing detected it.
For a system whose promise is "every action is on the tamper-evident chain,"
that was the real gap.

## What

`Store::integrity_check()` reconciles state against the signed chain. It **fails
closed** if the chain does not verify, then confirms every power-granting or
effect-bearing state has the signed event that should back it:

- each customer → a `customer.create`
- each approved / revoked / delivered document → an `approval.granted`
  (plus `effect.revoked` / `delivery.confirmed` for those states)
- each recorded outbox effect → an `effect.file_written`

It is deliberately modest and says so: the ledger stores payload **hashes**, not
payloads, so it proves signed evidence *exists* for a state — not that a field's
value is unchanged.

Surfaced three honest ways:
- `sovereign integrity` CLI command — fails closed with a non-zero exit
- a **State integrity** panel in the Security Center (EN/中文)
- the same report embedded in `GET /api/state`, so the read path now checks integrity

## Validation

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`,
and `cargo test --workspace` (158 tests) all pass. Verified end-to-end: the CLI
reports PASS on a clean audited workspace and **FAIL with exit 1** on a corrupted
ledger; the Security Center panel renders "verified · 7 events reconciled against
state" with no JS errors. Unit test covers the clean reconcile, a fabricated
`Delivered` state, and a corrupted chain failing closed before any cross-check.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNaAoHftuMyML3uwCZHEYx)_