### PR TITLE
feat(app): add a durable, owner-visible data-disclosure log

### DIFF
--- a/apps/cli/assets/ui.html
+++ b/apps/cli/assets/ui.html
@@ -243,6 +243,12 @@
   </section>
 
   <section>
+    <h2 data-i18n="sec_disclosures"></h2>
+    <div class="honest" data-i18n="sec_disclosures_note"></div>
+    <div class="panel"><div id="disclosures" class="empty" data-i18n="loading"></div></div>
+  </section>
+
+  <section>
     <h2 data-i18n="sec_plugins"></h2>
     <div class="panel"><div id="plugins" class="empty" data-i18n="loading"></div></div>
   </section>
@@ -359,6 +365,11 @@ const STRINGS = {
     sec_integrity_note: "Binds your authoritative state to the tamper-evident ledger. It re-verifies the signed chain, then confirms every approved, revoked, or delivered document — and every customer — has the signed event that should back it. It proves signed evidence exists for a state, not that a field's value is unchanged.",
     integrity_ok: "verified", integrity_bad: "divergence found",
     integrity_summary: (chain, n) => (chain ? "signed chain re-verified" : "signed chain FAILED") + " · " + n + " events reconciled against state",
+    sec_disclosures: "Data disclosures — every time a model saw your customer data",
+    sec_disclosures_note: "Your right to know who processed your data. Each row is one call to the drafting assistant: which provider answered, whether the data stayed on this machine, and which providers were skipped on the way. The suggestion itself is never stored — only the disclosure.",
+    disclosures_empty: "No model has been shown customer data yet.",
+    th_provider: "Provider", th_where: "Where", th_class: "Data class", th_failover: "Skipped",
+    stayed_local: "stayed local", left_device: "left device",
     sec_plugins: "Admitted plugins — content-addressed store",
     sec_ledger: "Audit trail — signed hash chain (latest 25)",
     sec_gauntlet: "Security gauntlet — real attacks, run now, in memory",
@@ -470,6 +481,11 @@ const STRINGS = {
     sec_integrity_note: "将你的权威状态与防篡改账本绑定。它会重新验证签名链,然后确认每一份已批准、已撤销或已送达的文档,以及每一位客户,都有应有的签名事件作为支撑。它证明某个状态存在签名证据,而非证明字段值未被改动。",
     integrity_ok: "已验证", integrity_bad: "发现偏差",
     integrity_summary: (chain, n) => (chain ? "签名链已重新验证" : "签名链验证失败") + " · 已对照状态核对 " + n + " 条事件",
+    sec_disclosures: "数据披露 —— 每一次模型接触你的客户数据",
+    sec_disclosures_note: "你有权知道谁处理了你的数据。每一行对应一次调用起草助手:哪个提供方作出应答、数据是否留在本机、以及沿途跳过了哪些提供方。建议内容本身从不存储 —— 只记录披露事实。",
+    disclosures_empty: "尚无模型接触过客户数据。",
+    th_provider: "提供方", th_where: "位置", th_class: "数据分级", th_failover: "已跳过",
+    stayed_local: "留在本机", left_device: "离开本机",
     sec_plugins: "已准入插件 — 内容寻址存储",
     sec_ledger: "审计记录 — 签名哈希链(最近 25 条)",
     sec_gauntlet: "安全闯关 — 真实攻击,即刻在内存中运行",
@@ -738,6 +754,24 @@ function renderState() {
     wrap.classList.remove("empty");
     integrity.replaceChildren(wrap);
     integrity.classList.remove("empty");
+  }
+
+  const disclosures = $("disclosures");
+  const dl = state.disclosures || [];
+  if (!dl.length) {
+    disclosures.replaceChildren(el("div", "empty", t("disclosures_empty")));
+  } else {
+    disclosures.replaceChildren(table(
+      [t("th_time"), t("th_customer"), t("th_provider"), t("th_where"), t("th_class"), t("th_failover")],
+      dl.map(d => [
+        new Date(d.at * 1000).toLocaleString(locale()),
+        d.customer,
+        d.provider + " (" + d.provider_trust + ")",
+        d.stayed_local ? badge("good", t("stayed_local")) : badge("warn", t("left_device")),
+        d.data_class,
+        d.failover_from.length ? d.failover_from.join(", ") : "—",
+      ])));
+    disclosures.classList.remove("empty");
   }
 
   const plugins = $("plugins");

--- a/apps/cli/src/ui.rs
+++ b/apps/cli/src/ui.rs
@@ -416,9 +416,49 @@ fn state_json(root: &Path) -> serde_json::Value {
         "vault_entries": vault_entries,
         "ledger": ledger,
         "integrity": integrity_json(root),
+        "disclosures": disclosures_json(root),
         "plugins": admitted_plugins_json(root),
         "stage": "Stage 1 · Secure Kernel · Founder Command Center (early)",
     })
+}
+
+/// The owner-visible data-disclosure log for the Security Center: every time a
+/// model provider was shown customer data, newest first. Never the suggestion,
+/// only the disclosure. Silent on error rather than inventing a clean log.
+fn disclosures_json(root: &Path) -> serde_json::Value {
+    let workspace = match workspace::Store::open(root).and_then(|store| store.load()) {
+        Ok(workspace) => workspace,
+        Err(_) => return serde_json::json!([]),
+    };
+    let named = |id| {
+        workspace
+            .customers
+            .iter()
+            .find(|customer| customer.id == id)
+            .map(|customer| customer.name.clone())
+            .unwrap_or_else(|| "(unknown)".into())
+    };
+    let mut entries: Vec<serde_json::Value> = workspace
+        .disclosures
+        .iter()
+        .rev()
+        .take(50)
+        .map(|disclosure| {
+            serde_json::json!({
+                "at": disclosure.at,
+                "customer": named(disclosure.customer_id),
+                "task": disclosure.task,
+                "provider": disclosure.provider_id,
+                "provider_trust": disclosure.provider_trust,
+                "stayed_local": disclosure.stayed_local,
+                "data_class": disclosure.data_class,
+                "output_chars": disclosure.output_chars,
+                "failover_from": disclosure.failover_from,
+            })
+        })
+        .collect();
+    entries.truncate(50);
+    serde_json::Value::Array(entries)
 }
 
 /// Self-audit for the Security Center: reconcile authoritative state against

--- a/apps/cli/src/workspace.rs
+++ b/apps/cli/src/workspace.rs
@@ -207,6 +207,29 @@ pub struct DraftSuggestion {
     pub saved: bool,
 }
 
+/// A durable, owner-visible record of one time a model provider was given
+/// customer data. The product's promise is sovereignty over that data, so the
+/// founder gets a plain-language log of exactly what happened: which provider,
+/// how much it trusts the machine it ran on, whether the data stayed local, and
+/// which providers were skipped on the way there. This mirrors the signed
+/// `model.drafted` audit event, but keeps the human-readable detail (the event
+/// stores only a hash of it) so the log is legible without the export tooling.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelDisclosure {
+    pub id: Uuid,
+    pub at: i64,
+    pub customer_id: Uuid,
+    pub task: String,
+    pub provider_id: String,
+    pub provider_trust: String,
+    /// True when the provider ran locally and the data never left the machine.
+    pub stayed_local: bool,
+    pub data_class: String,
+    pub output_chars: usize,
+    /// Providers skipped before this one answered (health-aware failover).
+    pub failover_from: Vec<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Workspace {
     pub version: u32,
@@ -214,6 +237,10 @@ pub struct Workspace {
     pub customers: Vec<Customer>,
     pub documents: Vec<Document>,
     pub approvals: Vec<Approval>,
+    /// Every time a model provider was shown customer data. Append-only in
+    /// practice; `default` keeps vaults written before this field loadable.
+    #[serde(default)]
+    pub disclosures: Vec<ModelDisclosure>,
 }
 
 /// At-a-glance product view: the founder's whole business plus the security
@@ -584,6 +611,31 @@ impl Store {
             })
             .map_err(|error| WorkspaceError::Invalid(format!("drafting assistant: {error}")))?;
 
+        let provider_trust = format!("{:?}", disclosure.provider_trust).to_lowercase();
+        let failover_from: Vec<String> = disclosure
+            .skipped
+            .iter()
+            .map(|entry| entry.provider_id.clone())
+            .collect();
+
+        // Persist the disclosure to the owner-visible log — never the
+        // suggestion itself, only the fact that a provider saw the data.
+        let entry = ModelDisclosure {
+            id: Uuid::new_v4(),
+            at: now(),
+            customer_id,
+            task: disclosure.task.clone(),
+            provider_id: disclosure.provider_id.clone(),
+            stayed_local: provider_trust == "local",
+            provider_trust: provider_trust.clone(),
+            data_class: "amber".into(),
+            output_chars: disclosure.output_chars,
+            failover_from: failover_from.clone(),
+        };
+        let mut persisted = self.load()?;
+        persisted.disclosures.push(entry);
+        self.save(&persisted)?;
+
         // Record only the disclosure — never the suggestion — as evidence.
         self.record(
             "model.drafted",
@@ -591,14 +643,10 @@ impl Store {
             serde_json::json!({
                 "task": disclosure.task,
                 "provider": disclosure.provider_id,
-                "provider_trust": format!("{:?}", disclosure.provider_trust).to_lowercase(),
+                "provider_trust": provider_trust,
                 "data_class": "amber",
                 "output_chars": disclosure.output_chars,
-                "failover_from": disclosure
-                    .skipped
-                    .iter()
-                    .map(|entry| entry.provider_id.clone())
-                    .collect::<Vec<_>>(),
+                "failover_from": failover_from,
             }),
         )?;
 
@@ -2150,6 +2198,50 @@ mod tests {
     }
 
     #[test]
+    fn draft_assistant_records_a_persistent_data_disclosure() {
+        let (dir, store) = store();
+        store.set_venture("Acme", "Landing pages").unwrap();
+        let workspace = store
+            .add_customer("Dr. Tan", "dr.tan@example.com", "")
+            .unwrap();
+        let customer_id = workspace.customers[0].id;
+
+        // The suggestion is powerless, but the disclosure is durable.
+        let suggestion = store.draft_assistant(customer_id, "en").unwrap();
+        assert!(
+            !suggestion.saved,
+            "a suggestion is never authoritative state"
+        );
+
+        let workspace = store.load().unwrap();
+        assert_eq!(workspace.disclosures.len(), 1);
+        let disclosure = &workspace.disclosures[0];
+        assert_eq!(disclosure.customer_id, customer_id);
+        assert_eq!(disclosure.data_class, "amber");
+        assert!(
+            disclosure.stayed_local && disclosure.provider_trust == "local",
+            "Amber customer data must stay on this machine"
+        );
+        assert!(disclosure.output_chars > 0);
+
+        // The persisted log mirrors a signed model.drafted event on the chain —
+        // detail in state, tamper-evidence on the ledger.
+        let device = DeviceIdentity::load(&dir.path().join("device.json")).unwrap();
+        let ledger =
+            AuditLedger::load(&dir.path().join("ledger.json"), device.public_key_b64()).unwrap();
+        ledger.verify_chain().unwrap();
+        assert!(ledger
+            .events()
+            .iter()
+            .any(|event| event.action == "model.drafted"
+                && event.resource == format!("customer:{customer_id}")));
+
+        // A second call appends rather than replaces: the log is a history.
+        store.draft_assistant(customer_id, "zh").unwrap();
+        assert_eq!(store.load().unwrap().disclosures.len(), 2);
+    }
+
+    #[test]
     fn compose_email_is_wellformed_and_injection_safe() {
         let venture = Venture {
             name: "Acme".into(),
@@ -2262,7 +2354,7 @@ mod tests {
     }
 
     #[test]
-    fn draft_assistant_never_touches_authoritative_state() {
+    fn draft_assistant_never_touches_authoritative_business_state() {
         let (_dir, store) = store();
         store.set_venture("Acme", "Landing pages").unwrap();
         let workspace = store.add_customer("Dr. Tan", "", "").unwrap();
@@ -2274,15 +2366,29 @@ mod tests {
         assert_eq!(suggestion.provider_trust, "local");
         assert!(suggestion.text.contains("Dr. Tan"));
 
-        // The graph is byte-for-byte unchanged: the suggestion created nothing.
         let after = store.load().unwrap();
-        assert_eq!(
-            serde_json::to_value(&before).unwrap(),
-            serde_json::to_value(&after).unwrap()
-        );
+        // The untrusted suggestion is powerless: the business graph — venture,
+        // customers, documents, approvals — is byte-for-byte unchanged, and the
+        // suggestion text is never persisted anywhere in state.
+        let business = |workspace: &Workspace| {
+            serde_json::json!({
+                "venture": workspace.venture,
+                "customers": workspace.customers,
+                "documents": workspace.documents,
+                "approvals": workspace.approvals,
+            })
+        };
+        assert_eq!(business(&before), business(&after));
         assert!(after.documents.is_empty());
+        let serialized = serde_json::to_string(&after).unwrap();
+        assert!(
+            !serialized.contains(&suggestion.text),
+            "the model suggestion must never be written to authoritative state"
+        );
 
-        // Only a disclosure event was recorded.
+        // The only durable change is an append to the owner-visible disclosure
+        // log, mirrored by exactly one signed model.drafted event.
+        assert_eq!(after.disclosures.len(), 1);
         let device = DeviceIdentity::load(&_dir.path().join("device.json")).unwrap();
         let ledger =
             AuditLedger::load(&_dir.path().join("ledger.json"), device.public_key_b64()).unwrap();


### PR DESCRIPTION
## Why

The product's promise is sovereignty over customer data — so the founder should
be able to see exactly who processed it. The drafting assistant already emitted a
signed `model.drafted` event, but the ledger stores only a **hash** of the
payload, so the human-readable detail (which provider answered, whether the data
stayed local, which providers were skipped) wasn't legible without the export
tooling.

## What

Persist each disclosure into an **owner-visible log**:

- A `Workspace.disclosures` field (`#[serde(default)]`, so vaults written before
  this field still load), appended on every `draft_assistant` call and mirrored
  by the signed `model.drafted` event.
- The untrusted **suggestion itself is never stored** — only the disclosure.
- A **Data disclosures** panel in the Security Center (EN/中文), newest-first:
  time, customer, provider + trust, whether the data stayed on the machine, data
  class, and any failover. Also embedded in `GET /api/state`.

## Honesty / invariants

The disclosure log is metadata *about* a drafting call — not the model output and
not business state. The existing "assistant is powerless" invariant test is
**tightened** to assert the real property: the authoritative business graph
(venture, customers, documents, approvals) is byte-for-byte unchanged and the
suggestion text is never persisted, while the disclosure log grows by exactly
one. A new test confirms the disclosure is durable, marked `local`/`amber`,
mirrored on the verified chain, and appends as a history.

## Validation

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`,
and `cargo test --workspace` (159 tests) pass. Verified end-to-end: calling the
assistant records `stayed local · amber` in `/api/state`, and the Security Center
panel renders the row with no JS errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNaAoHftuMyML3uwCZHEYx)_