### PR TITLE
fix(ui): truncate the wordmark cleanly on narrow viewports

### DIFF
--- a/apps/cli/assets/ui.html
+++ b/apps/cli/assets/ui.html
@@ -93,6 +93,7 @@
     display: flex; justify-content: space-between; align-items: center; gap: 16px;
   }
   .brand { display: flex; align-items: center; gap: 12px; min-width: 0; }
+  .brand-text { min-width: 0; } /* lets the nowrap wordmark actually ellipsize */
   .brand-mark { width: 34px; height: 34px; flex-shrink: 0; color: var(--accent); }
   .brand-mark .seal { color: var(--bronze); }
   .brand-text h1 {


### PR DESCRIPTION
## What

One-line CSS fix: the brand `h1` is `nowrap` + `ellipsis`, but its flex parent
`.brand-text` lacked `min-width: 0`, so on a 390 px viewport the wordmark
refused to shrink and ran under the theme toggle.

## Validation

Verified headlessly at 390 px: the wordmark now ellipsizes and
`h1.right > themeToggle.left` is false (no overlap). No horizontal page scroll
on any view. fmt clean, CLI tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNaAoHftuMyML3uwCZHEYx)_