### PR TITLE
feat(ci): type-check the frontend with JSDoc + tsc, zero new dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,23 @@ jobs:
       - name: Build CLI
         run: cargo build -p sovereign-cli --release --locked
 
+  frontend-types:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      # Type-check the zero-dependency frontend: JSDoc types + `tsc --checkJs`
+      # (configured in apps/cli/assets/tsconfig.json). Check-only — noEmit, so
+      # nothing produced here ever reaches the shipped binary. The TypeScript
+      # compiler is a single exact-pinned package with no transitive
+      # dependencies, fetched only into this ephemeral runner with install
+      # scripts disabled; the runner's preinstalled Node is used directly.
+      - name: Type-check frontend (tsc --checkJs, no emit)
+        env:
+          npm_config_ignore_scripts: "true"
+        run: npx -y -p typescript@5.5.4 tsc -p apps/cli/assets/tsconfig.json
+
   security:
     runs-on: ubuntu-latest
     permissions:

--- a/apps/cli/assets/app.js
+++ b/apps/cli/assets/app.js
@@ -1,15 +1,42 @@
 "use strict";
+// Checked by `tsc --checkJs` in CI (see tsconfig.json) — types via JSDoc only,
+// zero build step, nothing here changes what ships.
+
+/**
+ * @typedef {{id: string, name: string, email: string, notes: string, created_at: number}} Customer
+ * @typedef {{relative_path: string, content_sha256: string, bytes: number}} OutboxWrite
+ * @typedef {{evidence_digest: string, approver_key_id: string, guest_exit_code: number, outbox: OutboxWrite|null}} Evidence
+ * @typedef {{id: string, document_id: string, status: string, action: string, policy_reason: string, requested_at: number, evidence: Evidence|null}} Approval
+ * @typedef {{id: string, customer_id: string, kind: string, title: string, body: string, status: string}} Doc
+ * @typedef {{name: string, service: string}} Venture
+ * @typedef {{version: number, venture: Venture|null, customers: Customer[], documents: Doc[], approvals: Approval[], disclosures: object[]}} Workspace
+ */
+
 let lang = localStorage.getItem("sovereign-ui-lang")
   || (navigator.language && navigator.language.toLowerCase().startsWith("zh") ? "zh" : "en");
 let view = localStorage.getItem("sovereign-ui-view") || "command";
 let lastState = null;
 let lastGauntlet = null;
 let lastCommand = null;
+/** @type {Workspace|null} */
 let ws = null;
 
+/**
+ * Elements fetched by id are used as inputs, buttons, dialogs, and plain
+ * containers alike; `any` keeps call sites honest-by-test rather than
+ * drowning a zero-dependency codebase in casts.
+ * @returns {any}
+ */
 const $ = (id) => document.getElementById(id);
+/** @returns {any} i18n value — a string or a formatting function */
 const t = (key) => STRINGS[lang][key];
 
+/**
+ * @param {string} tag
+ * @param {string|null} [className]
+ * @param {string} [text]
+ * @returns {HTMLElement}
+ */
 function el(tag, className, text) {
   const node = document.createElement(tag);
   if (className) node.className = className;
@@ -17,6 +44,10 @@ function el(tag, className, text) {
   return node;
 }
 
+/**
+ * @param {"good"|"bad"|"warn"|"neutral"} kind
+ * @param {string} label
+ */
 function badge(kind, label) {
   const marks = { good: "✓ ", bad: "✗ ", warn: "⧗ ", neutral: "" };
   return el("span", "badge " + kind, (marks[kind] || "") + label);
@@ -123,7 +154,7 @@ function renderWorkspace() {
   const select = $("d-customer");
   const selected = select.value;
   select.replaceChildren(...ws.customers.map(c => {
-    const option = el("option", null, c.name);
+    const option = /** @type {HTMLOptionElement} */ (el("option", null, c.name));
     option.value = c.id;
     return option;
   }));
@@ -544,7 +575,7 @@ function applyLanguage() {
   document.documentElement.lang = lang === "zh" ? "zh-CN" : "en";
   $("lang-en").classList.toggle("active", lang === "en");
   $("lang-zh").classList.toggle("active", lang === "zh");
-  document.querySelectorAll("[data-i18n]").forEach(node => {
+  document.querySelectorAll("[data-i18n]").forEach((/** @type {HTMLElement} */ node) => {
     const value = t(node.dataset.i18n);
     if (typeof value === "string") node.textContent = value;
   });

--- a/apps/cli/assets/tsconfig.json
+++ b/apps/cli/assets/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "target": "es2022",
+    "lib": ["es2022", "dom", "dom.iterable"],
+    "types": [],
+    "strict": false,
+    "noUnusedLocals": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["i18n.js", "app.js"]
+}


### PR DESCRIPTION
## Why

The split frontend (#24) deliberately stays zero-dependency, which gave up type
safety. This adds it back **without touching the supply-chain posture**: types
via JSDoc comments, checked by `tsc --checkJs --noEmit` in CI. Check-only —
nothing tsc produces reaches the shipped binary, and the served assets change
only by inert comments.

## What

- `apps/cli/assets/tsconfig.json`: `checkJs` + `noEmit` over `i18n.js` +
  `app.js` (es2022 + DOM libs, `noUnusedLocals`).
- `app.js`: JSDoc typedefs for the domain shapes (Workspace, Doc, Approval,
  Evidence, Customer, Venture) and annotations on the shared helpers (`el`,
  `badge`, `$`); two precise casts where `tsc` needed them.
- **CI job** following the workflow's existing discipline: checkout pinned by
  SHA, no `setup-node` action (the runner's preinstalled Node is used
  directly), TypeScript **exact-pinned** (`typescript@5.5.4` — a single package
  with no transitive dependencies) fetched only into the ephemeral runner with
  **install scripts disabled** (`npm_config_ignore_scripts`).

## Security review

- Product binary and runtime: unchanged (comments only in served JS).
- Dev machines: nothing to install — the check runs in CI.
- CI runner: one exact-pinned, dependency-free package, scripts disabled,
  `noEmit` so a hypothetically compromised compiler can't inject into artifacts.

## Validation

`tsc` clean (the initial run surfaced only DOM-typing noise, no logic bugs —
consistent with the browser-verified flows). Re-verified the annotated bundle
end-to-end in a headless browser: approve flow works, zero console errors.
`cargo fmt/clippy/test` unchanged and passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNaAoHftuMyML3uwCZHEYx)_