### PR TITLE
fix(kernel): make commits crash-consistent — atomic writes + audit-first ordering

### DIFF
--- a/apps/cli/assets/app.js
+++ b/apps/cli/assets/app.js
@@ -314,7 +314,7 @@ function renderState() {
     if (ir.error) wrap.appendChild(el("div", "mono", ir.error));
     (ir.findings || []).forEach(f => {
       const row = el("div", "gauntlet-row");
-      row.appendChild(badge("bad", f.severity));
+      row.appendChild(badge(f.severity === "critical" ? "bad" : "warn", f.severity));
       row.appendChild(el("div", "detail", f.resource + " — " + f.detail));
       wrap.appendChild(row);
     });

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -97,12 +97,18 @@ fn cmd_integrity() -> Result<(), Box<dyn std::error::Error>> {
         check(report.chain_verified),
         report.events
     );
+    let critical = report
+        .findings
+        .iter()
+        .filter(|finding| finding.severity == "critical")
+        .count();
+    let warnings = report.findings.len() - critical;
     if report.findings.is_empty() {
         println!("  state vs. evidence  PASS");
     } else {
         println!(
-            "  state vs. evidence  FAIL  ({} findings)",
-            report.findings.len()
+            "  state vs. evidence  {}  ({critical} critical, {warnings} warnings)",
+            if critical == 0 { "PASS" } else { "FAIL" }
         );
         for finding in &report.findings {
             println!(

--- a/apps/cli/src/workspace/ops.rs
+++ b/apps/cli/src/workspace/ops.rs
@@ -1,4 +1,5 @@
 use super::compose::{compose_email, draft_outreach_note, render_document};
+use super::store::AuditEntry;
 use super::util::{clean_email, clean_optional_text, clean_text, kernel, now};
 use super::*;
 
@@ -27,11 +28,13 @@ impl Store {
             service,
             updated_at: now(),
         });
-        self.save(&workspace)?;
-        self.record(
-            "venture.update",
-            "venture:profile",
-            serde_json::json!({ "name": name }),
+        self.commit(
+            &workspace,
+            vec![AuditEntry {
+                action: "venture.update".into(),
+                resource: "venture:profile".into(),
+                payload: serde_json::json!({ "name": name }),
+            }],
         )?;
         Ok(workspace)
     }
@@ -68,11 +71,13 @@ impl Store {
         };
         let resource = format!("customer:{}", customer.id);
         workspace.customers.push(customer);
-        self.save(&workspace)?;
-        self.record(
-            "customer.create",
-            &resource,
-            serde_json::json!({ "name": name }),
+        self.commit(
+            &workspace,
+            vec![AuditEntry {
+                action: "customer.create".into(),
+                resource,
+                payload: serde_json::json!({ "name": name }),
+            }],
         )?;
         Ok(workspace)
     }
@@ -144,20 +149,22 @@ impl Store {
         };
         let mut persisted = self.load()?;
         persisted.disclosures.push(entry);
-        self.save(&persisted)?;
 
         // Record only the disclosure — never the suggestion — as evidence.
-        self.record(
-            "model.drafted",
-            &format!("customer:{customer_id}"),
-            serde_json::json!({
-                "task": disclosure.task,
-                "provider": disclosure.provider_id,
-                "provider_trust": provider_trust,
-                "data_class": "amber",
-                "output_chars": disclosure.output_chars,
-                "failover_from": failover_from,
-            }),
+        self.commit(
+            &persisted,
+            vec![AuditEntry {
+                action: "model.drafted".into(),
+                resource: format!("customer:{customer_id}"),
+                payload: serde_json::json!({
+                    "task": disclosure.task,
+                    "provider": disclosure.provider_id,
+                    "provider_trust": provider_trust,
+                    "data_class": "amber",
+                    "output_chars": disclosure.output_chars,
+                    "failover_from": failover_from,
+                }),
+            }],
         )?;
 
         Ok(DraftSuggestion {
@@ -213,8 +220,14 @@ impl Store {
             "amount_cents": amount_cents,
         });
         workspace.documents.push(document);
-        self.save(&workspace)?;
-        self.record("document.draft", &resource, summary)?;
+        self.commit(
+            &workspace,
+            vec![AuditEntry {
+                action: "document.draft".into(),
+                resource,
+                payload: summary,
+            }],
+        )?;
         Ok(workspace)
     }
 
@@ -262,8 +275,14 @@ impl Store {
         let resource = format!("document:{document_id}");
         let summary = serde_json::json!({ "approval_id": approval.id });
         workspace.approvals.push(approval);
-        self.save(&workspace)?;
-        self.record("approval.requested", &resource, summary)?;
+        self.commit(
+            &workspace,
+            vec![AuditEntry {
+                action: "approval.requested".into(),
+                resource,
+                payload: summary,
+            }],
+        )?;
         Ok(workspace)
     }
 
@@ -309,24 +328,26 @@ impl Store {
             DocumentStatus::Rejected
         };
 
-        self.save(&workspace)?;
+        // Every event of this decision lands on the chain in one durable
+        // write, then the state commits — audit-first, no partial record.
         let resource = format!("document:{document_id}");
+        let mut events = Vec::new();
         match &evidence {
             Some(record) => {
-                self.record(
-                    "approval.granted",
-                    &resource,
-                    serde_json::json!({
+                events.push(AuditEntry {
+                    action: "approval.granted".into(),
+                    resource: resource.clone(),
+                    payload: serde_json::json!({
                         "approval_id": approval_id,
                         "signed_approval_id": record.approval_id,
                         "evidence_digest": record.evidence_digest,
                         "approver_key_id": record.approver_key_id,
                     }),
-                )?;
-                self.record(
-                    "capability.executed",
-                    &resource,
-                    serde_json::json!({
+                });
+                events.push(AuditEntry {
+                    action: "capability.executed".into(),
+                    resource: resource.clone(),
+                    payload: serde_json::json!({
                         "tool": "workspace.delivery/prepare",
                         "component_digest": record.component_digest,
                         "canonical_input_digest": record.canonical_input_digest,
@@ -334,27 +355,28 @@ impl Store {
                         "exit_code": record.guest_exit_code,
                         "fuel": record.fuel_consumed,
                     }),
-                )?;
+                });
                 if let Some(outbox) = &record.outbox {
-                    self.record(
-                        "effect.file_written",
-                        &resource,
-                        serde_json::json!({
+                    events.push(AuditEntry {
+                        action: "effect.file_written".into(),
+                        resource: resource.clone(),
+                        payload: serde_json::json!({
                             "outbox_path": outbox.relative_path,
                             "content_sha256": outbox.content_sha256,
                             "bytes": outbox.bytes,
                         }),
-                    )?;
+                    });
                 }
             }
             None => {
-                self.record(
-                    "approval.rejected",
-                    &resource,
-                    serde_json::json!({ "approval_id": approval_id, "approved": false }),
-                )?;
+                events.push(AuditEntry {
+                    action: "approval.rejected".into(),
+                    resource: resource.clone(),
+                    payload: serde_json::json!({ "approval_id": approval_id, "approved": false }),
+                });
             }
         }
+        self.commit(&workspace, events)?;
         Ok(workspace)
     }
 
@@ -395,15 +417,16 @@ impl Store {
 
         let document_entry = workspace.document_mut(document_id)?;
         document_entry.status = DocumentStatus::Revoked;
-        self.save(&workspace)?;
-
-        self.record(
-            "effect.revoked",
-            &format!("document:{document_id}"),
-            serde_json::json!({
-                "outbox_path": outbox.relative_path,
-                "content_sha256": outbox.content_sha256,
-            }),
+        self.commit(
+            &workspace,
+            vec![AuditEntry {
+                action: "effect.revoked".into(),
+                resource: format!("document:{document_id}"),
+                payload: serde_json::json!({
+                    "outbox_path": outbox.relative_path,
+                    "content_sha256": outbox.content_sha256,
+                }),
+            }],
         )?;
         Ok(workspace)
     }
@@ -423,11 +446,13 @@ impl Store {
             ));
         }
         document.status = DocumentStatus::Delivered;
-        self.save(&workspace)?;
-        self.record(
-            "delivery.confirmed",
-            &format!("document:{document_id}"),
-            serde_json::json!({ "attested_by": "founder", "system_sent": false }),
+        self.commit(
+            &workspace,
+            vec![AuditEntry {
+                action: "delivery.confirmed".into(),
+                resource: format!("document:{document_id}"),
+                payload: serde_json::json!({ "attested_by": "founder", "system_sent": false }),
+            }],
         )?;
         Ok(workspace)
     }

--- a/apps/cli/src/workspace/reporting.rs
+++ b/apps/cli/src/workspace/reporting.rs
@@ -1,6 +1,7 @@
 use super::types::document_status_label;
 use super::util::{now, storage};
 use super::*;
+use uuid::Uuid;
 
 use sovereign_audit_ledger::AuditLedger;
 
@@ -219,10 +220,67 @@ impl Store {
             }
         }
 
+        // The reverse direction: signed events whose state never landed.
+        // Commits are audit-first — every event of an operation in one chain
+        // write, then the state write — so only the *tail* of the chain can
+        // be torn by a crash. Check just the trailing events of the most
+        // recent operation (same resource); a mismatch there is an
+        // interrupted operation that retrying heals, reported as a warning —
+        // deliberately distinct from the critical findings above (state
+        // without evidence), which audit-first ordering makes impossible
+        // short of tampering. Older unmatched events are history (an
+        // interruption later retried under a fresh id) and are not flagged
+        // forever.
+        if let Some(last) = events.last() {
+            let tail_torn = events
+                .iter()
+                .rev()
+                .take_while(|event| event.resource == last.resource)
+                .any(|event| {
+                    let subject_id = event
+                        .resource
+                        .split_once(':')
+                        .and_then(|(_, id)| Uuid::parse_str(id).ok());
+                    let document_status = subject_id
+                        .and_then(|id| workspace.document(id).ok().map(|document| document.status));
+                    match event.action.as_str() {
+                        "customer.create" => {
+                            subject_id.is_some_and(|id| workspace.customer(id).is_err())
+                        }
+                        "approval.granted" => !matches!(
+                            document_status,
+                            Some(
+                                DocumentStatus::ApprovedPendingDelivery
+                                    | DocumentStatus::Revoked
+                                    | DocumentStatus::Delivered
+                            )
+                        ),
+                        "effect.revoked" => document_status != Some(DocumentStatus::Revoked),
+                        "delivery.confirmed" => document_status != Some(DocumentStatus::Delivered),
+                        _ => false,
+                    }
+                });
+            if tail_torn {
+                findings.push(IntegrityFinding {
+                    severity: "warning",
+                    resource: last.resource.clone(),
+                    detail: format!(
+                        "the most recent operation ({}) is signed on the chain but its \
+                         state write did not complete — an interrupted operation; retry it",
+                        last.action
+                    ),
+                });
+            }
+        }
+
         Ok(IntegrityReport {
             chain_verified,
             events: events.len(),
-            ok: findings.is_empty(),
+            // Warnings (interrupted operations) do not fail the audit; state
+            // that lacks its signed evidence does.
+            ok: !findings
+                .iter()
+                .any(|finding| finding.severity == "critical"),
             findings,
         })
     }

--- a/apps/cli/src/workspace/store.rs
+++ b/apps/cli/src/workspace/store.rs
@@ -1,5 +1,13 @@
 use super::util::storage;
 use super::*;
+
+/// One audit event of a state-changing operation: the action, the resource it
+/// touched, and a human-meaningful summary payload (hashed onto the chain).
+pub(super) struct AuditEntry {
+    pub action: String,
+    pub resource: String,
+    pub payload: serde_json::Value,
+}
 use std::path::Path;
 
 use sovereign_audit_ledger::{hash_bytes, AppendInput, AuditLedger};
@@ -72,36 +80,66 @@ impl Store {
         )
     }
 
+    /// Commit one logical operation **audit-first**: every event of the
+    /// operation is appended to the signed chain in a single durable ledger
+    /// write, and only then is the state written. A crash between the two
+    /// leaves the chain ahead of the state — an interrupted operation the
+    /// integrity self-audit reports as a warning and a retry heals — and
+    /// never committed state without its signed evidence.
+    pub(super) fn commit(
+        &self,
+        workspace: &Workspace,
+        events: Vec<AuditEntry>,
+    ) -> Result<(), WorkspaceError> {
+        self.append_events(events)?;
+        self.save(workspace)
+    }
+
+    /// Append audit events without a state change (exports, disclosures of
+    /// read-only actions). State-changing operations go through [`commit`].
     pub(super) fn record(
         &self,
         action: &str,
         resource: &str,
         payload: serde_json::Value,
     ) -> Result<(), WorkspaceError> {
+        self.append_events(vec![AuditEntry {
+            action: action.into(),
+            resource: resource.into(),
+            payload,
+        }])
+    }
+
+    /// Append every event to the signed hash chain and persist the chain in
+    /// one atomic write, so a multi-event operation can never leave a
+    /// half-recorded ledger behind.
+    fn append_events(&self, events: Vec<AuditEntry>) -> Result<(), WorkspaceError> {
         let ledger_path = self.root.join("ledger.json");
         let mut ledger = if ledger_path.exists() {
             AuditLedger::load(&ledger_path, self.device.public_key_b64()).map_err(storage)?
         } else {
             AuditLedger::new()
         };
-        let payload_digest = hash_bytes(&serde_json::to_vec(&payload).map_err(storage)?);
-        ledger
-            .append(
-                AppendInput {
-                    venture_id: "workspace".into(),
-                    actor_id: "founder".into(),
-                    action: action.into(),
-                    resource: resource.into(),
-                    capability_id: None,
-                    payload: serde_json::json!({
-                        "summary": payload,
-                        "payload_digest": payload_digest,
-                    }),
-                    policy_decision_hash: None,
-                },
-                &self.device,
-            )
-            .map_err(storage)?;
+        for event in events {
+            let payload_digest = hash_bytes(&serde_json::to_vec(&event.payload).map_err(storage)?);
+            ledger
+                .append(
+                    AppendInput {
+                        venture_id: "workspace".into(),
+                        actor_id: "founder".into(),
+                        action: event.action,
+                        resource: event.resource,
+                        capability_id: None,
+                        payload: serde_json::json!({
+                            "summary": event.payload,
+                            "payload_digest": payload_digest,
+                        }),
+                        policy_decision_hash: None,
+                    },
+                    &self.device,
+                )
+                .map_err(storage)?;
+        }
         ledger.save(&ledger_path).map_err(storage)?;
         Ok(())
     }

--- a/apps/cli/src/workspace/tests.rs
+++ b/apps/cli/src/workspace/tests.rs
@@ -297,6 +297,80 @@ fn draft_assistant_records_a_persistent_data_disclosure() {
 }
 
 #[test]
+fn interrupted_operation_is_a_warning_and_retry_heals_it() {
+    let (_dir, store) = store();
+    store.set_venture("Acme", "Landing pages").unwrap();
+    store.add_customer("Dr. Tan", "", "").unwrap();
+
+    // Simulate a crash in the commit window: commits are audit-first, so the
+    // chain already carries customer.create while the state write never
+    // landed. Rewind the state to just before the customer.
+    let mut behind = store.load().unwrap();
+    behind.customers.clear();
+    store.save(&behind).unwrap();
+
+    let report = store.integrity_check().unwrap();
+    assert!(
+        report.ok,
+        "an interrupted operation must not read as tampering"
+    );
+    assert!(
+        report
+            .findings
+            .iter()
+            .any(|finding| finding.severity == "warning" && finding.detail.contains("interrupted")),
+        "expected an interrupted-operation warning, got {:?}",
+        report.findings
+    );
+
+    // Retrying the operation heals the audit: the new tail matches state.
+    store.add_customer("Dr. Tan", "", "").unwrap();
+    let healed = store.integrity_check().unwrap();
+    assert!(
+        healed.ok && healed.findings.is_empty(),
+        "{:?}",
+        healed.findings
+    );
+}
+
+#[test]
+fn torn_decision_is_a_warning_until_state_lands() {
+    let (_dir, store) = store();
+    store.set_venture("Acme", "Landing pages").unwrap();
+    let workspace = store
+        .add_customer("Dr. Tan", "dr.tan@example.com", "")
+        .unwrap();
+    let customer_id = workspace.customers[0].id;
+    let workspace = store
+        .create_document(DocumentKind::Invoice, customer_id, Some(250_000), "en")
+        .unwrap();
+    let document_id = workspace.documents[0].id;
+    let workspace = store.request_send(document_id).unwrap();
+    let approval_id = workspace.approvals[0].id;
+    store.decide(approval_id, true).unwrap();
+
+    // Tear the decision: the chain holds approval.granted /
+    // capability.executed / effect.file_written, but roll the state back to
+    // pending as if the vault write never completed.
+    let mut behind = store.load().unwrap();
+    behind.approvals[0].status = ApprovalStatus::Pending;
+    behind.approvals[0].evidence = None;
+    behind.documents[0].status = DocumentStatus::PendingApproval;
+    store.save(&behind).unwrap();
+
+    let report = store.integrity_check().unwrap();
+    assert!(report.ok, "a torn decision is interrupted, not tampering");
+    assert!(
+        report
+            .findings
+            .iter()
+            .any(|finding| finding.severity == "warning"),
+        "expected a warning for the torn decision, got {:?}",
+        report.findings
+    );
+}
+
+#[test]
 fn compose_email_is_wellformed_and_injection_safe() {
     let venture = Venture {
         name: "Acme".into(),

--- a/apps/cli/src/workspace/types.rs
+++ b/apps/cli/src/workspace/types.rs
@@ -288,7 +288,9 @@ pub struct IntegrityReport {
     pub chain_verified: bool,
     /// Events on the verified chain.
     pub events: usize,
-    /// True when `chain_verified` holds and there are no findings.
+    /// True when `chain_verified` holds and there are no **critical**
+    /// findings. Warnings (interrupted operations: the chain ahead of the
+    /// state, healed by retrying) are reported but do not fail the audit.
     pub ok: bool,
     /// Each divergence between state and the signed chain, never hidden.
     pub findings: Vec<IntegrityFinding>,

--- a/crates/audit-ledger/src/lib.rs
+++ b/crates/audit-ledger/src/lib.rs
@@ -161,9 +161,12 @@ impl AuditLedger {
         Ok(())
     }
 
+    /// Durably persist the chain. Crash-safe: the whole file is written to a
+    /// sibling temp path, fsynced, then renamed over the target, so a crash
+    /// mid-save leaves the previous complete chain — never a truncated one.
     pub fn save(&self, path: &std::path::Path) -> Result<(), LedgerError> {
         let json = serde_json::to_vec_pretty(&self.events)?;
-        std::fs::write(path, json)?;
+        write_atomic(path, &json)?;
         Ok(())
     }
 
@@ -175,6 +178,32 @@ impl AuditLedger {
         let events: Vec<AuditEvent> = serde_json::from_slice(&bytes)?;
         Self::from_events(events, trusted_device_public_key_b64)
     }
+}
+
+/// Crash-safe replacement write: temp file + fsync + rename + directory
+/// flush. A crash at any point leaves either the old content or the new,
+/// never a truncated chain. Mirrors the admission store's write pattern; on
+/// non-Unix the directory flush is skipped because std cannot express it,
+/// and the rename itself is atomic.
+fn write_atomic(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
+    use std::io::Write;
+    let temp_path = path.with_extension("tmp");
+    let result = (|| {
+        let mut file = std::fs::File::create(&temp_path)?;
+        file.write_all(bytes)?;
+        file.sync_all()?;
+        drop(file);
+        std::fs::rename(&temp_path, path)?;
+        #[cfg(unix)]
+        if let Some(directory) = path.parent() {
+            std::fs::File::open(directory)?.sync_all()?;
+        }
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temp_path);
+    }
+    result
 }
 
 pub fn hash_bytes(data: &[u8]) -> String {
@@ -190,6 +219,36 @@ pub fn hash_event_body(body: &AuditEventBody) -> String {
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[test]
+    fn save_replaces_atomically_and_leaves_no_temp_file() {
+        let device = DeviceIdentity::generate();
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("ledger.json");
+        let mut ledger = AuditLedger::new();
+        for i in 0..2 {
+            ledger
+                .append(
+                    AppendInput {
+                        venture_id: "v".into(),
+                        actor_id: "a".into(),
+                        action: format!("act{i}"),
+                        resource: "r".into(),
+                        capability_id: None,
+                        payload: serde_json::json!({}),
+                        policy_decision_hash: None,
+                    },
+                    &device,
+                )
+                .unwrap();
+            // Each save fully replaces the previous file via temp+rename.
+            ledger.save(&path).unwrap();
+        }
+        assert!(!path.with_extension("tmp").exists());
+        let reloaded = AuditLedger::load(&path, device.public_key_b64()).unwrap();
+        assert_eq!(reloaded.events().len(), 2);
+        reloaded.verify_chain().unwrap();
+    }
 
     #[test]
     fn append_and_verify_chain() {

--- a/crates/vault/src/lib.rs
+++ b/crates/vault/src/lib.rs
@@ -79,7 +79,7 @@ impl Vault {
         let blob = encrypt(&self.key, plaintext)?;
         let path = self.root.join(format!("{name}.enc"));
         let json = serde_json::to_vec_pretty(&blob)?;
-        std::fs::write(path, json)?;
+        write_atomic(&path, &json)?;
         if !self.manifest.entries.contains(&name.to_string()) {
             self.manifest.entries.push(name.to_string());
             self.save_manifest()?;
@@ -105,9 +105,35 @@ impl Vault {
     fn save_manifest(&self) -> Result<(), VaultError> {
         let path = self.root.join("manifest.json");
         let json = serde_json::to_vec_pretty(&self.manifest)?;
-        std::fs::write(path, json)?;
+        write_atomic(&path, &json)?;
         Ok(())
     }
+}
+
+/// Durable, crash-safe replacement write: write to a sibling temp file, fsync
+/// it, rename over the target, then fsync the directory. A crash at any point
+/// leaves either the old content or the new — never a truncated file. Mirrors
+/// the admission store's write pattern; on non-Unix the directory flush is
+/// skipped because std cannot express it, and the rename itself is atomic.
+fn write_atomic(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
+    use std::io::Write;
+    let temp_path = path.with_extension("tmp");
+    let result = (|| {
+        let mut file = std::fs::File::create(&temp_path)?;
+        file.write_all(bytes)?;
+        file.sync_all()?;
+        drop(file);
+        std::fs::rename(&temp_path, path)?;
+        #[cfg(unix)]
+        if let Some(directory) = path.parent() {
+            std::fs::File::open(directory)?.sync_all()?;
+        }
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temp_path);
+    }
+    result
 }
 
 fn validate_entry_name(name: &str) -> Result<(), VaultError> {
@@ -132,7 +158,7 @@ fn generate_key() -> [u8; 32] {
 }
 
 fn save_key(path: &std::path::Path, key: &[u8; 32]) -> Result<(), VaultError> {
-    std::fs::write(path, STANDARD.encode(key))?;
+    write_atomic(path, STANDARD.encode(key).as_bytes())?;
     Ok(())
 }
 
@@ -188,6 +214,24 @@ mod tests {
         vault.put("company_profile", b"stealth startup").unwrap();
         let data = vault.get("company_profile").unwrap();
         assert_eq!(data, b"stealth startup");
+    }
+
+    #[test]
+    fn writes_replace_atomically_and_leave_no_temp_files() {
+        let dir = tempdir().unwrap();
+        let mut vault = Vault::init(dir.path()).unwrap();
+        vault.put("entry", b"one").unwrap();
+        vault.put("entry", b"two").unwrap();
+        assert_eq!(vault.get("entry").unwrap(), b"two");
+        let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|x| x == "tmp"))
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "temp files left behind: {leftovers:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Why

Two crash-consistency holes in the state/audit pair (owner-approved work on the
security-critical path):

1. **Torn files.** Vault entries, the vault manifest, the vault **key file**,
   and the **audit ledger** were written with bare `fs::write` — a crash
   mid-write could truncate an encrypted entry or the entire signed chain.
2. **State without evidence.** Every mutation saved state *first* and appended
   audit events *after* (one ledger write per event). A crash in between left
   committed state with no signed evidence — indistinguishable from tampering
   by the integrity self-audit.

## What

**Atomic persistence.** All four sites now use the same crash-safe pattern as
the admission store (sibling temp file → fsync → rename → directory flush on
Unix): a crash leaves either the old complete content or the new, never a torn
file. The newer durable crates (authority/execution/workflow/artifact) already
did this; identity's Unix path already had a stricter dirfd-based variant.

**Audit-first commits.** `Store::commit` appends **every event of an operation
to the chain in a single durable ledger write**, then writes state. All eight
mutation sites converted (venture, customer, document, request-send, decide
with its three events, revoke, deliver, disclosure). The remaining torn window
now leaves the chain *ahead* of the state, and the integrity check inspects the
**trailing operation**: reported as a **warning** ("interrupted operation;
retry it") — deliberately distinct from critical findings, which audit-first
ordering makes impossible short of tampering. Only the tail is checked, so an
interruption later retried under a fresh id never becomes a permanent warning.

CLI `integrity` output now counts criticals vs. warnings; the Security Center
badge renders warnings amber.

## Validation

- New tests: interrupted create → warning, then **retry heals to clean**; a
  torn decision (chain holds granted/executed/file_written, state rolled back)
  reads as warning, not tampering; ledger + vault replacement writes leave no
  temp files and reload chain-verified.
- **163 tests** total, fmt/clippy clean, file-size guardrail green.
- Full approve chain re-verified end-to-end at runtime (admit → policy → sign →
  token → sandbox → outbox; integrity clean, 7 events).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNaAoHftuMyML3uwCZHEYx)_