### PR TITLE
feat(kernel): run the approved send as a durable, crash-resumable workflow

### DIFF
--- a/apps/cli/src/workspace/mod.rs
+++ b/apps/cli/src/workspace/mod.rs
@@ -30,6 +30,7 @@ mod compose;
 mod kernel_exec;
 mod ops;
 mod reporting;
+mod send_workflow;
 mod store;
 mod types;
 mod util;

--- a/apps/cli/src/workspace/ops.rs
+++ b/apps/cli/src/workspace/ops.rs
@@ -1,4 +1,4 @@
-use super::compose::{compose_email, draft_outreach_note, render_document};
+use super::compose::{draft_outreach_note, render_document};
 use super::store::AuditEntry;
 use super::util::{clean_email, clean_optional_text, clean_text, kernel, now};
 use super::*;
@@ -300,83 +300,30 @@ impl Store {
             return Err(WorkspaceError::Invalid("approval already decided".into()));
         }
         let document_id = approval.document_id;
-        let document = workspace.document(document_id)?.clone();
+        workspace.document(document_id)?;
 
-        let evidence = if approve {
-            let customer = workspace
-                .customers
-                .iter()
-                .find(|customer| customer.id == document.customer_id);
-            let message = compose_email(workspace.venture.as_ref(), customer, &document);
-            Some(self.execute_signed_approval(&document, message.as_bytes())?)
-        } else {
-            None
-        };
+        if approve {
+            // The approved send runs as a durable, checkpointed workflow —
+            // compose, the signed kernel chain with its outbox effect, then
+            // the audit-first state commit — so a crash at any point resumes
+            // on the next attempt instead of losing or double-running the
+            // effect (see send_workflow.rs).
+            self.run_durable_send(approval_id, document_id)?;
+            return self.load();
+        }
 
         let approval = workspace.approval_mut(approval_id)?;
-        approval.status = if approve {
-            ApprovalStatus::Approved
-        } else {
-            ApprovalStatus::Rejected
-        };
+        approval.status = ApprovalStatus::Rejected;
         approval.decided_at = Some(now());
-        approval.evidence = evidence.clone();
-        let document_entry = workspace.document_mut(document_id)?;
-        document_entry.status = if approve {
-            DocumentStatus::ApprovedPendingDelivery
-        } else {
-            DocumentStatus::Rejected
-        };
-
-        // Every event of this decision lands on the chain in one durable
-        // write, then the state commits — audit-first, no partial record.
-        let resource = format!("document:{document_id}");
-        let mut events = Vec::new();
-        match &evidence {
-            Some(record) => {
-                events.push(AuditEntry {
-                    action: "approval.granted".into(),
-                    resource: resource.clone(),
-                    payload: serde_json::json!({
-                        "approval_id": approval_id,
-                        "signed_approval_id": record.approval_id,
-                        "evidence_digest": record.evidence_digest,
-                        "approver_key_id": record.approver_key_id,
-                    }),
-                });
-                events.push(AuditEntry {
-                    action: "capability.executed".into(),
-                    resource: resource.clone(),
-                    payload: serde_json::json!({
-                        "tool": "workspace.delivery/prepare",
-                        "component_digest": record.component_digest,
-                        "canonical_input_digest": record.canonical_input_digest,
-                        "idempotency": record.capability_idempotency,
-                        "exit_code": record.guest_exit_code,
-                        "fuel": record.fuel_consumed,
-                    }),
-                });
-                if let Some(outbox) = &record.outbox {
-                    events.push(AuditEntry {
-                        action: "effect.file_written".into(),
-                        resource: resource.clone(),
-                        payload: serde_json::json!({
-                            "outbox_path": outbox.relative_path,
-                            "content_sha256": outbox.content_sha256,
-                            "bytes": outbox.bytes,
-                        }),
-                    });
-                }
-            }
-            None => {
-                events.push(AuditEntry {
-                    action: "approval.rejected".into(),
-                    resource: resource.clone(),
-                    payload: serde_json::json!({ "approval_id": approval_id, "approved": false }),
-                });
-            }
-        }
-        self.commit(&workspace, events)?;
+        workspace.document_mut(document_id)?.status = DocumentStatus::Rejected;
+        self.commit(
+            &workspace,
+            vec![AuditEntry {
+                action: "approval.rejected".into(),
+                resource: format!("document:{document_id}"),
+                payload: serde_json::json!({ "approval_id": approval_id, "approved": false }),
+            }],
+        )?;
         Ok(workspace)
     }
 

--- a/apps/cli/src/workspace/send_workflow.rs
+++ b/apps/cli/src/workspace/send_workflow.rs
@@ -1,0 +1,232 @@
+//! The approved send as a durable, crash-resumable workflow.
+//!
+//! Approving a send does real work — compose, the full RFC 0003 kernel chain
+//! with its outbox effect, then the audit-first state commit. Routing it
+//! through the checkpointed [`WorkflowRunner`] means a crash at any point
+//! resumes instead of losing or double-running the effect:
+//!
+//! - crash **during execute** → no checkpoint, no state: the retry re-runs
+//!   the whole step; an orphaned `.eml` from the interrupted attempt is
+//!   removed first (no committed state references it, and the recomposed
+//!   content is deterministic over the same state);
+//! - crash **between execute and commit** → the execute receipt is durable
+//!   and the signed record is persisted beside it: the retry replays the
+//!   receipt without re-consuming a capability or rewriting the outbox, and
+//!   runs only the commit;
+//! - crash **inside commit** → the audit-first commit itself guarantees the
+//!   chain is never behind the state, and re-running the commit is an
+//!   idempotent no-op once the approval is decided.
+//!
+//! The workflow directory (checkpoint + signed record) is kept after
+//! completion as an execution trace; the authoritative copies of the same
+//! facts live in the vault and on the signed chain.
+
+use super::store::AuditEntry;
+use super::util::{kernel, now};
+use super::*;
+
+use sovereign_workflow::{StepContext, WorkflowRunner, WorkflowStep};
+use uuid::Uuid;
+
+impl Store {
+    /// Run (or resume) the durable send workflow for one pending approval.
+    /// The caller has already verified the approval is pending.
+    pub(super) fn run_durable_send(
+        &self,
+        approval_id: Uuid,
+        document_id: Uuid,
+    ) -> Result<(), WorkspaceError> {
+        let workflow_id = format!("send-{approval_id}");
+        let dir = self.root.join("workflows").join(&workflow_id);
+        let record_path = dir.join("record.json");
+        let runner = WorkflowRunner::open(&dir, &workflow_id).map_err(kernel)?;
+        let steps: Vec<Box<dyn WorkflowStep>> = vec![
+            Box::new(ExecuteSendStep {
+                root: self.root.clone(),
+                record_path: record_path.clone(),
+                approval_id,
+                document_id,
+            }),
+            Box::new(CommitDecisionStep {
+                root: self.root.clone(),
+                record_path,
+                approval_id,
+                document_id,
+            }),
+        ];
+        runner.run(&steps).map_err(kernel)?;
+        Ok(())
+    }
+
+    /// Apply an executed approval to state, audit-first. Idempotent: once the
+    /// approval is decided this is a no-op, so a resumed commit step (crash
+    /// after the state landed but before the checkpoint) cannot double-apply
+    /// or double-record.
+    pub(super) fn commit_approve_decision(
+        &self,
+        approval_id: Uuid,
+        document_id: Uuid,
+        record: SignedApprovalRecord,
+    ) -> Result<(), WorkspaceError> {
+        let mut workspace = self.load()?;
+        if workspace.approval(approval_id)?.status != ApprovalStatus::Pending {
+            return Ok(());
+        }
+
+        let approval = workspace.approval_mut(approval_id)?;
+        approval.status = ApprovalStatus::Approved;
+        approval.decided_at = Some(now());
+        approval.evidence = Some(record.clone());
+        workspace.document_mut(document_id)?.status = DocumentStatus::ApprovedPendingDelivery;
+
+        let resource = format!("document:{document_id}");
+        let mut events = vec![
+            AuditEntry {
+                action: "approval.granted".into(),
+                resource: resource.clone(),
+                payload: serde_json::json!({
+                    "approval_id": approval_id,
+                    "signed_approval_id": record.approval_id,
+                    "evidence_digest": record.evidence_digest,
+                    "approver_key_id": record.approver_key_id,
+                }),
+            },
+            AuditEntry {
+                action: "capability.executed".into(),
+                resource: resource.clone(),
+                payload: serde_json::json!({
+                    "tool": "workspace.delivery/prepare",
+                    "component_digest": record.component_digest,
+                    "canonical_input_digest": record.canonical_input_digest,
+                    "idempotency": record.capability_idempotency,
+                    "exit_code": record.guest_exit_code,
+                    "fuel": record.fuel_consumed,
+                }),
+            },
+        ];
+        if let Some(outbox) = &record.outbox {
+            events.push(AuditEntry {
+                action: "effect.file_written".into(),
+                resource,
+                payload: serde_json::json!({
+                    "outbox_path": outbox.relative_path,
+                    "content_sha256": outbox.content_sha256,
+                    "bytes": outbox.bytes,
+                }),
+            });
+        }
+        self.commit(&workspace, events)
+    }
+}
+
+/// Step 1 — compose the message and run the signed kernel chain (the outbox
+/// `.eml` is written inside it). The signed record is persisted beside the
+/// checkpoint so the commit step can read it on a resumed run: receipts
+/// store only output digests, never outputs.
+pub(super) struct ExecuteSendStep {
+    pub root: std::path::PathBuf,
+    pub record_path: std::path::PathBuf,
+    pub approval_id: Uuid,
+    pub document_id: Uuid,
+}
+
+impl WorkflowStep for ExecuteSendStep {
+    fn name(&self) -> &str {
+        "execute_signed_send"
+    }
+
+    fn run(&self, _context: &StepContext<'_>) -> Result<Vec<u8>, String> {
+        let store = Store::open(&self.root).map_err(|e| e.to_string())?;
+        let workspace = store.load().map_err(|e| e.to_string())?;
+        if workspace
+            .approval(self.approval_id)
+            .map_err(|e| e.to_string())?
+            .status
+            != ApprovalStatus::Pending
+        {
+            return Err("approval is no longer pending".into());
+        }
+        let document = workspace
+            .document(self.document_id)
+            .map_err(|e| e.to_string())?
+            .clone();
+        let customer = workspace
+            .customers
+            .iter()
+            .find(|customer| customer.id == document.customer_id);
+        let message = compose::compose_email(workspace.venture.as_ref(), customer, &document);
+
+        // An interrupted earlier attempt may have left an orphaned `.eml`
+        // (state uncommitted, so nothing references it). Remove it so the
+        // exclusive outbox write can run again; the recomposed content is
+        // deterministic over the same state.
+        let broker =
+            sovereign_effects::OutboxBroker::open(self.root.join("outbox")).map_err(kernel_str)?;
+        match broker.revoke(&format!("{}.eml", document.id.simple())) {
+            Ok(()) | Err(sovereign_effects::EffectError::NotFound) => {}
+            Err(error) => return Err(error.to_string()),
+        }
+
+        let record = store
+            .execute_signed_approval(&document, message.as_bytes())
+            .map_err(|e| e.to_string())?;
+        let bytes = serde_json::to_vec(&record).map_err(|e| e.to_string())?;
+        write_atomic(&self.record_path, &bytes).map_err(|e| e.to_string())?;
+        Ok(bytes)
+    }
+}
+
+/// Step 2 — apply the executed approval to state with the audit-first
+/// commit. Reads the signed record persisted by step 1, so it works the same
+/// on a fresh run and on a crash resume.
+pub(super) struct CommitDecisionStep {
+    pub root: std::path::PathBuf,
+    pub record_path: std::path::PathBuf,
+    pub approval_id: Uuid,
+    pub document_id: Uuid,
+}
+
+impl WorkflowStep for CommitDecisionStep {
+    fn name(&self) -> &str {
+        "commit_decision"
+    }
+
+    fn run(&self, _context: &StepContext<'_>) -> Result<Vec<u8>, String> {
+        let store = Store::open(&self.root).map_err(|e| e.to_string())?;
+        let bytes = std::fs::read(&self.record_path)
+            .map_err(|_| "missing signed record for an executed send".to_string())?;
+        let record: SignedApprovalRecord =
+            serde_json::from_slice(&bytes).map_err(|e| e.to_string())?;
+        store
+            .commit_approve_decision(self.approval_id, self.document_id, record)
+            .map_err(|e| e.to_string())?;
+        Ok(b"committed".to_vec())
+    }
+}
+
+fn kernel_str(error: impl std::fmt::Display) -> String {
+    kernel(error).to_string()
+}
+
+/// Crash-safe replacement write for the persisted record: temp + fsync +
+/// rename, mirroring the vault and ledger write pattern.
+fn write_atomic(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
+    use std::io::Write;
+    let temp_path = path.with_extension("tmp");
+    let result = (|| {
+        let mut file = std::fs::File::create(&temp_path)?;
+        file.write_all(bytes)?;
+        file.sync_all()?;
+        drop(file);
+        std::fs::rename(&temp_path, path)?;
+        #[cfg(unix)]
+        if let Some(directory) = path.parent() {
+            std::fs::File::open(directory)?.sync_all()?;
+        }
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temp_path);
+    }
+    result
+}

--- a/apps/cli/src/workspace/tests.rs
+++ b/apps/cli/src/workspace/tests.rs
@@ -371,6 +371,155 @@ fn torn_decision_is_a_warning_until_state_lands() {
 }
 
 #[test]
+fn durable_send_resumes_after_crash_without_rerunning_the_effect() {
+    use super::send_workflow::ExecuteSendStep;
+    use sovereign_workflow::{WorkflowRunner, WorkflowStep};
+
+    let (dir, store) = store();
+    store.set_venture("Acme", "Landing pages").unwrap();
+    let workspace = store
+        .add_customer("Dr. Tan", "dr.tan@example.com", "")
+        .unwrap();
+    let customer_id = workspace.customers[0].id;
+    let workspace = store
+        .create_document(DocumentKind::Invoice, customer_id, Some(250_000), "en")
+        .unwrap();
+    let document_id = workspace.documents[0].id;
+    let workspace = store.request_send(document_id).unwrap();
+    let approval_id = workspace.approvals[0].id;
+
+    // Simulate a crash between execute and commit: run only the first step
+    // of the same workflow the app would run, then "die".
+    let workflow_id = format!("send-{approval_id}");
+    let wf_dir = dir.path().join("workflows").join(&workflow_id);
+    let record_path = wf_dir.join("record.json");
+    let runner = WorkflowRunner::open(&wf_dir, &workflow_id).unwrap();
+    let only_execute: Vec<Box<dyn WorkflowStep>> = vec![Box::new(ExecuteSendStep {
+        root: dir.path().to_path_buf(),
+        record_path: record_path.clone(),
+        approval_id,
+        document_id,
+    })];
+    runner.run(&only_execute).unwrap();
+
+    // Effect happened, record persisted — but state still pending.
+    assert!(record_path.exists());
+    assert_eq!(
+        store.load().unwrap().approvals[0].status,
+        ApprovalStatus::Pending
+    );
+    let persisted: SignedApprovalRecord =
+        serde_json::from_slice(&std::fs::read(&record_path).unwrap()).unwrap();
+
+    // The retry (the owner clicks approve again) resumes: the execute
+    // receipt replays, only the commit runs — no second capability, no
+    // second outbox write.
+    let workspace = store.decide(approval_id, true).unwrap();
+    assert_eq!(workspace.approvals[0].status, ApprovalStatus::Approved);
+    assert_eq!(
+        workspace.documents[0].status,
+        DocumentStatus::ApprovedPendingDelivery
+    );
+    let evidence = workspace.approvals[0].evidence.as_ref().unwrap();
+    assert_eq!(
+        evidence.capability_idempotency, persisted.capability_idempotency,
+        "the committed evidence must be the persisted record, not a re-execution"
+    );
+    let eml_count = std::fs::read_dir(dir.path().join("outbox"))
+        .unwrap()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.path().extension().is_some_and(|x| x == "eml"))
+        .count();
+    assert_eq!(eml_count, 1, "exactly one composed message, no duplicates");
+
+    let report = store.integrity_check().unwrap();
+    assert!(
+        report.ok && report.findings.is_empty(),
+        "{:?}",
+        report.findings
+    );
+}
+
+#[test]
+fn durable_send_retries_after_crash_mid_execute() {
+    let (dir, store) = store();
+    store.set_venture("Acme", "Landing pages").unwrap();
+    let workspace = store
+        .add_customer("Dr. Tan", "dr.tan@example.com", "")
+        .unwrap();
+    let customer_id = workspace.customers[0].id;
+    let workspace = store
+        .create_document(DocumentKind::Invoice, customer_id, Some(250_000), "en")
+        .unwrap();
+    let document_id = workspace.documents[0].id;
+    let workspace = store.request_send(document_id).unwrap();
+    let approval_id = workspace.approvals[0].id;
+
+    // Simulate a crash mid-execute: the outbox file landed but neither the
+    // workflow checkpoint nor any state did — an orphan nothing references.
+    let broker = sovereign_effects::OutboxBroker::open(dir.path().join("outbox")).unwrap();
+    broker
+        .write_message(
+            &document_id.simple().to_string(),
+            sovereign_effects::EffectDataClass::Amber,
+            b"orphan from an interrupted attempt",
+        )
+        .unwrap();
+
+    // The retry pre-cleans the orphan and completes end-to-end.
+    let workspace = store.decide(approval_id, true).unwrap();
+    assert_eq!(workspace.approvals[0].status, ApprovalStatus::Approved);
+    let outbox = workspace.approvals[0]
+        .evidence
+        .as_ref()
+        .unwrap()
+        .outbox
+        .as_ref()
+        .unwrap();
+    let content = std::fs::read(dir.path().join("outbox").join(&outbox.relative_path)).unwrap();
+    assert!(
+        content.starts_with(b"From:"),
+        "the orphan was replaced by the real composed message"
+    );
+}
+
+#[test]
+fn commit_approve_decision_is_idempotent() {
+    let (dir, store) = store();
+    store.set_venture("Acme", "Landing pages").unwrap();
+    let workspace = store
+        .add_customer("Dr. Tan", "dr.tan@example.com", "")
+        .unwrap();
+    let customer_id = workspace.customers[0].id;
+    let workspace = store
+        .create_document(DocumentKind::Invoice, customer_id, Some(250_000), "en")
+        .unwrap();
+    let document_id = workspace.documents[0].id;
+    let workspace = store.request_send(document_id).unwrap();
+    let approval_id = workspace.approvals[0].id;
+    let workspace = store.decide(approval_id, true).unwrap();
+    let record = workspace.approvals[0].evidence.clone().unwrap();
+
+    let device = DeviceIdentity::load(&dir.path().join("device.json")).unwrap();
+    let before =
+        AuditLedger::load(&dir.path().join("ledger.json"), device.public_key_b64()).unwrap();
+    let events_before = before.events().len();
+
+    // A resumed commit step after the state already landed must change
+    // nothing and append nothing.
+    store
+        .commit_approve_decision(approval_id, document_id, record)
+        .unwrap();
+    let after =
+        AuditLedger::load(&dir.path().join("ledger.json"), device.public_key_b64()).unwrap();
+    assert_eq!(after.events().len(), events_before);
+    assert_eq!(
+        store.load().unwrap().approvals[0].status,
+        ApprovalStatus::Approved
+    );
+}
+
+#[test]
 fn compose_email_is_wellformed_and_injection_safe() {
     let venture = Venture {
         name: "Acme".into(),


### PR DESCRIPTION
## Why

Step 2 of the owner-approved kernel work. Approving a send does real work —
compose, the signed RFC 0003 chain with its outbox effect, then the
audit-first state commit. Until now a crash mid-approve meant a lost or
half-done operation. It now runs through the durable `WorkflowRunner`
(workflow id `send-{approval_id}`), so **a crash at any point resumes on the
next attempt instead of losing or double-running the effect**.

## Crash-window analysis (each covered by a test)

| crash point | what happens on retry |
|---|---|
| during execute | no checkpoint, no state — the step re-runs; an orphaned `.eml` from the interrupted attempt is pre-cleaned (nothing committed references it; the recomposed content is deterministic over the same state) |
| between execute and commit | the execute receipt is durable and the **signed record is persisted beside the checkpoint** (receipts store output digests, not outputs) — the retry replays the receipt and runs only the commit: **no second capability consumed, no second file written** |
| inside commit | `commit_approve_decision` is idempotent once the approval is decided, and the audit-first commit keeps the chain from ever trailing the state |

## What

- `workspace/send_workflow.rs`: `ExecuteSendStep` (compose → kernel chain →
  persist record atomically) + `CommitDecisionStep` (idempotent audit-first
  state application) + `Store::run_durable_send`.
- `decide()` delegates its approve branch to the workflow; the effect-free
  reject branch stays inline. No API change — the UI is untouched.
- The workflow directory (checkpoint + signed record) is kept after
  completion as an execution trace; the authoritative copies of the same
  facts live in the vault and on the signed chain.

## Validation

- New tests: crash-between-steps resumes **without re-execution** (committed
  evidence carries the persisted record's capability idempotency; exactly one
  `.eml`; integrity clean), crash-mid-execute retries after orphan pre-clean,
  resumed commit appends nothing to the chain.
- **166 tests**, fmt/clippy clean, file-size guardrail green.
- Approve re-verified through the UI at runtime — checkpoint + record present
  on disk, integrity self-audit clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNaAoHftuMyML3uwCZHEYx)_