### PR TITLE
fix(authority): retain approvals through their own expiry

### DIFF
--- a/crates/authority/src/lib.rs
+++ b/crates/authority/src/lib.rs
@@ -386,6 +386,29 @@ mod tests {
     }
 
     #[test]
+    fn purge_uses_each_claim_kind_expiry() {
+        let dir = tempdir().unwrap();
+        let store = AuthorityStore::open(dir.path()).unwrap();
+        let token = Uuid::new_v4();
+        let approval = Uuid::new_v4();
+        let idempotency = Uuid::new_v4();
+
+        store.consume_token(token, NOW, NOW + 30).unwrap();
+        store.consume_approval(approval, NOW, NOW + 120).unwrap();
+        store
+            .bind_idempotency(idempotency, &[0x01; 32], NOW, NOW + 30)
+            .unwrap();
+
+        assert_eq!(store.purge_expired(NOW + 31).unwrap(), 2);
+        assert_eq!(
+            store.consume_approval(approval, NOW + 31, NOW + 120),
+            Err(AuthorityError::AlreadyConsumed),
+            "the approval must retain its own later expiry"
+        );
+        assert_eq!(store.purge_expired(NOW + 120).unwrap(), 1);
+    }
+
+    #[test]
     fn purged_idempotency_key_can_be_rebound_without_false_conflict() {
         // An idempotency key that has expired and been purged must not haunt a
         // later, unrelated invocation as a phantom conflict — otherwise expired

--- a/crates/capability/src/v2.rs
+++ b/crates/capability/src/v2.rs
@@ -693,7 +693,7 @@ impl<C: TrustedClock> CapabilityValidatorV2<C> {
         // RFC 0003: the token's evidence claim, the presented signed object,
         // and the policy requirement must all agree. Any partial combination
         // fails closed.
-        let approval_id = match (
+        let approval_claim = match (
             context.policy_decision.requires_approval(),
             &claims.approval_evidence,
             approval,
@@ -732,7 +732,7 @@ impl<C: TrustedClock> CapabilityValidatorV2<C> {
                 if self.consumed_approvals.contains(&verified.approval_id) {
                     return Err(CapabilityV2Error::ApprovalReused);
                 }
-                Some(verified.approval_id)
+                Some((verified.approval_id, verified.expires_at_unix))
             }
         };
 
@@ -759,16 +759,16 @@ impl<C: TrustedClock> CapabilityValidatorV2<C> {
                     claims.expires_at_unix,
                 )
                 .map_err(map_authority_error_idempotency)?;
-            if let Some(approval_id) = approval_id {
+            if let Some((approval_id, approval_expires_at_unix)) = approval_claim {
                 store
-                    .consume_approval(approval_id, now_unix, claims.expires_at_unix)
+                    .consume_approval(approval_id, now_unix, approval_expires_at_unix)
                     .map_err(map_authority_error_approval)?;
             }
         }
 
         self.consumed_tokens.insert(claims.token_id);
         self.idempotency.insert(claims.idempotency_key, fingerprint);
-        if let Some(approval_id) = approval_id {
+        if let Some((approval_id, _)) = approval_claim {
             self.consumed_approvals.insert(approval_id);
         }
         Ok(AuthorizedCapabilityV2 { claims })

--- a/crates/capability/tests/approval_v2.rs
+++ b/crates/capability/tests/approval_v2.rs
@@ -221,6 +221,15 @@ fn request<'a>(
     policy_decision: &'a PolicyAuthorizationV2,
     idempotency: Uuid,
 ) -> CapabilityV2IssueRequest<'a> {
+    request_with_ttl(invocation, policy_decision, idempotency, 60)
+}
+
+fn request_with_ttl<'a>(
+    invocation: &'a PreparedInvocation,
+    policy_decision: &'a PolicyAuthorizationV2,
+    idempotency: Uuid,
+    ttl_seconds: i64,
+) -> CapabilityV2IssueRequest<'a> {
     CapabilityV2IssueRequest {
         venture_id: VENTURE,
         subject_id: SUBJECT,
@@ -228,7 +237,7 @@ fn request<'a>(
         policy_decision,
         prepared_invocation: invocation,
         options: CapabilityV2IssueOptions {
-            ttl: Duration::seconds(60),
+            ttl: Duration::seconds(ttl_seconds),
             idempotency_key: idempotency,
         },
     }
@@ -540,6 +549,90 @@ fn approval_reuse_across_tokens_is_denied_at_consumption() {
         .unwrap_err(),
         CapabilityV2Error::ApprovalReused
     );
+}
+
+#[test]
+fn durable_approval_survives_token_expiry_purge_until_approval_expiry() {
+    let dir = tempfile::tempdir().unwrap();
+    let invocation = prepared("durable approval retention");
+    let idempotency = Uuid::from_u128(23);
+    let policy_decision = decision(&invocation, AutomationLevel::L3BoundedAuto, idempotency);
+    // The approval remains valid until t+120 while each capability token
+    // expires at t+30.
+    let approval = approve_at(NOW, &invocation, &policy_decision, 120);
+    let first_token = issuer_at(NOW)
+        .issue_approved(
+            request_with_ttl(&invocation, &policy_decision, idempotency, 30),
+            &approval,
+        )
+        .unwrap();
+
+    let mut first = validator_at(NOW + 1)
+        .with_authority_store(sovereign_authority::AuthorityStore::open(dir.path()).unwrap());
+    consume(
+        &mut first,
+        &first_token,
+        &invocation,
+        &policy_decision,
+        Some(&approval),
+    )
+    .unwrap();
+
+    // At t+31 the first token and its idempotency record may be purged, but
+    // the still-valid approval must continue to block a second token.
+    let store = sovereign_authority::AuthorityStore::open(dir.path()).unwrap();
+    store.purge_expired(NOW + 31).unwrap();
+    drop(store);
+
+    let second_token = issuer_at(NOW + 31)
+        .issue_approved(
+            request_with_ttl(&invocation, &policy_decision, idempotency, 30),
+            &approval,
+        )
+        .unwrap();
+    let mut reopened = validator_at(NOW + 31)
+        .with_authority_store(sovereign_authority::AuthorityStore::open(dir.path()).unwrap());
+    match consume(
+        &mut reopened,
+        &second_token,
+        &invocation,
+        &policy_decision,
+        Some(&approval),
+    ) {
+        Err(CapabilityV2Error::ApprovalReused) => {}
+        Err(error) => panic!("unexpected approval replay result: {error:?}"),
+        Ok(()) => panic!("approval replay incorrectly reopened after token-expiry purge"),
+    }
+}
+
+#[test]
+fn expired_approval_purges_at_approval_expiry() {
+    let dir = tempfile::tempdir().unwrap();
+    let invocation = prepared("durable approval expiry");
+    let idempotency = Uuid::from_u128(24);
+    let policy_decision = decision(&invocation, AutomationLevel::L3BoundedAuto, idempotency);
+    let approval = approve_at(NOW, &invocation, &policy_decision, 120);
+    let token = issuer_at(NOW)
+        .issue_approved(
+            request_with_ttl(&invocation, &policy_decision, idempotency, 30),
+            &approval,
+        )
+        .unwrap();
+    let mut validator = validator_at(NOW + 1)
+        .with_authority_store(sovereign_authority::AuthorityStore::open(dir.path()).unwrap());
+    consume(
+        &mut validator,
+        &token,
+        &invocation,
+        &policy_decision,
+        Some(&approval),
+    )
+    .unwrap();
+
+    let store = sovereign_authority::AuthorityStore::open(dir.path()).unwrap();
+    assert_eq!(store.purge_expired(NOW + 31).unwrap(), 2);
+    assert_eq!(store.purge_expired(NOW + 119).unwrap(), 0);
+    assert_eq!(store.purge_expired(NOW + 120).unwrap(), 1);
 }
 
 #[test]


### PR DESCRIPTION
## What changed

- retain consumed approval claims through the expiry signed into the approval evidence
- keep capability-token and idempotency retention tied to the shorter token expiry
- add real purge/reopen replay regressions and per-claim-kind purge coverage

## Why

The validator previously stored a consumed approval using the capability token's expiry. A short-lived token could therefore expire, be purged, and allow the still-valid signed approval to authorize a second token.

## Security boundary

This changes no public API, wire format, or on-disk JSON schema. Claim consumption remains fail closed and non-transactional as documented; this PR only corrects the approval record's retention deadline.

## Verification

- exact regression test: pass
- `cargo fmt --all -- --check`: pass
- workspace Clippy, all targets/features, `-D warnings`: pass
- `cargo test --workspace --locked`: pass
- file-size and diff checks: pass
- independent spec/security/code review: approved with no Critical, Important, or Minor findings