### PR TITLE
docs(plan): replace unsafe owner and playground paths

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -87,10 +87,12 @@ after an unauthenticated loopback/API decision. Its capability binds document
 and resource preparation, not the final recipient or exact RFC 5322 bytes, and
 the execution journal completes before the trusted host writes the outbox
 file. The Authority Store persists individual filesystem claims, but current
-tests do not prove a true multi-process boundary and approval records may be
-purged before the approval itself expires. The complete token/approval/
-idempotency reservation is not one transaction and has no revocation API. Core
-Wasm guests cannot invoke host effects.
+approval claims retain the verified signed approval expiry. Token-expiry
+purge, store reopen while the approval remains valid, rejection of reuse, and
+purge at approval expiry are tested. The token/idempotency/approval claims are
+still ordered filesystem operations rather than one transaction; revocation,
+a full real-subprocess validator race, and an independently admitted owner
+ceremony remain absent. Core Wasm guests cannot invoke host effects.
 
 The Model Gateway contains deterministic stand-ins and an unsafe legacy
 classification/trust API; it is not a real Model Mesh. Workflow checkpoints

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,8 +33,9 @@ used only for a named exit criterion with evidence.
 ## Current verified state
 
 The repository is a **Developer Preview / pre-release** with no tagged release.
-The workspace currently passes 183 Rust tests plus formatting, lint,
-file-size, locked dependency, TypeScript, and release-build gates.
+A fresh `cargo test --workspace --locked -- --list` enumerates 186 Rust tests.
+Formatting, lint, file-size, locked dependency, TypeScript, and release-build
+gates are configured in the repository.
 
 ### Founder product today
 
@@ -80,7 +81,7 @@ prove independently authenticated human intent or exact effect authorization.
 | --- | --- |
 | **Identity, policy, capability** | Current cryptographic/deterministic primitives; owner ceremony, final effect binding, key lifecycle, and hardware/OS storage remain targets. |
 | **Vault and audit** | Current prototype: AES-GCM entries and a replaceable-file, device-signed hash chain that proves internal consistency. This remains Experimental as a product boundary: the raw vault key sits beside the data, and rollback anchoring, restore, and state-value commitments are absent. |
-| **Authority and execution** | Experimental filesystem claims plus crash journal. A known approval-expiry retention gap prevents a durable one-use approval claim; claims are not transactional, revocation is absent, and process-level coverage remains. |
+| **Authority and execution** | Experimental filesystem claims plus crash journal. Approval claims now retain the verified signed approval expiry; token-expiry purge, store reopen, replay denial, and approval-expiry purge are tested. Token/idempotency/approval claims remain ordered filesystem operations rather than one transaction; revocation, full real-subprocess validator races, and independent owner admission remain. |
 | **Artifacts and Wasm** | Current verification/admission and tested import-free V2 pure computation; worker/cache are optional, cache bindings are partial, and Component/WIT/high-risk isolation remain. |
 | **Model Gateway** | Current prototype: an Experimental deterministic routing simulator, not a real model or local-model sandbox. Caller classification and provider self-reported trust can authorize unsafe Amber/Green cloud routing; [RFC 0004](rfcs/0004-data-sovereignty-boundaries.md) must remove it before real egress. |
 | **Workflow and releases** | Same-directory checkpoint resume and `v*` release automation exist; no lease, replication, real node failover, or tagged preview exists. |
@@ -183,8 +184,8 @@ persona and first private-AI tasks; mandate isolated compilation/cache on the
 product path; deliver 1C0's admitted owner authenticator, expiry-bound session,
 and single one-use approval issuer; bind recipient/content/policy/expiry
 into an opaque effect grant; make authorization claims transactional and
-revocable; retain approval claims through approval expiry; upgrade audit/effect
-ordering and rollback anchoring; implement RFC 0005 Program 1A as a non-product
+revocable; add full real-subprocess validator race coverage; upgrade audit/
+effect ordering and rollback anchoring; implement RFC 0005 Program 1A as a non-product
 SQLCipher/key-custody engine with a closed legacy importer while keeping legacy
 workspaces isolated and honestly labelled; add process-kill,
 concurrency, and filesystem-fault tests; publish preview binaries.

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -35,7 +35,7 @@ Mitigations are labelled **Current** when enforced by merged repository code and
 - **Current:** device-signed hash-chain prototype behind an append-only API;
   its replaceable local file has no independent rollback anchor and does not
   prevent deletion
-- **Current foundation:** RFC 0003 approval-role-signed evidence — approval-required Capability V2 tokens are issued only with exactly invocation-bound evidence and fail closed without it. Validators are process-local by default. The Workspace attaches persistent filesystem claims, but approval records may currently be purged before approval expiry, so durable one-use approval is not claimed. Independent owner presence, correct retention, transactional reservation, and revocation remain Targets.
+- **Current foundation:** RFC 0003 approval-role-signed evidence — approval-required Capability V2 tokens are issued only with exactly invocation-bound evidence and fail closed without it. Validators are process-local by default. The Workspace attaches persistent filesystem claims whose approval records now retain the verified signed approval expiry; token-expiry purge, store reopen, replay denial, and approval-expiry purge are tested. Independent owner presence, one-transaction reservation, revocation, and a full real-subprocess validator race remain Targets.
 
 ### Untrusted (always)
 
@@ -70,7 +70,7 @@ Mitigations are labelled **Current** when enforced by merged repository code and
 **Description:** An agent or plugin attempts to expand its permissions beyond what was granted.
 
 **Mitigations:**
-- **Current foundation:** short-lived Capability V2 binds the exact artifact, operation, input commitments, and resource commitments; validators are process-local by default, while the Workspace attaches experimental persistent claims with the approval-retention limitation above
+- **Current foundation:** short-lived Capability V2 binds the exact artifact, operation, input commitments, and resource commitments; validators are process-local by default, while the Workspace attaches experimental persistent claims with the transactional, revocation, subprocess, and owner-ceremony limitations above
 - **Current:** Authority and Publisher signing roles are distinct, and an AI agent cannot make its own key trusted
 - **Current foundation:** strict publisher manifest enforcement and import-free Core Wasm isolation
 - **Target:** durable token revocation, container/micro-VM backends, and reviewed effectful host interfaces
@@ -243,7 +243,8 @@ Alpha release must pass:
 - [x] Current policy fixture rejects Red data sent through a cloud-labelled tool
 - [x] Capability V2 rejects same-process replay and idempotency conflicts
 - [x] Attached Authority Store rejects covered duplicate claims after reopen and token races across threads
-- [ ] Approval reuse remains rejected after token expiry/purge and across real subprocess races/restart
+- [x] Attached Authority Store rejects approval reuse after token expiry/purge and store reopen until the signed approval's own expiry
+- [ ] Approval reuse and the full reservation remain rejected across real subprocess validator races/restart, with durable revocation
 - [ ] Transactional authorization-bundle revocation remains rejected across races and restart
 - [ ] Full prompt-injection and data-disclosure paths pass the Alpha gauntlet
 - [ ] Primary model failure does not block data access

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -58,6 +58,6 @@ an accepted RFC proposal.
 | --- | --- | --- |
 | [0001](../rfcs/0001-canonical-task-contract.md) | Draft | Canonical task contract |
 | [0002](../rfcs/0002-wasm-sandbox-and-plugin-capabilities.md) | Draft; partially implemented | WASM sandbox and plugin capabilities |
-| [0003](../rfcs/0003-signed-approval-evidence.md) | Draft; partial foundation | Signed approval-role evidence; human ceremony remains target |
+| [0003](../rfcs/0003-signed-approval-evidence.md) | Draft; partial foundation | Signed approval-role evidence; approval-expiry retention is tested, while owner ceremony, transactional reservation, revocation, and full subprocess races remain Target |
 | [0004](../rfcs/0004-data-sovereignty-boundaries.md) | Draft; approved implementation target | Data sovereignty, privacy compilation, visibility, and compute placement |
 | [0005](../rfcs/0005-dual-root-vault-and-recovery.md) | Draft; implementation none | Dual-root Vault, backup, and recovery target |

--- a/docs/superpowers/plans/2026-08-13-security-architecture-program.md
+++ b/docs/superpowers/plans/2026-08-13-security-architecture-program.md
@@ -42,8 +42,12 @@ Exact Effect Protocol appropriate to its side effect.
   it. Legacy mode may prepare its honestly labelled local outbox artifact until
   migration. Activated v2 mode disables outbox preparation unless the Exact
   Effect slice has passed; preserving a known post-approval composition gap is
-  never a compatibility requirement. Security setup remains an advanced
-  readiness view until product activation is safe.
+  never a compatibility requirement. The synthetic consultant Playground is
+  additive and standalone: it must not replace the current Experimental UI,
+  export, disclosure, integrity, or Workspace paths before an authenticated
+  product router exists. Preserving those paths is continuity, not a security
+  endorsement. Security setup remains an advanced readiness view until product
+  activation is safe.
 - Use Current, Target, and Research exactly as defined in the design documents. Never promote a feature because an RFC or mock exists.
 - Follow strict red-green-refactor. Capture the failing test before production code, then run focused and workspace gates after the minimal fix.
 - Give each slice a fresh implementer, specification review, security/code-quality review, and fix loop until no known Critical or High finding remains in scope.
@@ -54,6 +58,47 @@ Exact Effect Protocol appropriate to its side effect.
   `ActiveV2`, Exact Effect, Credential Broker where applicable, and Privacy all
   pass.
 - Never invent cryptographic primitives, protocol patterns, ratchets, KEM hybrids, suites, key derivation, nonce strategies, or authentication-failure fallbacks.
+
+### Chosen Target reference-slice design
+
+- `broker` names a logical coordinator and authority boundary. It does not
+  require a child process, internal listener, or private transport protocol.
+  The Target synthetic owner/exact-outbox reference slice will use one process
+  with one public loopback listener; that process will own WebAuthn/session
+  state, the coordinator database, and the local outbox. New process isolation
+  requires a concrete threat, an established transport, and a separate RFC.
+- The Target reference executable will be `publish = false`, excluded from
+  product releases, and absent from `sovereign-cli`'s dependency graph. It will
+  exercise only fixed `.example.test` fixture mechanisms. It will not create a
+  product owner, open a product Workspace, satisfy 1C0, complete Program 2,
+  send email, or establish E2EE.
+- Before its reservation transaction, the Target slice will separate
+  side-effect-free Capability V2/RFC 0003 verification from current
+  `AuthorityStore` consumption. An upper fixture coordinator will consume
+  opaque verified proofs and will be the only constructor of the writer's
+  private, non-cloneable, non-serializable, move-only reservation handle. The
+  legacy pure-compute wrapper will preserve current behavior; dependency
+  inversion remains separate future work.
+- After taking its OS lock, the Target fixture will create an ephemeral
+  approval-role signer and random signer epoch. A closed approval bridge will
+  consume one-use, exact-bound fresh-UV grants; only public historical trust
+  records will persist. Restarted pre-dispatch work will not be re-signed, and
+  restarted `Dispatching` work will reconcile only to `Succeeded` or
+  `Indeterminate`.
+- Existing approval claims now retain the verified signed approval expiry.
+  Tests cover token-expiry purge, store reopen and replay denial while the
+  approval remains valid, and purge at approval expiry. The token,
+  idempotency, and approval claims remain ordered filesystem operations rather
+  than one transaction; revocation, a full real-subprocess validator race, and
+  independently admitted owner presence remain unfinished.
+- Product continuity is an invariant for every slice: the current UI and
+  consultant walking skeleton remain runnable. The Target synthetic teaching
+  and security fixtures will use separate commands, routes, state, and
+  maturity labels.
+- Target race qualification will use concurrent requests/threads inside the
+  one lock-holding process plus real process kill/reopen. A second live process
+  will test only lock denial before redb open; a full cross-process validator
+  race remains unfinished.
 
 ## Program 1A: Vault v2 format, custody, and migration engine
 
@@ -311,10 +356,10 @@ cannot create a trusted handle or read credential bytes.
 Required state machine:
 
 ```text
-Prepared → AuthorityReserved → Dispatching
-                                  ├─► Succeeded
-                                  ├─► FailedBeforeDispatch
-                                  └─► Indeterminate
+Prepared ───────► AuthorityReserved ───────► Dispatching
+  │                       │                    ├─► Succeeded
+  └─► FailedBeforeDispatch└─► FailedBeforeDispatch
+                                               └─► Indeterminate
 ```
 
 Exit gate:
@@ -332,10 +377,11 @@ Exit gate:
   expiry, and idempotency. Each dispatch attempt resolves exactly one unchanged
   tuple from that list.
   A tuple change or identity outside the list needs a new preview and approval.
-  The broker may advance within the list only after it proves
-  `FailedBeforeDispatch` with zero exposed request bytes; exposure or uncertain
-  exposure makes timeout/error/drop/crash terminal `Indeterminate`, with no
-  retry or failover;
+  Before entering `Dispatching`, the broker may advance within the list only
+  after it proves `FailedBeforeDispatch` with zero exposed request bytes. Once
+  `Dispatching` is durable, observation can close only as `Succeeded` or
+  `Indeterminate`; exposure or uncertain exposure makes
+  timeout/error/drop/crash terminal `Indeterminate`, with no retry or failover;
 - signed/value-free evidence projects only the random target ID, outcome, and
   provider/model fields independently classified approved-public by the
   registry. Account, tenant, credential-handle, private endpoint/audience, and
@@ -362,10 +408,13 @@ Exit gate:
 - the audit ledger is a signed evidence projection, not the transaction coordinator;
 - the existing pure-compute execution journal remains version-compatible.
 
-The known approval-retention/purge bug is fixed in this program as its own
-first TDD commit; it does not justify storing new secrets before 1D. Exact
-Effect may be built against deterministic fixtures before 1D, but product
-activation and real dispatch remain blocked.
+The approval-retention/purge bug was fixed by commit `6c0259b`: durable
+approval claims retain the verified signed approval expiry, with token-expiry
+purge/store-reopen and approval-expiry regressions. This does not make the
+three ordered claim writes transactional, add revocation, prove a full
+real-subprocess validator race, establish owner presence, or justify storing
+new secrets before 1D. Exact Effect may be built against deterministic
+fixtures before 1D, but product activation and real dispatch remain blocked.
 
 ## Program 3: Data Sovereignty Boundary v1
 

--- a/docs/superpowers/plans/2026-08-14-consultant-onboarding-minimal-graph-v1-implementation.md
+++ b/docs/superpowers/plans/2026-08-14-consultant-onboarding-minimal-graph-v1-implementation.md
@@ -1,3 +1,11 @@
+> **Status: Superseded — do not execute.**
+>
+> This historical plan would replace the current Experimental product UI and
+> withdraw its export, disclosure, and integrity paths before an authenticated
+> product router exists. Use the additive
+> [Consultant Playground Standalone v2 plan](2026-08-14-consultant-playground-standalone-v2-implementation.md)
+> instead; the body below is retained unchanged as design history.
+
 # Independent Consultant Synthetic Playground Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-08-14-consultant-playground-standalone-v2-implementation.md
+++ b/docs/superpowers/plans/2026-08-14-consultant-playground-standalone-v2-implementation.md
@@ -1,0 +1,261 @@
+# Consultant Playground Standalone v2
+
+**Status:** Target; additive product-learning slice.
+
+**Goal:** Let an independent consultant practice one fixed
+Company → Offer → Lead/Customer → Discovery thread, two fixed changes,
+compiled search, and deterministic guidance without reading, accepting,
+persisting, or exporting real business data.
+
+This plan adds `sovereign playground --port 7788`. It preserves the current
+Experimental `sovereign ui` product skeleton and all of its routes, assets,
+Workspace behavior, export, disclosure, integrity, and offline verification
+paths byte- and behavior-compatibly. That preservation is continuity, not a
+security endorsement.
+
+## Sources and boundary
+
+- [Security Architecture Program](2026-08-13-security-architecture-program.md)
+- [Architecture](../../../ARCHITECTURE.md)
+- [Roadmap](../../../ROADMAP.md)
+- [Threat model](../../../THREAT_MODEL.md)
+
+```text
+compiled fixture constants
+        |
+        v
+publish=false sovereign-consultant-playground leaf
+  private non-serializable graph
+        |
+        v
+process-local session -> one-way serializable read model
+        |
+        v
+exact loopback routes and embedded assets
+
+sovereign playground --port 7788 -> leaf run(7788)
+```
+
+The leaf has no dependency on Workspace, Vault, `dirs`, authority,
+capability, policy, model, effects, audit, workflow, or the CLI. It has no
+filesystem, environment, process, clock, randomness, outbound-network, import,
+export, or generic backend API. `tiny_http` is used only for one inbound server
+bound to literal `127.0.0.1`. It has no product authority and cannot read or
+mutate product state.
+
+The command does not open a browser. It accepts only built-in Clap parsing of
+`--port <u16>` with default `7788`; it accepts no root, path, Workspace,
+business value, configuration file, hidden flag, custom parser, or environment
+backend selector.
+
+## Exact synthetic domain
+
+`ConsultantPlaygroundGraph` is private and never implements `Serialize`,
+`Deserialize`, `save`, `load`, `export`, or a conversion to Workspace. Its
+compiled fixture is exactly:
+
+| Entity | Fixed value |
+| --- | --- |
+| Company | North Star Operations |
+| Offer | Reporting clarity sprint; initial price $2,500 |
+| Relationship | Acme Ltd; Alex Chen; `alex.chen@example.test`; Lead |
+| Discovery | Weekly reporting takes six hours; budget $3,000–$5,000; finance must approve; next step is a 30-minute scoping call |
+
+Human-language teaching facts are closed semantic keys with complete compiled
+English and Simplified Chinese catalogs. Names, the `.example.test` address,
+and numeric money are the only shared literals.
+
+Allowed actions are exactly:
+
+```text
+CorrectOfferPrice       $2,500 -> $3,500
+PromoteAcmeToCustomer   Lead -> Customer
+ShowReportingSearch     pure read
+Reset                   reconstruct exact fixture
+```
+
+No action accepts a string, ID, timestamp, price, status, query, patch, or
+arbitrary JSON value. Search and guidance are read-only. Restart reconstructs
+the exact fixture; it is not persistence, recovery, or resume.
+
+`PlaygroundReadModel` is a one-way serializable projection. Responses always
+state `profile = synthetic_playground`, `real_data_enabled = false`, and
+`persistence = none`. There is no constructor or conversion from a response
+DTO back into the graph or any product type.
+
+## Exact HTTP and asset surface
+
+The leaf serves only:
+
+| Method | Route |
+| --- | --- |
+| GET | `/` |
+| GET | `/assets/styles.css` |
+| GET | `/assets/i18n.js` |
+| GET | `/assets/app.js` |
+| GET | `/assets/consultant-ui.js` |
+| GET | `/favicon.svg` |
+| GET | `/api/playground/consultant` |
+| POST | `/api/playground/consultant/action` |
+
+There are no wildcard routes, aliases, query actions, uploads, forms for
+business data, cookies, CORS, telemetry, analytics, remote resources, or
+browser storage for exercise state. The POST body is a deny-unknown-fields
+object containing one closed unit action and is limited to 256 bytes. JSON and
+404 responses are typed and `Cache-Control: no-store`.
+
+The browser uses `textContent`, literal same-origin endpoints, local embedded
+assets, semantic HTML, keyboard-visible focus, 44-pixel targets, reduced-motion
+support, and a single-column 375-pixel layout. Beginner copy says plainly:
+
+> Practice with this example only. You cannot enter or save your own business
+> or customer data here. Real-data setup is unavailable in this preview.
+
+The Simplified Chinese catalog carries the same meaning. Trust-program names
+appear only in optional advanced details.
+
+## Product compatibility contract
+
+The implementation may add the leaf package, its assets/tests, one CLI
+dependency, and one additive `Playground` command/arm. It must not modify:
+
+- `Commands::Ui`, its help, port/default, `--no-open` flag, or match arm;
+- `apps/cli/src/ui.rs` or `apps/cli/assets/**`;
+- `apps/cli/src/workspace/**` or Workspace bytes and behavior;
+- `/api/export`, `/api/verify-export`, `/api/state`, disclosure browsing,
+  integrity, or Workspace routes;
+- `verify-export`, `integrity`, or any other existing command behavior.
+
+The top-level help changes only by listing the new `playground` command.
+Snapshot and process regressions pin the existing `ui` help/flags and current
+route transcripts before the additive change.
+
+A future authenticated product router remains Target. It may accept real
+Company/Offer/Relationship/Discovery values only when the actual landed
+`OwnerSession` authorization and actual `ActiveV2` protected storage selector
+are construction requirements. A Boolean, header, warning acknowledgement,
+environment flag, fake grant, or fixture type cannot substitute for either.
+
+## Implementation tasks
+
+Every behavior task uses genuine RED → minimal GREEN → focused gate →
+existing-product regression → independent review. Capture the failing test
+before code. Keep commits small and do not mix the owner/effect fixture into
+this branch.
+
+### Task 1 — Add the physical leaf and non-serializable graph
+
+Create `crates/consultant-playground` as `publish = false`. Register only the
+new workspace member/dependency and lockfile local-package edge. Create the
+private graph, closed semantic-key enum, exact fixture, and process-local
+session; do not add actions, HTTP, or assets yet.
+
+RED tests prove the exact fixture, deterministic reconstruction, graph
+invariants, absence of serde/persistence/product types, and exact package
+dependency surface.
+
+Suggested commit: `feat(playground): add fixed consultant teaching graph`.
+
+### Task 2 — Add closed actions, read models, localization, search, and guidance
+
+Implement only the four actions above. Add one-way response DTOs, exhaustive
+English/Chinese catalogs, fixed reporting search, and ordered guidance:
+correct price, promote lead, follow the recorded scoping call, then complete.
+
+RED tests compare every graph field before/after each action, prove search and
+guidance do not mutate, reject arbitrary values, exercise every fixture state,
+verify catalog/placeholder parity, and prove no response converts into a graph
+or Workspace.
+
+Suggested commit: `feat(playground): add fixed actions search and guidance`.
+
+### Task 3 — Add typed leaf HTTP contracts
+
+Add the deny-unknown-fields action request, stable error codes, bounded raw-body
+parser, and a handler whose only field is `Mutex<PlaygroundSession>`. Keep it
+inside the leaf; do not change CLI code in this task.
+
+RED tests cover exact success/error bodies and headers, empty/malformed/
+duplicate/unknown/oversized input, every disallowed method and Host, no CORS,
+and construction without a root, Store, Vault, authority, or backend.
+
+Suggested commit: `feat(playground): add typed synthetic http contracts`.
+
+### Task 4 — Serve exact assets and add the standalone command
+
+Add the exact server/route manifest and six embedded assets under the leaf.
+Add `Commands::Playground { port }` and the direct
+`sovereign_consultant_playground::run(port)?` arm. Preserve the existing `Ui`
+variant and arm exactly and do not launch a browser.
+
+RED tests prove:
+
+- one literal loopback bind and the exact route/asset graph;
+- browser calls only the two Playground endpoints;
+- no business input, persistence, remote resource, or hidden network API;
+- `sovereign playground --help` exposes only `--port` with default 7788;
+- `sovereign ui --help`, flags, startup arguments, route behavior, assets,
+  export, disclosure, integrity, and Workspace tests are unchanged;
+- leaf production sources have no Vault/Workspace/`dirs`/authority,
+  filesystem, environment, process, outbound-client, or include escape;
+- two real Playground processes under two content-distinct fake platform-data
+  roots return byte-identical complete HTTP transcripts and stdout/stderr,
+  contain no canary, and leave both roots recursively unchanged.
+
+Suggested commit: `feat(cli): add standalone consultant playground`.
+
+### Task 5 — Attack, accessibility, and product handoff
+
+Run an independent attack review over route closure, raw HTTP, source/dependency
+inventory, two-root process isolation, asset references, hostile rendered
+strings, action replay, and product compatibility. Record manual accessibility
+and five-consultant usability protocols as Target until real observations
+exist; never invent results.
+
+Update Current product docs only after code lands, using at most:
+
+> Synthetic consultant Playground: one fixed in-memory
+> Company/Offer/Lead/Discovery example, two fixed changes, compiled bilingual
+> search, and read-only guidance. It cannot accept, save, inspect, verify, or
+> export your business data.
+
+Suggested commit: `test(playground): review standalone isolation`.
+
+## Verification gates
+
+Focused gates must enumerate expected test names and reject zero/skipped tests.
+The final branch gate is:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+cargo test --workspace --locked
+cargo build -p sovereign-cli --release --locked
+npx -y -p typescript@5.5.4 tsc \
+  -p crates/consultant-playground/assets/tsconfig.json
+./scripts/check-file-size.sh
+git diff --check
+```
+
+Additionally compare the pre/post `sovereign ui --help` bytes and current UI
+route transcript, run the full Workspace/export/disclosure/integrity tests, run
+the two-root real-process test, inspect `cargo tree` for the leaf's exact
+dependencies, and scan the product diff to prove `apps/cli/src/ui.rs`,
+`apps/cli/assets/**`, and `apps/cli/src/workspace/**` are unchanged.
+
+## Exit criteria
+
+1. A non-specialist can understand and practice the fixed consultant thread in
+   English or Simplified Chinese without Trust Layer terminology.
+2. The graph is compiled, non-serializable, process-local, and accepts no real
+   business value or storage selector.
+3. Search/guidance cannot mutate, and the UI can request only four closed
+   actions.
+4. Two fake data roots remain byte-identical while real Playground processes
+   return identical canary-free transcripts.
+5. The current Experimental UI, export, disclosure, integrity, Workspace, and
+   offline verifier remain behavior-compatible.
+6. The Playground makes no AI, owner-authentication, Vault, E2EE, recovery,
+   persistence, or production-safety claim.
+7. Persistent real-data integration remains blocked on actual OwnerSession and
+   `ActiveV2` types, not a substitute flag or fixture grant.

--- a/docs/superpowers/plans/2026-08-14-owner-session-exact-effect-v1-implementation.md
+++ b/docs/superpowers/plans/2026-08-14-owner-session-exact-effect-v1-implementation.md
@@ -1,3 +1,12 @@
+> **Status: Superseded — do not execute.**
+>
+> This historical plan invented a custom HMAC/nonce/sequence IPC protocol,
+> coupled the fixture to the product CLI, and attempted to accept its own
+> effect RFC. Those choices conflict with the program-wide protocol and RFC
+> governance rules. Use the
+> [Synthetic Owner-UV and Exact Local-Outbox Fixture v2 plan](2026-08-14-synthetic-owner-exact-local-outbox-v2-implementation.md)
+> instead; the body below is retained unchanged as design history.
+
 # Synthetic Owner Session and Exact Local-Outbox Fixture v1 Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-08-14-synthetic-owner-exact-local-outbox-v2-implementation.md
+++ b/docs/superpowers/plans/2026-08-14-synthetic-owner-exact-local-outbox-v2-implementation.md
@@ -1,0 +1,472 @@
+# Synthetic Owner-UV and Exact Local-Outbox Fixture v2
+
+**Status:** Target — blocked until the closed RFC 0002 profile below is
+accepted through normal governance.
+
+**Goal:** Build a fixed-value fixture that can demonstrate a fresh
+user-verification ceremony authorizing one exact local `.eml` publication
+through the existing RFC 0003 and Capability V2 primitives, one durable
+reservation transaction, and conservative crash recovery.
+
+This is a security fixture, not product onboarding. It is not 1C0, Program 2
+completion, product authority, product-safe persistence, an email send, or
+E2EE.
+
+## Sources and prerequisites
+
+- [Security Architecture Program](2026-08-13-security-architecture-program.md)
+- [RFC 0002](../../../rfcs/0002-wasm-sandbox-and-plugin-capabilities.md)
+- [RFC 0003](../../../rfcs/0003-signed-approval-evidence.md)
+- [Threat model](../../../THREAT_MODEL.md)
+- [Contributing and RFC process](../../../CONTRIBUTING.md)
+
+Before implementation, a **separate PR** must amend RFC 0002 with the closed
+profile in this plan. That RFC stays Draft during discussion, receives at
+least the repository's seven-day substantial-change discussion period, and
+requires explicit maintainer acceptance with rationale. An implementation PR
+cannot accept its own RFC. Any accepted change to the profile updates this
+plan before code begins.
+
+The approval-retention fix is already Current at commit `6c0259b`. Do not
+reimplement it: durable approval claims retain the verified signed approval
+expiry, and token-expiry purge, store reopen, replay denial, and
+approval-expiry purge are tested. The larger reservation is still missing.
+
+## Chosen architecture
+
+```text
+browser at fixed loopback origin
+        |
+        v
+one release-excluded fixture process
+  - HTTP origin and closed routes
+  - WebAuthn UV, session and CSRF state
+  - RFC 0003 approval ceremony
+  - sole redb coordinator
+  - fixed Core Wasm invocation
+  - exact local-outbox publisher
+        |
+        v
+value-free synthetic evidence
+```
+
+The independent `publish = false` fixture executable owns the entire path.
+It has one public listener bound to `127.0.0.1:7787`, with origin
+`http://localhost:7787` and RP ID `localhost`. It acquires and retains an OS
+file lock **before** opening redb. There is no internal listener or private
+transport: all owner, session, coordinator, and outbox calls are ordinary
+typed calls inside the same process.
+
+The fixture package may be a workspace member for tests, but it is excluded
+from product packaging and is not a dependency of `sovereign-cli`.
+`sovereign-cli`, `apps/cli/**`, and the current product UI are untouched.
+Clean product release graphs and symbols must exclude the fixture package,
+redb, and WebAuthn dependencies.
+
+### Rejected design
+
+Do not implement the superseded HMAC transport, launch key/nonce, sequence
+protocol, connection registration/revocation, hidden child mode, broker child
+process, or second/ephemeral TCP listener. Process separation can return only
+after a concrete threat and a separately reviewed standard transport justify
+it.
+
+## Capability verification and authority seam
+
+Current `CapabilityValidatorV2` mixes COSE/context verification with
+side-effecting `AuthorityStore` consumption. Before the fixture implements any
+transaction, split that path into a side-effect-free cryptographic and context
+verifier. It returns an opaque `VerifiedCapabilityV2` and, when approval is
+required, an opaque `VerifiedApprovalV1`. Both proof types have private fields,
+no public constructor, and no `Clone`, `Serialize`, or `Debug` implementation.
+Narrow read-only accessors may expose already-verified bindings needed by the
+coordinator, but the coordinator must consume each proof by value.
+
+Pure verification must not mutate process-local replay state, open or write an
+`AuthorityStore`, or reserve any claim. The existing pure-compute
+`authorize_and_consume*` wrappers temporarily call this verifier and then
+perform the current `AuthorityStore` token, idempotency, and approval
+operations with unchanged ordering, error behavior, and regression results.
+That compatibility path remains non-transactional. This slice does not invert
+or remove the current capability-to-authority dependency; dependency inversion
+is a separately reviewed follow-up plan, not hidden fixture work.
+
+The new fixture coordinator lives in an upper, release-excluded crate that
+depends on both capability verification and authority primitives. Neither
+lower crate gains a reverse dependency, so there is no
+authority-to-capability-to-authority cycle. The coordinator must never copy
+COSE, canonicalization, trust, policy, approval, or context checks, and it must
+never call the legacy consuming validator before opening its own transaction.
+It accepts only the opaque verified proofs and commits approval claim,
+capability/token claim, idempotency binding, synthetic authority-node use, and
+intent transition in one redb transaction.
+
+Only a successful coordinator reservation can construct the private
+`AuthorityReservedEffect`. Its fields and constructor are private, it has no
+reconstruction accessor, and it implements neither `Clone`, `Serialize`, nor
+`Debug`. The sole exact-outbox publish entry consumes that type by value; there
+is no raw-ID, raw-redb, boolean, test-only, or alternate constructor that can
+reach it.
+
+## Closed RFC 0002 profile to propose
+
+The amendment defines one structured Target profile; it is never parsed from
+a dotted or free-form string:
+
+```text
+risk_class   = low-risk-effectful
+backend      = core-wasm
+abi          = sovereign_core_wasm_v2
+tool_id      = local_outbox
+tool_version = 1.0.0
+operation_id = write_rfc5322
+```
+
+The profile permits only the fixed synthetic recipient
+`fixture-recipient@example.test` and fixed compiled sender, subject, and body.
+Every address is under `.example.test`. The Core Wasm guest has no ambient
+filesystem, network, environment, clock, randomness, or host-call surface.
+It receives authenticated canonical input and returns a closed result; the
+trusted coordinator alone owns publication.
+
+The coordinator allocates a random 128-bit `effect_intent_id` before reading
+the compiled values, then seals the exact normalized recipient, exact RFC 5322
+bytes, exact coordinator-derived outbox-relative path, operation, policy and
+invocation binding, expiry, fixture generation, and signer epoch. A changed
+byte or field creates a new intent and requires a new preview and approval.
+
+## Owner mechanism and honest label
+
+The fixture uses a maintained WebAuthn library through its safe API. Freeze a
+mechanism-matrix row before enabling a real browser/OS combination: exact OS,
+browser, authenticator class, UV result, origin, cookie behavior, stored
+credential behavior, and localhost cross-port residuals. A deterministic
+virtual authenticator is test evidence only.
+
+Empty-registry enrollment is `UnqualifiedFixtureBootstrap`: first valid UV
+wins. It does not identify the intended owner against another same-account
+native process. The fixture admits one credential, has no recovery or second
+credential, and loss requires destroying the synthetic fixture.
+
+After acquiring the retained OS lock and before opening redb, every fixture
+process generates a fresh, per-process `TypedSigner<ApprovalRole>` and a random
+signer epoch. A closed `ApprovalBridge` owns the signer privately: it exposes
+no signer getter, secret export, generic signing method, or serialization path.
+The bridge itself is not cloneable, serializable, or debuggable. Keep the
+dependency's zeroize-on-drop support enabled, keep the secret key only in
+process memory, and exclude it from logs, redb, backups, and crash evidence.
+After redb opens, it records only the corresponding approval-role public trust
+record, random signer epoch, and explicit `unqualified_fixture` label for
+historical verification and reconciliation.
+
+After login, the process issues a memory-only session with a 15-minute
+absolute lifetime, five-minute idle lifetime, one Secure/HttpOnly/SameSite
+cookie, and an independent memory-only CSRF value. Exact Host, Origin, Fetch
+Metadata, JSON media type, and bounded-body checks protect every JSON route.
+Logout revokes the session, pending challenges, and unreserved approvals.
+
+Session presence is not approval. After the exact preview, successful fresh UV
+creates one opaque `FreshUvGrant`. It has private fields and no public
+constructor, and is neither `Clone`, `Serialize`, nor `Debug`. The grant is
+one-use and bound to the exact session ID, session generation/logout epoch,
+credential ID, WebAuthn challenge, signer epoch, effect intent, invocation,
+policy decision, fixture generation, and expiry.
+
+`ApprovalBridge::approve_invocation` is the only signing entry point. It
+consumes the grant by value, rechecks every binding and expiry, and then emits
+one RFC 0003 COSE/Ed25519 approval over the existing canonical claim. Reuse the
+existing role separation and canonical bytes; add no cryptographic primitive,
+key derivation, signature envelope, or parallel freshness protocol.
+
+A restart creates a new signer epoch and invalidates all earlier sessions and
+in-memory grants. Persisted `Prepared` or `AuthorityReserved` work bound to an
+older epoch fails closed as `FailedBeforeDispatch`, after proving no writer I/O
+occurred, and is never automatically re-signed. Historical public trust
+records can verify existing evidence or support reconciliation only; they can
+never activate the old signer epoch. Persisted `Dispatching` work does not use
+the new signer for authorization and reconciles only to `Succeeded` or
+`Indeterminate`. These rules still describe a first-writer
+`unqualified_fixture`; they do not provide owner continuity, credential
+recovery, role-key custody, or satisfy 1C0/1C1.
+
+The final loopback route manifest is closed and fixed before HTTP code lands:
+
+| Method | Route |
+| --- | --- |
+| GET | `/` and the exact embedded fixture assets |
+| POST | `/api/fixture/auth/register/start` |
+| POST | `/api/fixture/auth/register/finish` |
+| POST | `/api/fixture/auth/login/start` |
+| POST | `/api/fixture/auth/login/finish` |
+| POST | `/api/fixture/effect/prepare` |
+| POST | `/api/fixture/effect/preview` |
+| POST | `/api/fixture/effect/approve/start` |
+| POST | `/api/fixture/effect/approve/finish` |
+| POST | `/api/fixture/effect/dispatch` |
+| POST | `/api/fixture/effect/reconcile` |
+| POST | `/api/fixture/auth/logout` |
+
+There are no API GETs, aliases, query actions, wildcard handlers, redirects,
+or method overrides. Registration/login are the only pre-session routes; all
+effect and logout routes require the live cookie and independent CSRF value.
+
+## Durable coordinator and effect state
+
+The side-effect-free verifier authenticates the capability, approval, policy,
+invocation, and exact context before reservation. One redb write transaction
+then rechecks the verified bindings against current durable state and commits
+all of the following together:
+
+```text
+approval claim (retained through signed approval expiry)
+capability/token claim
+idempotency binding to random effect_intent_id
+synthetic authority-node use/decrement
+Prepared -> AuthorityReserved
+```
+
+The coordinator consumes `VerifiedCapabilityV2` and `VerifiedApprovalV1` by
+value. In the transaction it matches their exact structured profile, policy,
+intent, fixture generation, signer epoch, session/logout epoch, expiry, and
+synthetic authority record. It neither repeats cryptographic verification nor
+calls the legacy consuming validator. No public API accepts raw claim IDs, a
+raw redb handle, recipient bytes, RFC 5322 bytes, or a generic writer.
+
+Required states are:
+
+```text
+Prepared -----------> AuthorityReserved -----------> Dispatching
+   |                         |                           |-> Succeeded
+   `-> FailedBeforeDispatch  `-> FailedBeforeDispatch  `-> Indeterminate
+```
+
+Immediately before committing `Dispatching`, the same transaction rechecks
+the live session/logout epoch, policy, prepared intent, capability, authority,
+fixture generation, signer epoch, and every expiry/revocation generation. A
+losing race may commit `FailedBeforeDispatch` only before `Dispatching` and
+with a live proof that no payload byte reached the writer. Once `Dispatching`
+has committed, reconciliation has only `Succeeded` or `Indeterminate` outcomes.
+
+The coordinator durably commits `Dispatching` before touching the filesystem.
+It publishes `<effect_intent_id>.eml` through an owner-only same-directory
+temporary file, flush, no-replace publication, and directory flush. After a
+crash, an identical final file may reconcile to `Succeeded`; absence,
+difference, wrong type, unreadability, or uncertain durability is
+`Indeterminate`. `Dispatching` and `Indeterminate` never retry, rewrite,
+delete, fail over, or suggest that a send occurred.
+
+Signed fixture evidence contains only version/type, random event ID, random
+intent ID, closed outcome, prior-event hash, synthetic public signer identity,
+event hash, and signature. It contains no recipient/content, path, size, exact
+time, business identifier, or deterministic digest of a low-entropy value.
+
+## Scope and product gates
+
+The fixture accepts no product root, Workspace, Vault, import, migration,
+business value, provider credential, attachment, SMTP setting, or arbitrary
+path. Its redb data may contain fixed synthetic plaintext and is not a Vault
+or product persistence boundary.
+
+Product enablement remains blocked on all applicable Security Architecture
+Program gates, including an independently admitted 1C0 owner, 1C1 custody,
+1B1 recovery qualification, Program 1D `ActiveV2`, a reviewed protected
+payload design, and the accepted effect profile. A mechanism-matrix pass cannot
+promote the fixture into product authority.
+
+## Implementation tasks
+
+Each task uses genuine RED → minimal GREEN → focused gate → workspace
+regression → independent review. Capture the RED diagnostic before
+production code and make one reviewable commit per task.
+
+### Task 0 — Governance gate (separate PR; blocks every code task)
+
+Modify only RFC 0002 and its direct index/threat-model references. Add the
+closed structured profile, exact fixture-only limits, one-transaction
+reservation, state machine, value-free evidence, and non-claims above. Follow
+the full RFC process; do not mark it Accepted from an implementation branch.
+
+Gate:
+
+```bash
+git diff --check
+rg -n 'low-risk-effectful|write_rfc5322|Indeterminate' \
+  rfcs/0002-wasm-sandbox-and-plugin-capabilities.md
+```
+
+Stop until maintainers accept the RFC.
+
+### Task 1 — Separate verification from consumption
+
+Before creating any fixture transaction, refactor `CapabilityValidatorV2` so
+its COSE, RFC 0003, trust, canonical-binding, policy, invocation, context, and
+expiry checks are one side-effect-free path. That path returns the opaque
+`VerifiedCapabilityV2` and `VerifiedApprovalV1` proof types described above.
+
+RED tests and compile-fail fixtures must establish that:
+
+- running pure verification repeatedly changes neither process-local replay
+  state nor any attached/on-disk `AuthorityStore`;
+- neither verified proof is cloneable, serializable, debuggable, publicly
+  constructible, or field-constructible;
+- the legacy pure-compute wrappers invoke the pure verifier and then preserve
+  their current AuthorityStore operation order, errors, replay behavior,
+  approval-retention behavior, and complete regression suite; and
+- the dependency graph gains no authority-to-capability edge.
+
+Do not duplicate verification and do not invert the existing
+capability-to-authority dependency in this task. Record dependency inversion as
+a separate follow-up plan.
+
+Suggested commit: `refactor(capability): separate verification from consumption`.
+
+### Task 2 — Establish the release-excluded single-process boundary
+
+Create the upper `publish = false` fixture package, depending on capability
+verification and authority primitives, plus the exact root classifier,
+retained OS lock, sole redb open, fixed loopback listener, and boundary script.
+Add no owner or effect behavior yet.
+
+RED tests:
+
+- product Cargo tree and release symbols contain no fixture, redb, or WebAuthn;
+- a second real fixture process fails on the OS lock before attempting redb
+  open; this is the only two-live-process claim in this slice;
+- lock acquisition precedes the only production redb open;
+- product/unmarked/symlink roots fail before listener or database state;
+- source inventory contains one listener and no internal transport module; and
+- Cargo metadata confirms the upper dependency seam and no dependency cycle.
+
+Suggested commit: `test(fixture): establish single-process owner boundary`.
+
+### Task 3 — Add unqualified WebAuthn UV, session, CSRF, and signer epoch
+
+Add the exact registration/login route schemas, one-credential registry,
+mechanism matrix, memory sessions, request middleware, and complete logout.
+After the retained lock and before redb open, generate the ephemeral
+`TypedSigner<ApprovalRole>`, random signer epoch, and closed `ApprovalBridge`;
+persist only the labelled public trust record after redb opens. Do not add
+effect publication.
+
+RED tests cover first-writer-wins non-admission, required UV, exact origin/RP,
+stored-credential allowlist, 300-second one-use ceremonies, cookie/CSRF
+independence, absolute/idle expiry, cross-port cookie and credential DoS,
+logout races, restart invalidation, destructive credential loss, ordering of
+lock/signer/redb initialization, signer-epoch rotation, non-exportability, no
+secret bytes in redb/backup/log output, and historical-key verify-only status.
+The dependency profile must retain secret-key zeroization support.
+
+Suggested commit: `feat(fixture): add unqualified owner uv sessions`.
+
+### Task 4 — Seal the intent and bridge fresh UV to RFC 0003
+
+Allocate the random intent before content access; compose fixed CRLF RFC 5322
+bytes inside the coordinator; persist only the private sealed fixture payload;
+and render a fixed synthetic preview. Successful fresh UV creates the
+non-cloneable, non-serializable, non-debuggable `FreshUvGrant` with every exact
+binding above. Only `ApprovalBridge::approve_invocation`, consuming that grant,
+may produce RFC 0003 evidence. Validate the accepted RFC 0002 profile and
+create exact Capability V2 claims.
+
+RED tests cover byte/recipient substitution, header injection, intent
+randomness, approval/capability binding, approval expiry, session-alone denial,
+challenge or grant replay, credential/session/logout/signer-epoch mismatch,
+restart invalidation, absence of signer getters or generic sign methods, no
+automatic re-sign of old pre-dispatch work, no generic value input, and
+compile-fail access to private proof, grant, payload, or constructor fields.
+
+Suggested commit: `feat(fixture): bridge fresh uv to exact approval`.
+
+### Task 5 — Reserve every authority fact in one redb transaction
+
+Implement the sole coordinator write-transaction helper. It consumes the
+opaque verified capability and approval proofs and atomically reserves their
+claims, idempotency binding, synthetic authority node/use, and intent
+transition. It returns the privately constructible `AuthorityReservedEffect`.
+Never call the legacy consuming validator first and never duplicate its crypto
+checks. Carry the already-fixed signed approval expiry into the redb claim; do
+not add a second retention implementation.
+
+RED tests cover every named failpoint between logical mutations with full
+rollback, real process kill immediately before and after commit followed by
+reopen, same-process concurrent HTTP requests/threads racing one intent with
+one reservation winner, same-key idempotent replay, different-intent conflict,
+expiry/revocation/logout/signer-epoch races, and reopen with either all or none
+of the reservation. A second real process is tested only for pre-redb lock
+denial. Compile-fail cases reject constructing, cloning, serializing,
+debug-formatting, destructuring, or reconstructing `AuthorityReservedEffect`.
+A full cross-process validator race remains Target and unqualified.
+
+Suggested commit: `feat(fixture): reserve exact authority atomically`.
+
+### Task 6 — Publish once and reconcile conservatively
+
+Run the fixed import-free Core Wasm step, accept only the private
+`AuthorityReservedEffect`, commit `Dispatching`, publish the exact local file,
+reconcile without writing, and append value-free signed fixture evidence. Add
+release-excluded named failpoints at every state and filesystem boundary.
+
+RED tests cover absence of any alternate writer entry; compile-fail attempts to
+reuse the handle after move or manufacture concurrent cloned handles; guest
+imports; changed output; first/partial write; temp flush; publication;
+directory flush; terminal commit; identical/different/absent reopen; restart
+of old pre-dispatch work to `FailedBeforeDispatch`; restart of `Dispatching`
+only to `Succeeded` or `Indeterminate`; no retry or automatic re-sign after
+ambiguity; no recipient/content/digest in evidence; and a table/path-aware
+synthetic canary allowlist.
+
+Suggested commit: `feat(fixture): publish exact local outbox once`.
+
+### Task 7 — Qualification and handoff
+
+Run at least 25 real process-kill/reopen iterations per crash boundary and 100
+iterations per same-process concurrent HTTP/thread reservation, logout, and
+dispatch race. Run the virtual-browser matrix and each attended real mechanism
+row separately. Publish a limitations/evidence note that cannot change product
+status and explicitly leaves the full cross-process validator race Target.
+
+Final gate:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+cargo test --workspace --locked
+./scripts/check-file-size.sh
+./scripts/check-synthetic-owner-effect-boundary.sh
+cargo tree -p sovereign-cli --locked
+cargo build -p sovereign-cli --release --locked
+git diff --check
+```
+
+Also run the fixture-specific browser, crash, race, canary, compile-fail, and
+exact-test manifests. Reject zero/skipped tests. Record exact toolchain,
+platform, mechanism row, commands, results, and commit; keep all unsupported
+rows Target.
+
+## Exit criteria
+
+The fixture is qualified only when:
+
+1. pure verification has no replay/store side effect, its opaque proof objects
+   cannot be forged or cloned through public APIs, and every legacy
+   pure-compute authorization regression remains unchanged. Repeating
+   independent pure verification is allowed; one-use is enforced only by the
+   redb reservation transaction;
+2. one process and one public listener own the complete synthetic path, while
+   a second process is denied on the OS lock before redb open;
+3. the ephemeral approval signer is memory-only and bridge-confined, and fresh
+   UV yields a one-use exact-bound grant rather than treating session presence
+   as approval;
+4. one redb transaction consumes verified approval, token, idempotency,
+   authority-node, and intent state; every partial failpoint rolls all of them
+   back and a same-process concurrent race has one winner;
+5. only the coordinator can construct `AuthorityReservedEffect`; it cannot be
+   cloned, serialized, debugged, destructured, reconstructed, or reused after
+   move, and no other writer entry exists;
+6. exact bytes are sealed before approval and published at most once;
+7. old pre-dispatch work never gains a new signature, and every ambiguous
+   post-`Dispatching` observation is `Indeterminate` with no retry;
+8. evidence is value-free and product release graphs exclude the fixture; and
+9. documentation still calls it a synthetic, unqualified, plaintext fixture,
+   leaves full cross-process validator qualification Target, and makes no
+   email, owner-continuity, 1C0/1C1, Vault, or E2EE claim.

--- a/docs/superpowers/specs/2026-08-13-data-sovereignty-boundaries-v1-design.md
+++ b/docs/superpowers/specs/2026-08-13-data-sovereignty-boundaries-v1-design.md
@@ -520,8 +520,10 @@ This design is intentionally decomposed. Each stage gets its own plan, tests, re
 3. **Authority + Exact Effect Protocol v1 (local outbox first):** bind exact
    effect bytes/recipient/provider/resource to the 1C0 approval, Capability V2,
    durable authority reservation, execution journal, effect outcome, and signed
-   evidence. Fix approval retention and define `Indeterminate`; no real network
-   effect bypasses this state machine.
+   evidence. Build on the completed approval-expiry retention fix, move the
+   still-ordered token/idempotency/approval claims into one recoverable
+   reservation, add revocation and real-subprocess races, and define
+   `Indeterminate`; no real network effect bypasses this state machine.
 4. **Vault Program 1B0 — backup/restore mechanics:** add the separately
    encrypted business backup, trust-continuity artifact, loss-matrix tests,
    rotation, and clean-machine harness from a closed backup registry. Snapshot

--- a/rfcs/0002-wasm-sandbox-and-plugin-capabilities.md
+++ b/rfcs/0002-wasm-sandbox-and-plugin-capabilities.md
@@ -348,13 +348,22 @@ experimental pure-compute backend and can never authorize a host effect.
 The current `sovereign-authority` primitive persists token, idempotency, and
 approval claims as three sequential atomic filesystem operations; partial
 failure burns earlier claims and fails closed. It has no transaction or
-revocation API. Approval retention is currently derived from the shorter
-capability expiry rather than approval expiry, so approval one-use is not yet
-restart-safe after purge. Tests cover reopen behavior and concurrent threads,
-not a true subprocess race for all three claim types. Validators without an
-attached store remain process-local. V2 tokens stay restricted to pure
-computation until this gap, crash-safe effect ordering, and reviewed host
+revocation API. Durable approval claims now retain the verified signed
+approval expiry rather than the shorter capability expiry. Tests expire and
+purge the first token, reopen the store while the approval remains valid,
+reject a second token's reuse, and purge the approval at its own expiry. The
+three claims are still ordered filesystem operations rather than one
+transaction, and tests do not yet cover a full real-subprocess validator race
+across all three claim types. Independently admitted owner presence also
+remains absent. Validators without an attached store remain process-local. V2
+tokens stay restricted to pure computation until transactional reservation,
+revocation, crash-safe effect ordering, owner authority, and reviewed host
 interfaces are complete.
+
+Any future RFC 0002 exact-effect profile amendment starts from this Current
+approval-retention fact. It must not plan to fix retention again; its remaining
+authorization work is the one-transaction reservation, revocation, complete
+race/restart evidence, exact effect binding, and owner-authority integration.
 
 Production time comes from a trusted runtime clock. An untrusted caller cannot provide the validation timestamp.
 
@@ -433,9 +442,10 @@ Admission and executor tests cover on-disk substitution, record tampering,
 cross-role signatures, poisoned/symlinked entries, mandatory admitted handles,
 cache poisoning, store reopen, and concurrent token claims across threads.
 Mandatory worker/cache wiring on product paths, full cache-record binding and
-strict parsing, real subprocess claim races, approval retention, transactional
-authorization and revocation, durable effect-intent ordering, Component/WIT
-behavior, and capability-bound host interfaces remain completion-gate work.
+strict parsing, full real-subprocess validator races, transactional
+authorization and revocation, durable effect-intent ordering, independently
+admitted owner presence, Component/WIT behavior, and capability-bound host
+interfaces remain completion-gate work.
 
 ## Implementation Phases
 

--- a/rfcs/0003-signed-approval-evidence.md
+++ b/rfcs/0003-signed-approval-evidence.md
@@ -103,19 +103,21 @@ rejected.
 ## Replay and Durability (honest labels)
 
 Approval one-use accounting is process-local when no Authority Store is
-attached. The Workspace attaches persistent filesystem claims, but the current
-validator stores approval consumption only until the shorter capability expiry,
-not the approval's own expiry. After capability expiry and purge, the same
-still-valid approval may be presented with a newly issued token. Durable
-one-use approval is therefore **not claimed**.
+attached. When the Workspace attaches the current filesystem Authority Store,
+the durable approval claim now retains the verified signed approval's own
+expiry rather than the shorter capability-token expiry. Tests expire and purge
+the first token, reopen the store while the approval remains valid, reject a
+second token's reuse, and purge the approval at its own expiry.
 
-The implementation target retains approval consumption through approval
-expiry (and any required audit-retention window), reserves token/approval/
-idempotency in one recoverable transaction, supports durable revocation, and
-proves behavior using real subprocess restart/race tests. Approval evidence is
-also necessary but not sufficient for an external effect: independent owner
-presence, exact effect preview/payload binding, durable intent/result ordering,
-and a reviewed host broker remain required.
+This is still a partial durability boundary. Token, idempotency, and approval
+claims are ordered filesystem operations, not one recoverable transaction;
+partial failure burns earlier claims and fails closed. Durable revocation, a
+full real-subprocess validator race, and an independently admitted owner
+ceremony remain Targets. RFC 0003 is therefore not a complete human-approval
+or product-authority claim. Approval evidence is also necessary but not
+sufficient for an external effect: independent owner presence, exact effect
+preview/payload binding, durable intent/result ordering, and a reviewed host
+coordinator remain required.
 
 ## Threat Cases (tested)
 
@@ -125,13 +127,13 @@ and a reviewed host broker remain required.
 - Expired approval, future-dated approval, approval predating its policy
   decision, and out-of-range lifetime.
 - Approval reuse across two tokens before persistent-record purge (second
-  consumption denied).
+  consumption denied), and after the first token's expiry/purge plus Authority
+  Store reopen while the signed approval remains valid.
 - Evidence supplied when policy does not require approval.
 - Token claiming approval evidence that does not match the presented object,
   or presented without any object.
 - Legacy behavior preserved: issuance without evidence fails closed for
   approval-required decisions.
 
-Target regression coverage additionally expires and purges the first token,
-restarts in a new process while the approval remains valid, and proves that a
-new token cannot reuse the approval.
+Target regression coverage still adds a true subprocess validator race and
+durable revocation; current reopen coverage does not establish either one.


### PR DESCRIPTION
## Outcome

Replaces two conflicting execution plans without changing production code.

- The owner/exact-effect reference becomes a release-excluded, single-process fixture with no invented HMAC/TCP IPC protocol.
- The consultant playground becomes an additive `sovereign playground` path and preserves the current Experimental UI, Workspace, disclosure, integrity, and export surfaces.

## Security corrections

- requires a separate RFC 0002 amendment and normal governance before any effect implementation;
- specifies side-effect-free opaque capability verification before one redb reservation transaction;
- defines a one-use fresh-UV grant and process-ephemeral ApprovalRole signer boundary;
- separates same-process reservation races from real second-process lock rejection;
- synchronizes the merged approval-retention fix while preserving the remaining non-transactional/revocation/owner-admission limits.

## Validation

- independent review: APPROVED after one fix cycle (0 Critical / 0 Important / 0 Minor);
- Rust 1.97 workspace fmt, all-features Clippy, 186 tests, and file-size guard passed;
- Markdown fences, relative links, scope, stale-wording and `git diff --check` passed.

Documentation only. It does not implement owner admission, exact effects, Vault v2, remote compute, or E2EE.