### PR TITLE
docs(vault): complete Task 1 dependency profile

### DIFF
--- a/docs/superpowers/plans/2026-08-13-dual-root-vault-v2-implementation.md
+++ b/docs/superpowers/plans/2026-08-13-dual-root-vault-v2-implementation.md
@@ -54,6 +54,7 @@ tempfile = "=3.27.0"
 sha2 = { version = "=0.10.9", default-features = false }
 syn = { version = "=2.0.118", default-features = false,
   features = ["full", "parsing", "visit"] }
+proc-macro2 = { version = "=1.0.106", default-features = false }
 static_assertions = "=1.1.0"
 trybuild = "=1.0.116"
 
@@ -106,7 +107,11 @@ cargo fetch --manifest-path Cargo.toml --target x86_64-unknown-linux-gnu
 
 This exception MUST NOT run `cargo update`, `cargo generate-lockfile`,
 `cargo metadata`, `cargo tree`, `cargo check`, `cargo build`, `cargo test`, or
-any other dependency/build script. Review the resulting lock diff and require
+any other dependency/build script. If this sole fetch attempt fails or leaves
+partial state for any reason, stop for plan/RFC amendment and re-review. Do not
+retry it, and do not reuse a pre-existing Cargo home, copied registry, or warmed
+cache while describing the result as the required fresh-home transition.
+Review the resulting lock diff and require
 every pre-existing `(name, version, source)` entry to be unchanged; only the
 engine package and its exact Task 1 dependency closure may be added. Record the
 post-transition lock SHA-256 and the completed review, then run
@@ -148,25 +153,34 @@ including `LIBSQLITE3_SYS_USE_PKG_CONFIG`, `LIBSQLITE3_FLAGS`,
 this as a closed allowlist: a newly observed dependency-shaping or tool-
 selection variable stops for RFC review. It also removes `PERL5OPT`,
 `PERL5LIB`, `RUSTFLAGS`, `CARGO_ENCODED_RUSTFLAGS`, and unapproved linker/tool
-overrides; resolves Cargo, rustc, C compiler, archiver, ranlib, Perl, and make
-from an approved path set; and records their canonical paths, versions, and
-SHA-256 digests. Qualification is `--frozen --offline` after the reviewed
-one-time lock transition and a separate `cargo fetch --locked` acquisition
-step, so the controlled child does not run network acquisition. A new tool or
-environment input stops for review.
+overrides; resolves Cargo, rustc, rustdoc, cargo-clippy, clippy-driver, C
+compiler, archiver, ranlib, Perl, and make from an approved path set; and
+records their canonical paths, versions, and SHA-256 digests. Qualification is
+`--frozen --offline` after the reviewed one-time lock transition and a separate
+`cargo fetch --locked` acquisition step, so the controlled child does not run
+network acquisition. A new tool or environment input stops for review.
 
 The child starts from `env -i` and receives only fresh `HOME`/`TMPDIR`, the
 reviewed Cargo/rustup homes, `LANG`/`LC_ALL`, fixed `SOURCE_DATE_EPOCH`, exact
-absolute Cargo/rustc/rustdoc/C compiler/archiver/ranlib paths, the exact
-`CARGO_BUILD_TARGET`, `CARGO_NET_OFFLINE=true`, and a PATH assembled only from
-the reviewed Perl/make/linker directories. Qualification rejects every Cargo
-config file that Cargo would discover in the repository/ancestors or selected
-`CARGO_HOME`, not only source replacement, and rejects caller `--config`.
-Program 1A has no approved Cargo-config extension surface; this closes
-`target.*.rustflags` routes that could replace the default `getrandom` backend
-or otherwise mutate code generation. Cargo-created build-script variables such as
-`HOST`, `TARGET`, `OUT_DIR`, and `CARGO_MAKEFLAGS` are allowed only inside the
-child and are recorded where relevant; they are not accepted from the caller.
+absolute `CARGO`, `RUSTC`, `RUSTDOC`, C compiler, archiver, and ranlib paths,
+plus wrapper-private absolute `SOVEREIGN_CARGO_CLIPPY` and
+`SOVEREIGN_CLIPPY_DRIVER` bindings, the exact `CARGO_BUILD_TARGET`,
+`CARGO_NET_OFFLINE=true`, and a PATH assembled only from the reviewed
+Perl/make/linker directories. Qualification rejects every Cargo config file
+that Cargo would discover in the repository/ancestors or selected `CARGO_HOME`,
+not only source replacement, and rejects caller `--config`. Program 1A has no
+approved Cargo-config extension surface; this closes `target.*.rustflags`
+routes that could replace the default `getrandom` backend or otherwise mutate
+code generation. Cargo-created build-script variables such as `HOST`, `TARGET`,
+`OUT_DIR`, and `CARGO_MAKEFLAGS` are allowed only inside the child and are
+recorded where relevant; they are not accepted from the caller. The wrapper
+invokes normal Cargo commands through the absolute `CARGO` binding. For Clippy
+it invokes `SOVEREIGN_CARGO_CLIPPY` directly, never `cargo clippy`, and exports
+that same absolute `CARGO` binding for cargo-clippy's Cargo child. Before Clippy
+runs, the canonical `clippy-driver` sibling selected by that exact cargo-clippy
+executable MUST equal the independently reviewed, hashed, and absolute
+`SOVEREIGN_CLIPPY_DRIVER` binding. Neither Clippy executable may be selected
+through the child PATH.
 
 `crates/vault-v2-engine/build.rs` repeats the checks as defense in depth, but a
 downstream build script runs too late to prevent an overridden upstream
@@ -510,15 +524,26 @@ target explicitly.
 Project-authored `macro_rules!` and all other macro definitions are forbidden.
 Every macro invocation, attribute, and derive uses a closed allowlist. In
 addition to normal AST visiting, the visitor recursively scans every
-`syn::Macro.tokens` token tree, including nested groups, and rejects `unsafe`,
-`extern`, raw symbol names, `include`, `path`, and every other forbidden token;
-no allowed macro may generate additional project-authored FFI or unsafe code.
-Separate production and `cfg(test)` allowlists detect direct and aliased paths,
-glob imports, raw symbol declarations, and calls, proving exactly two
-project-authored production unsafe FFI entry points plus the single test-only
-OpenSSL LOAD_CONFIG negative control. Required mutation tests hide a third
-unsafe/FFI declaration or call first in a macro definition and then in macro
-invocation tokens; both mutations must fail the source-closure gate.
+`syn::Macro.tokens` token tree structurally through the direct exact dev
+dependency
+`proc-macro2 = { version = "=1.0.106", default-features = false }`, including
+nested `proc_macro2::TokenTree::Group` streams, and rejects `unsafe`, `extern`,
+raw symbol names, `include`, `path`, and every other forbidden token. The
+`proc-macro2 1.0.106` tuple already exists in the pre-transition baseline lock,
+but Task 1 still adds and reviews the engine's direct dev-dependency edge and
+enabled feature set while requiring that old tuple to remain unchanged.
+`syn::__private`, token-stream stringification, and Debug/Display text scans are
+forbidden anywhere in the source-closure gate. Recursion, token classification,
+and every allow/deny decision use the public `proc_macro2::TokenTree` structure;
+exact identifier classification may inspect only the individual `Ident` token's
+value, never serialized enclosing token or group text. No allowed macro may
+generate additional project-authored FFI or unsafe code. Separate production
+and `cfg(test)` allowlists detect direct and aliased paths, glob imports, raw
+symbol declarations, and calls, proving exactly two project-authored production
+unsafe FFI entry points plus the single test-only OpenSSL LOAD_CONFIG negative
+control. Required mutation tests hide a third unsafe/FFI declaration or call
+first in a macro definition and then in macro invocation tokens; both mutations
+must fail the source-closure gate.
 
 The fixed fixture is at least 8192 bytes and page-aligned. The named
 `page_2_ciphertext_bitflip_is_detected_cryptographically` test copies it to a
@@ -563,6 +588,16 @@ This five-case constraint does not prohibit a later, separately declared Cargo
 test target and fixture root; Task 2 recovery UI evidence never enters this
 harness or group.
 
+These five compile-fail cases are acceptance evidence, not meaningful initial
+RED while the engine implementation is absent: absence already makes forbidden
+names fail to compile. Behavior/profile/API tests must supply the first genuine
+RED. Before accepting the boundary, expose each forbidden boundary one at a
+time only in a temporary copy or temporary mutation and require trybuild to
+fail because the case unexpectedly compiled. Never commit a leak feature,
+public probe API, or mutation. Restore the source after every case, then require
+all five reviewed fixtures to pass. A missing package, missing fixture,
+unresolved dependency, or zero-test result is not RED or acceptance evidence.
+
 - [ ] **Step 2: Capture genuine RED**
 
 ```bash
@@ -575,10 +610,14 @@ harness or group.
 First create the private crate, exact dev dependencies, non-production
 skeleton/tests, and perform the one-time reviewed lock transition above so the
 harness itself compiles. Then run `-- --list` for filtered targets and reject
-`running 0 tests`. Save missing-engine-API stderr; missing `trybuild`,
-`static_assertions`, package, or lockfile is not valid RED. The stacked PR must
-target `main` (or an explicitly amended CI trigger) because current CI runs
-only for `main` pull requests; absence of a workflow run is never evidence.
+`running 0 tests`. Capture genuine behavior/profile/API RED before treating the
+five compile-fail cases as acceptance evidence. Save missing-engine-API stderr
+only for those behavior/API tests; missing `trybuild`, `static_assertions`, a
+package, fixture, or lockfile is not valid RED. Perform the five temporary
+boundary-exposure mutations from Step 1 before acceptance and retain only their
+test evidence, never the leaking source. The stacked PR must target `main` (or
+an explicitly amended CI trigger) because current CI runs only for `main` pull
+requests; absence of a workflow run is never evidence.
 
 In the same Task 1 slice, change CI so dependency acquisition is an explicit
 `cargo fetch --locked` step, then run engine/workspace qualification only via

--- a/rfcs/0005-dual-root-vault-and-recovery.md
+++ b/rfcs/0005-dual-root-vault-and-recovery.md
@@ -290,6 +290,8 @@ The first implementation pins:
 rusqlite = { version = "=0.40.2", default-features = false,
   features = ["bundled-sqlcipher-vendored-openssl", "hooks", "limits"] }
 openssl-sys = { version = "=0.9.117", default-features = false }
+# Task 1 dev-only recursive source-closure scanner
+proc-macro2 = { version = "=1.0.106", default-features = false }
 ```
 
 These dependencies live only in the private, `publish = false` workspace crate
@@ -359,7 +361,11 @@ cargo fetch --manifest-path Cargo.toml --target x86_64-unknown-linux-gnu
 
 It MUST NOT be replaced or accompanied by
 `cargo update`, `cargo generate-lockfile`, metadata/tree/check/build/test, or
-any other dependency/build script. Review of the resulting lock diff requires
+any other dependency/build script. If this sole fetch attempt fails or leaves
+partial state for any reason, implementation stops for amendment and re-review.
+It is not retried, and a pre-existing Cargo home, copied registry, or warmed
+cache MUST NOT be substituted and described as the required fresh-home
+transition. Review of the resulting lock diff requires
 every old `(name, version, source)` entry to remain unchanged and permits only
 the engine package and its exact Task 1 dependency closure to be added. The
 post-transition lock SHA-256 and review are recorded, followed by
@@ -385,19 +391,29 @@ allowlist: any newly observed dependency-shaping or build-tool-selection
 variable fails until this RFC is amended. It removes Perl injection variables,
 Rust/linker flags, and unapproved tool overrides; constructs a positive-
 allowlist child environment; resolves and records canonical path, version, and
-SHA-256 for Cargo, rustc, C compiler, archiver, ranlib, Perl, and make; creates
-and owns a new `CARGO_TARGET_DIR`; and runs Cargo `--frozen --offline` only
-after the reviewed one-time lock transition and a separate
+SHA-256 for Cargo, rustc, rustdoc, cargo-clippy, clippy-driver, C compiler,
+archiver, ranlib, Perl, and make; creates and owns a new `CARGO_TARGET_DIR`;
+and runs Cargo `--frozen --offline` only after the reviewed one-time lock
+transition and a separate
 `cargo fetch --locked` acquisition step. Its `full` mode
 reuses the fresh target only within that one invocation and deletes it on exit.
 The child starts from `env -i` and receives only fresh home/temp directories,
 reviewed Cargo/rustup homes, locale/reproducibility values, exact absolute tool
-paths, the exact build target, offline mode, and a PATH composed from reviewed
+paths, including absolute `CARGO`, `RUSTC`, and `RUSTDOC` values plus wrapper-
+private `SOVEREIGN_CARGO_CLIPPY` and `SOVEREIGN_CLIPPY_DRIVER` bindings, the
+exact build target, offline mode, and a PATH composed from reviewed
 Perl/make/linker directories. Every Cargo configuration file that Cargo would
 discover in the repository, its ancestors, or the selected `CARGO_HOME` is
 rejected, and caller `--config` is forbidden; Program 1A has no approved Cargo-
 config extension surface. This closes source replacement and
 `target.*.rustflags` routes, including cfg-driven `getrandom` backend changes.
+The wrapper invokes normal Cargo commands through the absolute `CARGO` binding.
+For Clippy it invokes `SOVEREIGN_CARGO_CLIPPY` directly, never `cargo clippy`,
+and exports that same absolute `CARGO` binding for cargo-clippy's Cargo child.
+Before Clippy runs, the canonical `clippy-driver` sibling selected by that exact
+cargo-clippy executable MUST equal the independently reviewed, hashed, and
+absolute `SOVEREIGN_CLIPPY_DRIVER` binding. Neither Clippy executable may be
+selected through the child PATH.
 Negative tests create a temporary config for each forbidden backend and require
 refusal before dependency compilation. Cargo-generated `HOST`, `TARGET`,
 `OUT_DIR`, and `CARGO_MAKEFLAGS` are allowed only inside the child, never
@@ -478,8 +494,18 @@ disabled and every target is explicit.
 Project-authored `macro_rules!` and all other macro definitions are forbidden.
 Every macro invocation, attribute, and derive uses a closed allowlist. Beyond
 normal AST visiting, the visitor recursively scans every `syn::Macro.tokens`
-token tree, including nested groups, and rejects `unsafe`, `extern`, raw symbol
-names, `include`, `path`, and every other forbidden token. No allowed macro may
+token tree structurally through the direct exact dev dependency
+`proc-macro2 = { version = "=1.0.106", default-features = false }`, including
+nested `proc_macro2::TokenTree::Group` streams, and rejects `unsafe`, `extern`,
+raw symbol names, `include`, `path`, and every other forbidden token. The
+`proc-macro2 1.0.106` tuple already exists in the pre-transition baseline lock,
+but Task 1 still adds and reviews the engine's direct dev-dependency edge and
+enabled feature set while requiring that old tuple to remain unchanged.
+`syn::__private`, token-stream stringification, and Debug/Display text scans are
+forbidden anywhere in the source-closure gate. Recursion, token classification,
+and every allow/deny decision use the public `proc_macro2::TokenTree` structure;
+exact identifier classification may inspect only the individual `Ident` token's
+value, never serialized enclosing token or group text. No allowed macro may
 generate additional project-authored FFI or unsafe code. Separate production
 and `cfg(test)` allowlists detect direct and aliased paths, glob imports, raw
 symbol declarations, and calls, proving exactly the two project-authored
@@ -1335,7 +1361,16 @@ Implementations MUST NOT:
   is not a permanent five-fixture limit for the project: Task 2 declares the
   separate `tests/recovery_ui.rs` Cargo target and owns only
   `tests/recovery_ui/recovery_read_only.rs` plus its `.stderr`; neither enters
-  the Task 1 harness or fixture group.
+  the Task 1 harness or fixture group. These five compile-fail cases are
+  acceptance evidence, not meaningful initial RED while the engine
+  implementation is absent: absence already makes forbidden names fail to
+  compile. Behavior/profile/API tests supply the first genuine RED. Before
+  accepting the boundary, expose each forbidden boundary one at a time only in
+  a temporary copy or temporary mutation and require trybuild to fail because
+  the case unexpectedly compiled. Never commit a leak feature, public probe
+  API, or mutation. Restore the source after every case, then require all five
+  reviewed fixtures to pass. A missing package, missing fixture, unresolved
+  dependency, or zero-test result is neither RED nor acceptance evidence.
 - Bound, malformed, corruption, truncation, schema substitution, wrong
   workspace/database/epoch/role, cross-wrapper, and unknown object-tag tests.
 - Transaction/fault tests at begin, row/chunk insert, commit, journal sync,


### PR DESCRIPTION
## Outcome

Closes the final execution blocker found in the merged Vault Task 1 preflight.

- pins direct `proc-macro2 = 1.0.106` test dependency for structural macro token-tree traversal;
- forbids `syn::__private` and string/debug token scans as source-boundary substitutes;
- binds `cargo-clippy` and `clippy-driver` by reviewed absolute paths in the sanitized child environment;
- makes trybuild boundary evidence mutation-backed rather than accepting missing-code/zero-test false RED;
- requires the one-time fresh-home fetch to stop on failure without cache fallback.

## Validation

- independent review: APPROVED (0 Critical / 0 Important / 0 Minor);
- Cargo.lock unchanged; the proc-macro2 tuple already exists in the baseline lock;
- Markdown fences/links, scope, key wording, and `git diff --check` passed.

Documentation only; no Vault engine or product protection is claimed.