### PR TITLE
docs(citation): add software citation metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,23 @@
+cff-version: 1.2.0
+message: >-
+  If you use or reference this software, please cite it using the metadata
+  below.
+title: Sovereign Founder OS
+type: software
+authors:
+  - family-names: Xu
+    given-names: Franz
+abstract: >-
+  An early-stage, open-source, local-first AI operating system for
+  founder-controlled business workflows, backed by a Rust runtime for
+  policy-enforced execution, scoped capabilities, sandboxing, auditability,
+  and recovery.
+keywords:
+  - agentic AI
+  - AI security
+  - capability-based security
+  - local-first software
+  - Rust
+repository-code: https://github.com/IcantFind-a-username/Sovereign-Founder-OS
+url: https://github.com/IcantFind-a-username/Sovereign-Founder-OS
+license: Apache-2.0


### PR DESCRIPTION
## Summary

- add a valid CFF 1.2.0 citation file for Sovereign Founder OS
- identify Franz Xu as the software author and Apache-2.0 as the license
- describe the current local-first Rust security-runtime scope without claiming a release, DOI, or production maturity

## Verification

- CFF 1.2.0 schema checks
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `./scripts/check-file-size.sh`