### PR TITLE
feat(provenance): automate public evidence records

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,17 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Test provenance validators
+        run: python3 -m unittest discover -s scripts/tests -v
+      - name: Validate provenance records
+        run: python3 scripts/validate-provenance.py
+      - name: Validate citation metadata schema
+        uses: citation-file-format/cffconvert-github-action@4cf11baa70a673bfdf9dad0acc7ee33b3f4b6084 # 2.0.0
+        with:
+          args: "--validate"
+      - name: Lint GitHub Actions workflows
+        run: ./scripts/check-workflows.sh
       - uses: dtolnay/rust-toolchain@1a3a6d54512beeaffd394f8d516ca16f2c506a20 # 1.97.0
         with:
           components: rustfmt, clippy
@@ -33,7 +43,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # Type-check the zero-dependency frontend: JSDoc types + `tsc --checkJs`
       # (configured in apps/cli/assets/tsconfig.json). Check-only — noEmit, so
       # nothing produced here ever reaches the shipped binary. The TypeScript
@@ -52,7 +62,7 @@ jobs:
       checks: write
       pull-requests: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Audit Rust dependencies
@@ -72,7 +82,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Review dependency changes
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
         with:

--- a/.github/workflows/provenance-dry-run.yml
+++ b/.github/workflows/provenance-dry-run.yml
@@ -35,11 +35,13 @@ jobs:
           else
             git update-ref "$GITHUB_REF" "$GITHUB_SHA"
           fi
-          echo "EVIDENCE_REF=$GITHUB_REF" >> "$GITHUB_ENV"
-          echo "SNAPSHOT_ID=provenance-dry-run-$short_sha" >> "$GITHUB_ENV"
-          echo "EVIDENCE_DIR=$RUNNER_TEMP/provenance-evidence" >> "$GITHUB_ENV"
-          echo "CARGO_LOCK_PATH=$RUNNER_TEMP/provenance-material/Cargo.lock" >> "$GITHUB_ENV"
-          echo "SBOM_PATH=$RUNNER_TEMP/provenance-sbom.spdx.json" >> "$GITHUB_ENV"
+          {
+            echo "EVIDENCE_REF=$GITHUB_REF"
+            echo "SNAPSHOT_ID=provenance-dry-run-$short_sha"
+            echo "EVIDENCE_DIR=$RUNNER_TEMP/provenance-evidence"
+            echo "CARGO_LOCK_PATH=$RUNNER_TEMP/provenance-material/Cargo.lock"
+            echo "SBOM_PATH=$RUNNER_TEMP/provenance-sbom.spdx.json"
+          } >> "$GITHUB_ENV"
       - name: Build deterministic Git evidence
         run: |
           python3 scripts/build-provenance-evidence.py \

--- a/.github/workflows/provenance-dry-run.yml
+++ b/.github/workflows/provenance-dry-run.yml
@@ -1,0 +1,100 @@
+name: Provenance Evidence Dry Run
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - "CITATION.cff"
+      - "PROVENANCE.md"
+      - "Cargo.lock"
+      - "docs/release/**"
+      - "scripts/**"
+      - ".github/workflows/provenance-dry-run.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  evidence:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - name: Test evidence tooling
+        run: python3 -m unittest discover -s scripts/tests -v
+      - name: Materialize the explicit event ref
+        shell: bash
+        run: |
+          set -euo pipefail
+          short_sha="${GITHUB_SHA:0:12}"
+          git check-ref-format "$GITHUB_REF"
+          if git show-ref --verify --quiet "$GITHUB_REF"; then
+            test "$(git rev-parse "$GITHUB_REF^{commit}")" = "$GITHUB_SHA"
+          else
+            git update-ref "$GITHUB_REF" "$GITHUB_SHA"
+          fi
+          echo "EVIDENCE_REF=$GITHUB_REF" >> "$GITHUB_ENV"
+          echo "SNAPSHOT_ID=provenance-dry-run-$short_sha" >> "$GITHUB_ENV"
+          echo "EVIDENCE_DIR=$RUNNER_TEMP/provenance-evidence" >> "$GITHUB_ENV"
+          echo "CARGO_LOCK_PATH=$RUNNER_TEMP/provenance-material/Cargo.lock" >> "$GITHUB_ENV"
+          echo "SBOM_PATH=$RUNNER_TEMP/provenance-sbom.spdx.json" >> "$GITHUB_ENV"
+      - name: Build deterministic Git evidence
+        run: |
+          python3 scripts/build-provenance-evidence.py \
+            --repository . \
+            --ref "$EVIDENCE_REF" \
+            --snapshot-id "$SNAPSHOT_ID" \
+            --output-dir "$EVIDENCE_DIR" \
+            --mode dry-run \
+            --repository-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
+            --workflow-ref "$GITHUB_WORKFLOW_REF" \
+            --workflow-run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+      - name: Materialize the recorded Cargo.lock blob
+        run: |
+          python3 scripts/materialize-provenance-cargo-lock.py \
+            --repository . \
+            --metadata "$EVIDENCE_DIR/build-metadata.json" \
+            --output "$CARGO_LOCK_PATH"
+      - name: Generate Cargo.lock SBOM with digest-pinned Syft
+        run: ./scripts/generate-provenance-sbom.sh "$CARGO_LOCK_PATH" "$SBOM_PATH"
+      - name: Finalize and verify unsigned evidence
+        run: |
+          python3 scripts/finalize-provenance-evidence.py \
+            --evidence-dir "$EVIDENCE_DIR" \
+            --sbom "$SBOM_PATH" \
+            --sbom-generator syft \
+            --sbom-generator-version 1.51.0 \
+            --sbom-generator-source sha256:2a2e837a2c8d59ec9af5472ee22d3b04ee463c4e44476ecf993fd1e5ab6ebc7f
+          python3 scripts/verify-provenance-evidence.py \
+            --evidence-dir "$EVIDENCE_DIR"
+      - name: Upload unsigned dry-run artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: UNSIGNED-DRY-RUN-${{ github.sha }}
+          path: ${{ env.EVIDENCE_DIR }}
+          if-no-files-found: error
+          retention-days: 14
+
+  attest-manual-dry-run:
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    needs: evidence
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+    steps:
+      - name: Download unsigned dry-run artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: UNSIGNED-DRY-RUN-${{ github.sha }}
+          path: evidence
+      - name: Attest each dry-run evidence file
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: evidence/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,58 +1,15 @@
-name: Release
+name: Product Release Gate
 
 on:
-  push:
-    tags: ["v*"]
+  workflow_dispatch:
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
-  build:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            target: x86_64-linux
-            binary: sovereign
-            archive: tar.gz
-          - os: macos-latest
-            target: aarch64-macos
-            binary: sovereign
-            archive: tar.gz
-          - os: windows-latest
-            target: x86_64-windows
-            binary: sovereign.exe
-            archive: zip
-    runs-on: ${{ matrix.os }}
+  status:
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: dtolnay/rust-toolchain@1a3a6d54512beeaffd394f8d516ca16f2c506a20 # 1.97.0
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - name: Build release binary
-        run: cargo build -p sovereign-cli --release --locked
-      - name: Package
-        shell: bash
+      - name: Report disabled publication gate
         run: |
-          set -euo pipefail
-          NAME="sovereign-${GITHUB_REF_NAME}-${{ matrix.target }}"
-          mkdir "$NAME"
-          cp "target/release/${{ matrix.binary }}" "$NAME/"
-          cp README.md LICENSE NOTICE "$NAME/"
-          if [ "${{ matrix.archive }}" = "zip" ]; then
-            7z a "$NAME.zip" "$NAME"
-            echo "ASSET=$NAME.zip" >> "$GITHUB_ENV"
-          else
-            tar -czf "$NAME.tar.gz" "$NAME"
-            echo "ASSET=$NAME.tar.gz" >> "$GITHUB_ENV"
-          fi
-      - name: Upload to release
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
-            --title "$GITHUB_REF_NAME" --generate-notes 2>/dev/null || true
-          gh release upload "$GITHUB_REF_NAME" "$ASSET" --repo "$GITHUB_REPOSITORY" --clobber
+          echo "Automatic product publication is disabled."
+          echo "The documented product-release gates are not yet implemented."

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,12 +11,14 @@ abstract: >-
   An early-stage, open-source, local-first AI operating system for
   founder-controlled business workflows, backed by a Rust runtime for
   policy-enforced execution, scoped capabilities, sandboxing, auditability,
-  and recovery.
+  and recovery. Repository chronology and the maintainer's authorship
+  representation are documented in PROVENANCE.md.
 keywords:
   - agentic AI
   - AI security
   - capability-based security
   - local-first software
+  - software provenance
   - Rust
 repository-code: https://github.com/IcantFind-a-username/Sovereign-Founder-OS
 url: https://github.com/IcantFind-a-username/Sovereign-Founder-OS

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,8 +27,24 @@ Open an issue before beginning a large feature or architectural change. This let
 1. Fork the repository
 2. Create a feature branch from `main`
 3. Make focused changes with tests
-4. Ensure CI passes (when configured)
-5. Open a pull request with a clear description
+4. Sign off every commit as described below
+5. Ensure CI passes (when configured)
+6. Open a pull request with a clear description
+
+### Developer Certificate of Origin
+
+All new contributions must certify the [Developer Certificate of Origin
+1.1](DCO). Add a `Signed-off-by` trailer using your real name and an email
+address you control:
+
+```bash
+git commit --signoff
+```
+
+The sign-off certifies your authority to submit that contribution under the
+project license. It is prospective, does not rewrite historical commits, does
+not assign your copyright, and does not claim ownership of abstract ideas.
+Preserve applicable third-party license and attribution notices.
 
 ### Documentation
 
@@ -97,7 +113,8 @@ All contributors must follow [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the [Apache License 2.0](LICENSE).
+By contributing and signing off, you certify your contribution under the
+[Apache License 2.0](LICENSE) according to the DCO.
 
 ## Questions
 

--- a/DCO
+++ b/DCO
@@ -1,0 +1,30 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I have the
+    right to submit it under the open source license indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best of my
+    knowledge, is covered under an appropriate open source license and I have
+    the right under that license to submit that work with modifications,
+    whether created in whole or in part by me, under the same open source
+    license (unless I am permitted to submit under a different license), as
+    indicated in the file; or
+
+(c) The contribution was provided directly to me by some other person who
+    certified (a), (b) or (c) and I have not modified it.
+
+(d) I understand and agree that this project and the contribution are public
+    and that a record of the contribution (including all personal information
+    I submit with it, including my sign-off) is maintained indefinitely and
+    may be redistributed consistent with this project or the open source
+    license(s) involved.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -32,16 +32,31 @@ Require RFC process (see [CONTRIBUTING.md](CONTRIBUTING.md)):
 - Security advisories coordinated through [SECURITY.md](SECURITY.md) process
 - No security fixes behind paywalls
 
-## Release Process
+## Publication Classes
 
-1. All tests and security scans pass
-2. SBOM and provenance generated
-3. Binaries and containers signed
-4. CHANGELOG updated
-5. Git tag with semantic version
-6. GitHub Release with checksums and verification instructions
+### SemVer product releases
 
-Pre-Alpha releases use `0.x.y` versioning.
+Product releases use semantic versions and ship supported product artifacts.
+Their release gate remains unmet until an implementation enforces all tests and
+security scans, changelog review, checksums, dependency-scoped SBOMs, signed
+artifacts, build provenance, and verification instructions. Pre-Alpha product
+versions will use `0.x.y`; a workspace package version is not by itself a
+published release.
+
+Automatic `v*` publication is disabled until that separate product-release
+workflow exists and the applicable [roadmap](ROADMAP.md) gates pass.
+
+### Provenance snapshots
+
+Provenance snapshots use `provenance-YYYY.MM.DD.N`. They preserve one exact
+source tree, selected history, metadata, and verification assets as evidence of
+repository chronology. They contain no product binaries, do not satisfy or
+waive product-release gates, and do not imply production readiness or security
+certification.
+
+The publication design and current status are recorded in
+[PROVENANCE.md](PROVENANCE.md). An unsigned CI dry run is not a published
+snapshot.
 
 ## Verified Jurisdiction Packs
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,19 +1,24 @@
 Sovereign Founder OS
-Copyright 2026 The Sovereign Founder OS Authors
+Copyright 2026 Franz Xu
 
 This product includes software developed as part of the Sovereign Founder OS
 open source project (https://github.com/IcantFind-a-username/Sovereign-Founder-OS).
 
-The project documentation, architecture specifications, threat models, and
-design materials in this repository are original works of the project authors
-and are licensed under the Apache License, Version 2.0.
+Franz Xu declares that he is the original project author and current
+maintainer of the project-authored materials introduced in the initial
+repository history. The scope, chronology, and limits of that declaration are
+recorded in PROVENANCE.md. This declaration is not an independent legal
+finding and does not assign future contributors' rights to Franz Xu.
+
+Project-authored code and documentation are licensed under the Apache License,
+Version 2.0. Copyright notices and third-party attribution for later
+contributions remain with their respective authors and sources.
 
 Trademark Notice
 ----------------
-"Sovereign Founder OS", "Sovereign Runtime", "Mutually Constrained
-Autonomy", and associated logos are trademarks of the Sovereign Founder OS
-project. Use of these marks requires compliance with the project's trademark
-policy (see TRADEMARK.md).
+Project names and source identifiers are addressed by the project's trademark
+policy (see TRADEMARK.md). The policy prevents misleading source or endorsement
+claims; it does not narrow the Apache-2.0 permissions for copyrighted material.
 
 Third-Party References
 ----------------------

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -1,0 +1,100 @@
+# Project Provenance
+
+This record describes the repository evidence and maintainer declarations for
+Sovereign Founder OS. Its canonical repository is
+<https://github.com/IcantFind-a-username/Sovereign-Founder-OS>.
+
+## Maintainer Declaration
+
+I, Franz Xu (GitHub: `IcantFind-a-username`), represent that I originated the
+project-authored code and documentation in the initial repository history and
+that I currently hold or control the rights needed to publish those materials
+under the Apache License, Version 2.0. Later contributions, if any, remain
+attributable to their respective contributors and applicable third-party
+notices.
+
+This is the maintainer's representation. It is not an independently verified
+legal finding about authorship, ownership, novelty, patentability, prior art,
+or non-infringement.
+
+## What This Record Establishes
+
+The Git object identifiers below allow a reader to verify that particular
+expression is present in an exact tree referenced by an exact commit. Git
+author and committer timestamps are metadata recorded in those commit objects;
+they are not independent proof of the date on which GitHub or the public first
+observed the material.
+
+Copyright may protect original expression subject to applicable law. This
+record does not claim exclusive rights over abstract ideas, procedures,
+methods, systems, algorithms, or principles, and it does not restrict the
+permissions granted by Apache-2.0.
+
+## Reachable Chronology
+
+The earliest commit reachable from the repository's current history is:
+
+- Commit: [`97f555c9e6079d5258dba4ca2b22ef0ff7b4b1e2`](https://github.com/IcantFind-a-username/Sovereign-Founder-OS/commit/97f555c9e6079d5258dba4ca2b22ef0ff7b4b1e2)
+- Tree: `62bf2865c284f8d5dc683a2594df8fdecabf92ab`
+- Recorded author timestamp: `2026-07-13T16:25:44+08:00`
+- Recorded committer timestamp: `2026-07-13T16:25:44+08:00`
+- Subject: `docs: add project blueprint, architecture specs, and Apache-2.0 license`
+
+The following table indexes public concepts and milestones in each cited tree.
+A status describes the material in that historical path; it is not a claim
+that the complete product capability existed at that time.
+
+| Concept or milestone | Status in cited material | Commit | Tree | Path |
+| --- | --- | --- | --- | --- |
+| Sovereign Enterprise Graph | Target design | `97f555c9e6079d5258dba4ca2b22ef0ff7b4b1e2` | `62bf2865c284f8d5dc683a2594df8fdecabf92ab` | `ARCHITECTURE.md` |
+| Mutually Constrained Autonomy | Target architecture | `97f555c9e6079d5258dba4ca2b22ef0ff7b4b1e2` | `62bf2865c284f8d5dc683a2594df8fdecabf92ab` | `ARCHITECTURE.md` |
+| Capability Tokens | Target security mechanism | `97f555c9e6079d5258dba4ca2b22ef0ff7b4b1e2` | `62bf2865c284f8d5dc683a2594df8fdecabf92ab` | `README.md` |
+| Resilient Trust Mesh | Historical target; currently Research | `97f555c9e6079d5258dba4ca2b22ef0ff7b4b1e2` | `62bf2865c284f8d5dc683a2594df8fdecabf92ab` | `README.md` |
+| Stage 1 capability implementation | Experimental implementation | `658763b1263745fca67f96e068caeb5a06a16239` | `869534e7e7d166ab408204b1bbc09b29939e2fe2` | `crates/capability/src/lib.rs` |
+
+For the later implementation milestone, commit
+`658763b1263745fca67f96e068caeb5a06a16239` records both its author and
+committer timestamp as `2026-07-13T17:07:59+08:00`. As with the root commit,
+those values are Git object metadata rather than an independently observed
+publication time.
+
+The repository's current implementation, accepted RFCs, and maturity labels
+remain authoritative for present capability. Historical wording can describe
+targets that were later narrowed or reclassified.
+
+## Publication Status
+
+No immutable provenance snapshot has been published. The repository currently
+contains Git history and this maintainership declaration, but it has no
+project provenance tag, independently archived snapshot DOI, SWHID, or pinned
+maintainer signing-key fingerprint.
+
+A completed snapshot will use `provenance-YYYY.MM.DD.N`, identify one commit
+and tree, and publish a manifest, hashes, source archive, exact-ref Git bundle,
+SBOM, verification instructions, and maintainer signature. Until all required
+trust and publication gates succeed, automated bundles are explicitly unsigned
+dry runs and are not publication evidence.
+
+## Evidence Limits
+
+- Git history binds content to Git objects and self-recorded timestamps; it
+  does not independently establish public-disclosure time.
+- A maintainer signature establishes control of a disclosed key, not global
+  originality or legal ownership by itself.
+- A future immutable GitHub release can bind a hosted tag and asset set, but it
+  is not an independent legal judgment.
+- A future DOI or Software Heritage identifier can provide independent
+  archival identity or observation, but not a finding of novelty.
+- Similar design ideas can arise independently. This record exists to make
+  copying followed by a false chronology or attribution claim easier to test
+  against concrete public evidence.
+
+## Corrections and Future Records
+
+Factual corrections should be proposed in a public issue or pull request with
+the exact challenged commit, tree, path, and supporting evidence. Repository
+history will not be rewritten merely to make the chronology look cleaner.
+
+Future snapshots, archive identifiers, and signing-key information will be
+added only after they exist and can be verified. No placeholder fingerprint,
+DOI, date, or archive identifier should be treated as evidence.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ Read the **[Sovereign Founder OS Manifesto →](MANIFESTO.md)** for the principl
 
 Specialist designs, product drafts, positioning, and historical documents live under [`docs/`](docs/INDEX.md). They provide context; the core documents and accepted RFCs are authoritative when material conflicts.
 
+### Provenance and Design Chronology
+
+The [project provenance record](PROVENANCE.md) identifies exact commits, trees,
+and paths containing the project's documented core concepts and states Franz
+Xu's maintainership declaration. It makes chronology and attribution claims
+testable; it is not an independent finding of originality and does not claim
+exclusive rights over abstract ideas.
+
 ## Tech Stack (Planned)
 
 | Layer | Technology |
@@ -233,9 +241,13 @@ Report security issues via [SECURITY.md](SECURITY.md) — do not open public iss
 
 - **Code and documentation:** [Apache License 2.0](LICENSE)
 - **Attribution:** [NOTICE](NOTICE)
-- **Trademarks:** [TRADEMARK.md](TRADEMARK.md) — "Sovereign Founder OS" and related marks are protected
+- **Design chronology:** [PROVENANCE.md](PROVENANCE.md)
+- **Source identification:** [TRADEMARK.md](TRADEMARK.md)
 
-You are free to use, modify, and distribute this project under Apache 2.0 terms. Forks must retain license and attribution notices. Trademark use requires compliance with our trademark policy.
+You are free to use, modify, and distribute this project under Apache 2.0
+terms. Forks must retain notices required by that license. The trademark policy
+addresses confusing source or endorsement claims and does not withdraw those
+copyright permissions.
 
 ## Links
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,9 +28,8 @@ Include:
 
 | Version | Supported |
 | --- | --- |
-| Latest release | Yes |
-| Previous minor | Security fixes only |
-| Pre-Alpha / main branch | Best effort |
+| Published product release | None yet |
+| Developer Preview / main branch | Best effort |
 
 ## Security Requirements for Contributors
 
@@ -54,14 +53,16 @@ Changes to these paths require dual review once the team grows beyond one mainta
 
 ## Supply Chain Security
 
-Releases include:
+Future SemVer product releases must satisfy the checksums, dependency-scoped
+SBOM, signature, build-provenance, source-reference, and verification gates in
+[GOVERNANCE.md](GOVERNANCE.md) before publication. Those are release gates, not
+claims about the current branch.
 
-- SHA-256 checksums
-- SBOM (Software Bill of Materials)
-- Signed binaries and containers (Sigstore)
-- Build provenance (SLSA-aligned)
-- Source commit reference
-- Reproducible build instructions
+Provenance snapshots are a separate source/history evidence class. A completed
+snapshot will state its exact asset and signature scope in its manifest and
+verification guide. Until a signed snapshot is published, CI output is an
+unsigned dry run and must not be described as release evidence or security
+certification. See [PROVENANCE.md](PROVENANCE.md).
 
 ## Security Testing
 

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,42 +1,51 @@
-# Trademark Policy
+# Trademark and Source-Identification Policy
 
-## Protected Marks
+This policy helps readers distinguish the official Sovereign Founder OS
+project from forks, derivatives, and unrelated products. It does not change or
+withdraw permissions granted by the Apache License, Version 2.0.
 
-The following names and phrases are trademarks of the Sovereign Founder OS project:
+## Project Identifiers
+
+The project uses the following names as source identifiers:
 
 - **Sovereign Founder OS**
 - **Sovereign Runtime**
-- **Mutually Constrained Autonomy** (as used in this project's security architecture)
-- **Agent Security Gauntlet** (as used in this project's benchmark suite)
+- **Mutually Constrained Autonomy**, when identifying this project's security
+  architecture
+- **Agent Security Gauntlet**, when identifying this project's benchmark work
+- associated project logos, when published
 
-Associated logos and visual identity, when published, are also protected.
+No registration is claimed. Whether and to what extent a name is legally
+protectable depends on actual use and applicable law.
 
-## Permitted Uses
+## Permitted References
 
-You may use the project name to:
+You may truthfully:
 
-- Refer to the project in truthful, non-misleading descriptions
-- Indicate that your software is based on or compatible with Sovereign Founder OS
-- Link to the official repository: https://github.com/IcantFind-a-username/Sovereign-Founder-OS
+- refer to the official project and link to its repository;
+- describe software as based on, forked from, or compatible with the project;
+- retain notices and historical references required by the Apache-2.0 license;
+- make nominative references that do not imply endorsement or official status.
 
-## Prohibited Uses
+## Avoiding Confusion
 
-You may not:
+Do not use a project identifier in a way likely to mislead readers into
+believing that an independent project, release, service, or organization is
+officially produced, sponsored, approved, or supported by this project.
 
-- Use the marks in a way that implies official endorsement, sponsorship, or affiliation without written permission
-- Use the marks as part of your own product name in a confusingly similar manner
-- Remove or alter copyright, license, or attribution notices from project materials
-- Claim ownership of the project's architecture documents, threat models, or design specifications
+An independent fork should use a distinct primary name, state that it is
+independent, identify the upstream project truthfully, and avoid presenting
+modified logos or release artifacts as official. For example, "Acme Runtime,
+based on Sovereign Founder OS" clearly separates source from product name.
 
-## Forks and Derivatives
+## Copyright and Attribution Are Separate
 
-Forks and derivative works must:
-
-- Clearly state they are independent from the official project
-- Not use the official marks in their project name
-- Retain Apache 2.0 license and attribution requirements
-- Use a distinct name (e.g., "Acme Runtime based on Sovereign Founder OS")
+This policy cannot be used to prohibit copying, modification, or distribution
+that Apache-2.0 permits. Copyright, license, and NOTICE obligations are governed
+by [LICENSE](LICENSE) and [NOTICE](NOTICE). Repository chronology is documented
+in [PROVENANCE.md](PROVENANCE.md).
 
 ## Questions
 
-For trademark permission requests, open an issue in the official repository.
+For a proposed use that may imply official endorsement, open an issue in the
+official repository before publication.

--- a/docs/release/VERIFY.md
+++ b/docs/release/VERIFY.md
@@ -1,0 +1,115 @@
+# Verify a Provenance Evidence Bundle
+
+The current automated bundle is an **unsigned dry run**. It tests deterministic
+source packaging and tamper detection; it is not an immutable release, a
+maintainer signature, an independent publication timestamp, or a legal
+originality finding.
+
+## Expected Files
+
+- `SNAPSHOT-source.tar.gz`: normalized source for one exact ref;
+- `SNAPSHOT.bundle`: a Git bundle containing that exact positive ref;
+- `SNAPSHOT.sbom.spdx.json`: Syft SPDX 2.3 dependency evidence generated from
+  and checked exactly against the recorded `Cargo.lock` blob;
+- `build-metadata.json`: resolved ref, commit, tree, and build tool versions;
+- `release-manifest.json`: SHA-256 and size for payload assets only;
+- `SHA256SUMS`: hashes payloads and the manifest, but never itself;
+- `VERIFY.md`: this guide.
+
+A future publishable bundle must additionally contain a detached maintainer
+signature over `release-manifest.json` and independently verifiable trust-anchor
+instructions. No such trust anchor is configured today.
+
+When a maintainer manually starts the dry-run workflow, GitHub also records
+artifact attestations for each evidence file. Those attestations bind files to
+that workflow execution; they do not replace the missing maintainer signature
+or convert the dry run into a published snapshot.
+
+## Automated Verification
+
+The bundle is self-contained. From any directory containing the evidence:
+
+```bash
+python3 scripts/verify-provenance-evidence.py \
+  --evidence-dir PATH_TO_EVIDENCE
+```
+
+The verifier imports the exact bundle ref into a new bare repository, runs full
+Git object checking, and checks every checksum, manifest entry, ref/tag object,
+peeled commit, tree, material hash, Cargo.lock SBOM package identity, Syft
+generator version, and byte-for-byte rebuilt source archive. It rejects missing,
+altered, extra, symlinked, or wrongly named payloads and any bundle marked as
+publishable.
+
+## GitHub Artifact Attestations
+
+GitHub attestations exist only for a manually dispatched run whose source ref
+was the repository default branch. For this repository, the expected source ref
+is `refs/heads/main`. First run the self-contained verifier above; then bind
+GitHub verification to the exact commit recorded by that verified bundle:
+
+```bash
+EVIDENCE_DIR=PATH_TO_EVIDENCE
+REPOSITORY=IcantFind-a-username/Sovereign-Founder-OS
+SIGNER_WORKFLOW="$REPOSITORY/.github/workflows/provenance-dry-run.yml"
+CERT_IDENTITY="https://github.com/$SIGNER_WORKFLOW@refs/heads/main"
+EXPECTED_COMMIT="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["commit"])' "$EVIDENCE_DIR/release-manifest.json")"
+
+for artifact in "$EVIDENCE_DIR"/*; do
+  [ -f "$artifact" ] || continue
+  gh attestation verify "$artifact" \
+    --repo "$REPOSITORY" \
+    --cert-identity "$CERT_IDENTITY" \
+    --source-ref refs/heads/main \
+    --source-digest "$EXPECTED_COMMIT" \
+    --signer-digest "$EXPECTED_COMMIT" \
+    --cert-oidc-issuer https://token.actions.githubusercontent.com \
+    --deny-self-hosted-runners \
+    --predicate-type https://slsa.dev/provenance/v1
+done
+```
+
+Use `--repo`, not the broader `--owner`, and retain the complete certificate
+identity shown above. `--cert-identity` compares the certificate SAN exactly;
+do not replace it with a partial or regular-expression workflow match. In this
+direct, non-reusable workflow, the source and signer workflow revisions are the
+same event commit; pinning both digests prevents a later revision of the same
+workflow path from satisfying this check.
+
+`--source-ref refs/heads/main` verifies the signed source-ref claim, but the CLI
+does not independently prove that `main` is or was the repository's default or
+protected branch. It also has no direct filter for the `workflow_dispatch` event
+or one exact workflow run ID. Inspect the workflow at `EXPECTED_COMMIT` and, when
+those additional checks matter, evaluate the verified JSON certificate/run
+metadata separately. Do not treat workflow-controlled predicate fields as an
+independent identity source. GitHub attestations bind bytes to a GitHub-hosted
+workflow execution; they do not supply the missing maintainer signature or prove
+authorship, originality, safety, or publication time outside GitHub.
+
+## Manual Inspection
+
+Inspect the manifest and bundle without checking out their contents:
+
+```bash
+EVIDENCE_DIR="$(realpath PATH_TO_EVIDENCE)"
+BUNDLE_REPOSITORY="$(mktemp -d)"
+python3 -m json.tool "$EVIDENCE_DIR/release-manifest.json"
+git -C "$BUNDLE_REPOSITORY" init --bare
+git -C "$BUNDLE_REPOSITORY" bundle list-heads "$EVIDENCE_DIR/SNAPSHOT.bundle"
+git -C "$BUNDLE_REPOSITORY" bundle verify "$EVIDENCE_DIR/SNAPSHOT.bundle"
+(
+  cd "$EVIDENCE_DIR"
+  sha256sum --check SHA256SUMS
+)
+```
+
+Extract the archive only into a new empty directory after checking its entry
+names. Do not run code from an evidence bundle merely to verify its hashes.
+
+## Evidence Meaning
+
+Successful verification establishes internal consistency between the supplied
+files and the exact ref imported from the supplied Git bundle. It does not
+establish who authored the material, when a third party first observed it,
+whether similar ideas existed elsewhere, or whether the software is safe for
+production.

--- a/docs/superpowers/plans/2026-08-27-provenance-evidence-implementation.md
+++ b/docs/superpowers/plans/2026-08-27-provenance-evidence-implementation.md
@@ -1,0 +1,276 @@
+# Provenance Evidence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build and verify a deterministic, tamper-evident provenance evidence bundle in CI without publishing a release or pretending that an unsigned dry run is a final attestation.
+
+**Architecture:** Small Python command-line tools build normalized Git artifacts, finalize an acyclic hash graph, and verify the result. A read-only GitHub Actions workflow supplies a Cargo.lock-scoped SBOM and uploads an unsigned dry-run artifact. Publishable mode remains locked behind a maintainer-controlled signed tag and detached manifest signature.
+
+**Tech Stack:** Python 3 standard library, Git, GNU tar/gzip-compatible archives, Syft SPDX 2.3 JSON, GitHub Actions.
+
+**Spec:** `docs/superpowers/specs/2026-08-27-public-provenance-release-design.md`
+
+**Depends on:** `docs/superpowers/plans/2026-08-27-provenance-records-implementation.md`
+
+## Global Constraints
+
+- Dry-run output must say `publishable: false` and must never be presented as a signed release.
+- Final mode must fail closed unless the input is an annotated, cryptographically valid `provenance-*` tag and a detached maintainer signature is supplied.
+- Do not create or push tags, create GitHub releases, mint DOI records, or write external services.
+- Hash dependencies must be acyclic: manifest hashes payloads; detached signature signs the manifest; `SHA256SUMS` hashes payloads, manifest, and optional signature; it excludes itself.
+- The Git bundle must contain the exact requested ref, not all branches or unrelated refs.
+- All external actions and downloaded workflow tools must be pinned by immutable digest.
+
+---
+
+## Task 1: Specify and Test the Evidence Layout
+
+**Files:**
+
+- Create: `docs/release/VERIFY.md`
+- Create: `scripts/tests/test_provenance_evidence.py`
+
+**Step 1: Document the layout**
+
+Define required payloads:
+
+- normalized source tarball;
+- exact-ref Git bundle;
+- Cargo.lock-scoped SBOM;
+- verification instructions;
+- `release-manifest.json`;
+- optional detached maintainer signature;
+- `SHA256SUMS`.
+
+Document dry-run versus publishable requirements and exact verification commands.
+
+**Step 2: Write failing integration tests**
+
+Create a temporary Git repository fixture. Test:
+
+- two builds from the same ref produce identical source archives;
+- the bundle contains only the requested positive ref;
+- manifest entries are sorted and hash only payloads;
+- `SHA256SUMS` excludes itself and includes the manifest;
+- a modified or missing payload fails verification;
+- unsigned dry-run passes with `publishable: false`;
+- publishable mode rejects a branch, unsigned tag, missing signature, or mismatched snapshot ID.
+
+Run:
+
+```bash
+python3 -m unittest scripts.tests.test_provenance_evidence -v
+```
+
+Expected: FAIL because the commands do not exist.
+
+---
+
+## Task 2: Build Deterministic Git Payloads
+
+**Files:**
+
+- Create: `scripts/provenance_evidence.py`
+- Create: `scripts/build-provenance-evidence.py`
+
+**Step 1: Implement reusable primitives**
+
+In `scripts/provenance_evidence.py`, implement:
+
+- `run_git(root: Path, *args: str) -> str`
+- `resolve_ref(root: Path, ref: str) -> tuple[str, str, str]`
+- `normalized_source_archive(root: Path, ref: str, destination: Path, prefix: str) -> None`
+- `exact_ref_bundle(root: Path, ref: str, destination: Path) -> None`
+- `sha256_file(path: Path) -> str`
+- `write_json(path: Path, value: object) -> None`
+
+Use `git archive` and a gzip stream with no original filename and `mtime=0`. Set archive entry prefix from the validated snapshot/dry-run identifier.
+
+**Step 2: Implement the builder CLI**
+
+Accept:
+
+```text
+--repository PATH
+--ref FULL_REF
+--snapshot-id ID
+--output-dir PATH
+--mode dry-run|publishable
+--repository-url URL
+--workflow-ref REF
+--workflow-run-url URL
+```
+
+Dry run accepts an explicit branch or annotated tag ref and records the ref
+object separately from its peeled commit. Publishable mode remains locked and
+fails closed until the maintainer trust anchor is configured.
+
+The builder writes only the source archive, exact-ref bundle, and a machine-readable build metadata file. It must not synthesize an SBOM or signature.
+
+**Step 3: Run focused tests**
+
+```bash
+python3 -m unittest scripts.tests.test_provenance_evidence.ProvenanceEvidenceTests -v
+```
+
+Expected: PASS.
+
+---
+
+## Task 3: Finalize and Verify the Hash Graph
+
+**Files:**
+
+- Create: `scripts/finalize-provenance-evidence.py`
+- Create: `scripts/verify-provenance-evidence.py`
+
+**Step 1: Implement finalization**
+
+The finalizer accepts the evidence directory, an SBOM path already generated
+from `Cargo.lock`, and the pinned generator/action identity. It:
+
+1. validates filenames and required payloads;
+2. copies the SBOM and `docs/release/VERIFY.md` into the evidence directory;
+3. checks exact Cargo.lock package multiplicities, the Cargo.lock root hash, and
+   the pinned Syft identity in the SBOM;
+4. writes a sorted manifest containing repository, workflow, ref/tag object,
+   peeled commit, tree, Cargo.lock/CFF hashes, compressor/tool versions, SBOM
+   generator identity, and SHA-256 for payload assets only;
+5. rejects unsafe paths, symlinks, unexpected inputs, and publishable mode;
+6. writes sorted `SHA256SUMS` for payloads and manifest, excluding
+   `SHA256SUMS` itself.
+
+**Step 2: Implement independent verification**
+
+The standalone verifier recomputes hashes, rejects extra/missing manifest
+payloads, imports the bundle into an empty bare repository, runs full Git fsck,
+checks the advertised ref/tag object, peeled commit, tree and material blobs,
+rebuilds the source archive, and validates dry-run rules.
+
+**Step 3: Run all evidence tests**
+
+```bash
+python3 -m unittest scripts.tests.test_provenance_evidence -v
+```
+
+Expected: PASS.
+
+**Step 4: Commit the tooling**
+
+```bash
+git add docs/release/VERIFY.md scripts/provenance_evidence.py scripts/build-provenance-evidence.py scripts/finalize-provenance-evidence.py scripts/verify-provenance-evidence.py scripts/tests/test_provenance_evidence.py
+git commit -m "feat(provenance): build verifiable evidence bundles"
+```
+
+---
+
+## Task 4: Add a Read-Only Dry-Run Workflow
+
+**Files:**
+
+- Create: `.github/workflows/provenance-dry-run.yml`
+- Create: `scripts/check-workflows.sh`
+
+**Step 1: Pin workflow dependencies**
+
+Resolve official current release commits for checkout, artifact upload, and
+optional GitHub attestation. Record full commit SHAs in workflow `uses:`
+fields. Pin both `actionlint` and Syft versions and verify their downloaded
+archive SHA-256 values before execution.
+
+**Step 2: Implement the workflow**
+
+Trigger on `workflow_dispatch` and relevant pull-request paths. Use:
+
+- `contents: read` by default;
+- full Git history;
+- the current event ref as an explicit full ref;
+- Cargo.lock-scoped SBOM generation;
+- build, finalize, and verify commands in dry-run mode;
+- artifact upload with a clear `UNSIGNED-DRY-RUN` name and bounded retention.
+
+Do not request `contents: write`, create a tag/release, or use `--clobber`.
+
+If GitHub artifact attestation is enabled, isolate it behind a non-fork manual/default-branch condition and the minimum `id-token: write` plus `attestations: write` permissions. The evidence bundle itself remains `publishable: false`.
+
+**Step 3: Lint and inspect permissions**
+
+```bash
+./scripts/check-workflows.sh
+rg -n "contents: write|gh release|git push|--clobber" .github/workflows/provenance-dry-run.yml
+```
+
+Expected: actionlint passes and the forbidden publishing operations are absent.
+
+**Step 4: Commit**
+
+```bash
+git add .github/workflows/provenance-dry-run.yml scripts/check-workflows.sh
+git commit -m "ci(provenance): exercise evidence packaging"
+```
+
+---
+
+## Task 5: Perform a Local End-to-End Dry Run
+
+**Files:**
+
+- Generate under an ignored temporary directory only.
+
+**Step 1: Prepare a minimal local SBOM fixture**
+
+Generate the real SBOM with the pinned tool if available. If the tool is unavailable locally, use a clearly labeled test fixture only for local plumbing verification and rely on CI for the real SBOM job. Never commit or publish the fixture as release evidence.
+
+**Step 2: Build and verify**
+
+```bash
+tmp_dir="$(mktemp -d)"
+python3 scripts/build-provenance-evidence.py --repository . --ref refs/heads/docs/provenance-release-design --snapshot-id local-dry-run --output-dir "$tmp_dir/evidence" --mode dry-run
+python3 scripts/finalize-provenance-evidence.py --evidence-dir "$tmp_dir/evidence" --sbom "$tmp_dir/test-sbom.spdx.json" --sbom-generator syft --sbom-generator-version 1.51.0 --sbom-generator-source sha256:2a2e837a2c8d59ec9af5472ee22d3b04ee463c4e44476ecf993fd1e5ab6ebc7f
+python3 scripts/verify-provenance-evidence.py --evidence-dir "$tmp_dir/evidence"
+```
+
+Expected: verification succeeds and the manifest says `publishable: false`.
+
+**Step 3: Prove tamper detection**
+
+Modify a copied payload in a second temporary directory and rerun verification.
+
+Expected: non-zero exit with the altered filename identified.
+
+---
+
+## Task 6: Final Repository Verification
+
+**Files:**
+
+- Verify all files changed by both provenance plans.
+
+**Step 1: Run Python and workflow checks**
+
+```bash
+python3 -m unittest discover -s scripts/tests -v
+python3 scripts/validate-provenance.py
+./scripts/check-workflows.sh
+git diff --check
+```
+
+**Step 2: Run repository-required checks**
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace
+./scripts/check-file-size.sh
+```
+
+Expected: all commands exit zero.
+
+**Step 3: Confirm publication boundary**
+
+```bash
+git tag --list 'provenance-*'
+rg -n "publishable" .github/workflows/provenance-dry-run.yml scripts docs/release
+```
+
+Expected: no new provenance tag exists; all automated output is explicitly dry-run/non-publishable.

--- a/docs/superpowers/plans/2026-08-27-provenance-records-implementation.md
+++ b/docs/superpowers/plans/2026-08-27-provenance-records-implementation.md
@@ -1,0 +1,241 @@
+# Provenance Records Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add precise, machine-checked records that identify the project's documented design concepts, their repository evidence, and the maintainer's authorship representation without changing Apache-2.0 code rights or overstating legal conclusions.
+
+**Architecture:** A root provenance record is the human-readable source of truth. Existing policy files link to it and distinguish product releases from provenance snapshots. A Python standard-library validator checks stable cross-file invariants and candidate-only CFF fields. CI runs both unit tests and the official CFF schema validator.
+
+**Tech Stack:** Markdown, CFF 1.2.0 YAML, Python 3 standard library, GitHub Actions.
+
+**Spec:** `docs/superpowers/specs/2026-08-27-public-provenance-release-design.md`
+
+## Global Constraints
+
+- Keep source code under Apache-2.0; do not claim that copyright protects abstract ideas.
+- Describe provenance as the maintainer's signed representation, not an independent adjudication.
+- Use exact commit, tree, and path evidence; distinguish recorded Git timestamps from independently observed publication dates.
+- Do not add snapshot `version` or `date-released` to `CITATION.cff` until a dated candidate is created.
+- Do not create a tag, GitHub release, DOI, signing key, or publication claim in this plan.
+- Preserve current maturity labels and state explicitly that no immutable provenance snapshot exists yet.
+
+---
+
+## Task 1: Add a Test-Driven Metadata Validator
+
+**Files:**
+
+- Create: `scripts/validate-provenance.py`
+- Create: `scripts/tests/test_validate_provenance.py`
+
+**Step 1: Write failing tests**
+
+Use `unittest` and temporary fixture directories. Cover:
+
+- the repository's expected title, maintainer identity, repository URL, and Apache-2.0 license;
+- `version` and `date-released` both absent for an undated candidate;
+- rejection when only one candidate field is present;
+- acceptance only when `version` matches `YYYY.MM.DD-provenance.N`, `date-released` matches `YYYY-MM-DD`, and both encode the same date;
+- required provenance markers and links in the policy documents;
+- rejection of absolute ownership, independent-verification, and idea-copyright claims.
+
+Run:
+
+```bash
+python3 -m unittest scripts.tests.test_validate_provenance -v
+```
+
+Expected: FAIL because the validator does not exist.
+
+**Step 2: Implement the smallest validator**
+
+Implement named functions:
+
+- `parse_top_level_cff(text: str) -> dict[str, str]`
+- `validate_cff(root: Path) -> list[str]`
+- `validate_document_markers(root: Path) -> list[str]`
+- `validate_repository(root: Path) -> list[str]`
+- `main() -> int`
+
+Use no third-party YAML dependency. Parse only top-level scalar CFF keys needed by the invariant checks; leave full CFF schema validation to the official action.
+
+**Step 3: Run the focused tests**
+
+```bash
+python3 -m unittest scripts.tests.test_validate_provenance -v
+```
+
+Expected: PASS.
+
+**Step 4: Commit**
+
+```bash
+git add scripts/validate-provenance.py scripts/tests/test_validate_provenance.py
+git commit -m "test(provenance): validate evidence metadata"
+```
+
+---
+
+## Task 2: Create the Human-Readable Provenance Record
+
+**Files:**
+
+- Create: `PROVENANCE.md`
+- Modify: `NOTICE`
+- Modify: `CITATION.cff`
+- Modify: `README.md`
+
+**Step 1: Identify exact historical evidence**
+
+For each core concept named in the design specification, locate the earliest repository commit that contains the relevant text or implementation and record:
+
+```bash
+git log --reverse --format='%H %T %aI %cI' -- PATH
+git show COMMIT_SHA:PATH
+```
+
+Do not infer an independent publication date from these timestamps.
+
+**Step 2: Add `PROVENANCE.md`**
+
+Include:
+
+- scope and explicit Apache-2.0 boundary;
+- Franz Xu's authorship and chronology representation;
+- exact commit SHA, tree SHA, path, and concept status for each core concept;
+- the timestamp-evidence limitation;
+- current status: repository history exists, but no immutable snapshot/DOI has yet been published;
+- future snapshot identifier and verification model;
+- a correction/contact process.
+
+**Step 3: Align adjacent records**
+
+- Make `NOTICE` identify Franz Xu and point to `PROVENANCE.md` without claiming ownership of abstract ideas.
+- Keep `CITATION.cff` undated but add the provenance record to the abstract or keywords if schema-valid.
+- Add a concise README link explaining what the record proves and what it does not prove.
+
+**Step 4: Run the validator**
+
+```bash
+python3 scripts/validate-provenance.py
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add PROVENANCE.md NOTICE CITATION.cff README.md
+git commit -m "docs(provenance): record design chronology"
+```
+
+---
+
+## Task 3: Tighten Contribution, Trademark, and Release Governance
+
+**Files:**
+
+- Create: `DCO`
+- Modify: `CONTRIBUTING.md`
+- Modify: `TRADEMARK.md`
+- Modify: `GOVERNANCE.md`
+- Modify: `SECURITY.md`
+- Modify: `.github/workflows/release.yml`
+
+**Step 1: Add prospective contribution attestation**
+
+Add Developer Certificate of Origin 1.1 and require `Signed-off-by` for future contributions. Explain that sign-off concerns contribution authority and provenance, not assignment of copyright or ownership of ideas.
+
+**Step 2: Correct trademark wording**
+
+Use a factual source-identification policy. Do not imply registration or guaranteed protection. Preserve nominative references and clear fork naming guidance.
+
+**Step 3: Separate release classes**
+
+- Define SemVer product releases separately from `provenance-YYYY.MM.DD.N` snapshots.
+- State that provenance snapshots are evidence publications, not maturity claims.
+- Make release/security promises conditional on the implemented workflow and exact asset set.
+
+**Step 4: Disable unsafe automatic product publishing**
+
+Replace the `v*` publishing trigger with a manual, non-publishing informational workflow. It must not create releases, upload assets, or request write permissions.
+
+**Step 5: Validate and commit**
+
+```bash
+python3 scripts/validate-provenance.py
+git add DCO CONTRIBUTING.md TRADEMARK.md GOVERNANCE.md SECURITY.md .github/workflows/release.yml
+git commit -m "docs(governance): separate provenance publication"
+```
+
+---
+
+## Task 4: Enforce Records in CI
+
+**Files:**
+
+- Modify: `.github/workflows/ci.yml`
+
+**Step 1: Add deterministic checks**
+
+Add steps that run:
+
+```bash
+python3 -m unittest scripts.tests.test_validate_provenance -v
+python3 scripts/validate-provenance.py
+```
+
+Add the official CFF conversion/validation action pinned to an immutable commit SHA. Grant no additional permissions.
+
+**Step 2: Inspect the workflow diff**
+
+```bash
+git diff --check
+git diff -- .github/workflows/ci.yml
+```
+
+Expected: the checks run on the existing CI triggers and no publishing permission is introduced.
+
+**Step 3: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci(provenance): enforce attribution records"
+```
+
+---
+
+## Task 5: Verify the Records Subsystem
+
+**Files:**
+
+- Verify all files changed above.
+
+**Step 1: Run focused verification**
+
+```bash
+python3 -m unittest scripts.tests.test_validate_provenance -v
+python3 scripts/validate-provenance.py
+git diff --check
+```
+
+**Step 2: Run repository-required verification**
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace
+./scripts/check-file-size.sh
+```
+
+Expected: all commands exit zero.
+
+**Step 3: Review claims manually**
+
+Search for forbidden overclaims and inspect every match:
+
+```bash
+rg -n "protect(ed|s)? (the )?(idea|concept)|independently verified|immutable snapshot exists|registered trademark|original and proprietary" README.md PROVENANCE.md NOTICE CITATION.cff CONTRIBUTING.md TRADEMARK.md GOVERNANCE.md SECURITY.md
+```
+
+Expected: no misleading claim remains.

--- a/docs/superpowers/specs/2026-08-27-public-provenance-release-design.md
+++ b/docs/superpowers/specs/2026-08-27-public-provenance-release-design.md
@@ -1,0 +1,501 @@
+# Public Provenance and Immutable Snapshot Design
+
+**Status:** Proposed governance and supply-chain design. The maintainer approved
+the direction in discussion; this document becomes accepted only when its pull
+request is reviewed and merged to `main`.
+
+**Owner:** Franz Xu
+
+**Repository:** `IcantFind-a-username/Sovereign-Founder-OS`
+
+## Decision
+
+Sovereign Founder OS will remain Apache-2.0 licensed. The project will build the
+strongest practical public evidence chain for authorship, chronology,
+attribution, and released artifact integrity without claiming that a public
+repository can prevent independent reimplementation of its ideas.
+
+The first immutable record will be a source and architecture **provenance
+snapshot**, not a product release. It will not use a `v0.1` tag because the
+repository's documented v0.1 release gates are not yet complete. A candidate
+UTC date `D` will be fixed in the reviewed commit, CFF metadata, and signed tag.
+The final publish step must occur on `D` in UTC; if it does not, the draft is
+abandoned and a new candidate commit/date/tag is prepared. For example, a
+snapshot completed on 2026-08-27 will use tag
+`provenance-2026.08.27.1`, CFF version `2026.08.27-provenance.1`, and CFF
+`date-released: 2026-08-27`.
+
+## Goals
+
+1. Record Franz Xu's explicit representation that he is the current original
+   project author and rights holder for the project-authored code and
+   documentation, without presenting that declaration as an independent legal
+   adjudication.
+2. Preserve a reviewable history showing the exact trees referenced by specific
+   commit objects and their recorded author and committer timestamps.
+3. Bind one exact protected-main commit, source tree, history bundle, metadata,
+   and release assets into cryptographically verifiable records.
+4. Place the record on independent archival infrastructure with a DOI and a
+   Software Heritage persistent identifier when those services complete their
+   ingestion.
+5. Make future contributions and releases preserve a clear chain of origin,
+   authorship, and artifact provenance.
+6. Keep every maturity and security statement consistent with the implemented
+   code, repository tests, RFCs, and roadmap gates.
+
+## Non-goals and legal boundary
+
+- The design does not prohibit copying that Apache-2.0 expressly permits.
+- It does not claim that copyright protects an abstract idea, procedure,
+  method, algorithmic concept, or mathematical principle. It protects original
+  expression subject to applicable law.
+- It does not prove global priority, patentability, absence of prior art, or
+  that no third party independently conceived a similar idea.
+- It does not turn a repository timestamp, a Git signature, a DOI, an
+  attestation, or a Software Heritage identifier into proof of product safety.
+- It does not label the current project production-ready or claim that the
+  roadmap's v0.1 release gate has passed.
+- It is not legal advice. Patent, trademark registration, enforcement, and
+  jurisdiction-specific evidence questions require qualified counsel.
+
+For commit history, the defensible wording will be: **“This material is present
+in tree `<tree>` referenced by commit `<sha>`, whose author and committer
+timestamps record `<time>`.”** Only an independently observed GitHub immutable
+release, Zenodo record, or Software Heritage visit may support a statement that
+material was publicly available by that service's observed date. The project
+will not use “first ever,” “invented globally,” or similar claims without
+independent evidence and legal review.
+
+## Existing evidence and gaps
+
+The current reachable history begins with commit
+`97f555c9e6079d5258dba4ca2b22ef0ff7b4b1e2`, recorded on
+2026-07-13, which introduced the project blueprint, architecture material, and
+Apache-2.0 license. That is a Git object timestamp, not an independently
+observed public-disclosure date. The repository currently has no tags or
+releases. Its
+`CITATION.cff` identifies Franz Xu, but it has no release version, release date,
+DOI, or independent archive identifier.
+
+`LICENSE`, `NOTICE`, `TRADEMARK.md`, and the README already contain attribution
+and branding terms. They use a collective “Sovereign Founder OS Authors” label
+rather than identifying the current sole rights holder. Some trademark wording
+also reads more broadly than the evidence in the repository supports and must
+not imply registration.
+
+The current release workflow builds three platform archives but allows each
+matrix job to create the release, masks release-creation failures, and permits
+asset replacement. It does not enforce that a tag is on protected `main`, rerun
+all release gates, generate checksums or an SBOM, create artifact attestations,
+or stage all assets before publication. This conflicts with the release
+properties described in `SECURITY.md` and `GOVERNANCE.md`; those properties
+remain targets until the workflow enforces them.
+
+## Evidence model
+
+The project will distinguish four kinds of evidence instead of collapsing them
+into a single “proof” claim:
+
+| Evidence | What it supports | What it does not establish |
+| --- | --- | --- |
+| Git history and commit objects | Exact content/tree relationships and self-recorded chronology currently hosted by GitHub | The date GitHub or the public first observed the content, independent creative authorship, or global priority |
+| Verified commit/release signatures and attestations | Control of an accepted signing identity or trusted workflow; exact artifact/ref binding | Originality, code safety, or human intent by themselves |
+| Immutable GitHub Release | A locked tag, commit, and asset set with a release attestation | Permanent availability if the release is deleted, or independent archiving |
+| Zenodo DOI and Software Heritage SWHID | Independent, persistent citation and content/archive identity | A legal judgment of ownership, novelty, or non-infringement |
+
+Every public statement and verification guide will use these scoped meanings.
+
+## Repository records
+
+### Root provenance record
+
+A root `PROVENANCE.md` will become the human-readable authority for publication
+history. It will contain:
+
+- project name, canonical repository, Franz Xu's signed author/rights-holder
+  declaration, and an explicit statement that it is the declarant's
+  representation rather than an independent finding;
+- the exact GitHub identity and, when the owner provides one, ORCID;
+- the earliest reachable repository commit and a table of important concepts or
+  implementation milestones, each linked to an exact commit, tree, and path,
+  with author/committer timestamps labelled as Git metadata;
+- labels distinguishing current implementation, target design, research, and
+  historical material;
+- release tag, target commit, tree hash, release manifest hash, DOI, and SWHID
+  for each completed snapshot;
+- a plain statement of the evidence limits defined above; and
+- maintainer signing-key fingerprints and revocation/rotation instructions only
+  after a user-controlled signing key exists.
+
+The milestone table will include only concepts already public in the repository.
+It will not disclose new patent candidates or confidential implementation
+details merely to make the table appear more comprehensive.
+
+### Attribution metadata
+
+Based on the maintainer's confirmed chain-of-title representation, `NOTICE` will
+identify Franz Xu as the original project author and declarant of current
+rights, while retaining a form that can accommodate future contributors without
+retrospectively assigning their rights. It will not add restrictions that
+contradict Apache-2.0. The Apache license text will remain unchanged except that
+its application notice may name Franz Xu as the declarant copyright holder.
+Authorship credit in CFF and a legal ownership declaration remain distinct
+records.
+
+`CITATION.cff` will add the provenance-snapshot version and `date-released`
+before the tag is created. A DOI and optional ORCID will be added only when
+exact values are available; placeholders are forbidden. At candidate freeze,
+CFF, the proposed tag, and release metadata must agree on title, author,
+version, date, repository URL, and license. After publication, the immutable
+snapshot's embedded CFF remains canonical for what that snapshot contained;
+the Zenodo version record is canonical for its DOI, and a later `main` commit
+may add that DOI without pretending it was embedded in the earlier snapshot.
+
+`TRADEMARK.md` will describe project marks and anti-confusion rules without
+claiming that a mark is registered when no registration is evidenced. It will
+not attempt to use trademark policy to revoke Apache permissions.
+
+### Future contribution origin
+
+`CONTRIBUTING.md` will require contributors to certify that they have the right
+to submit their work under Apache-2.0 and to preserve third-party notices. A
+standard Developer Certificate of Origin record and `Signed-off-by` process will
+apply prospectively; historical commits will not be rewritten. Dependency and
+third-party attribution must remain separate from claims of project authorship.
+
+### Maintainer signing trust anchor
+
+Before the first snapshot, Franz Xu will create or select a user-controlled GPG
+or SSH signing key. The public key or allowed-signer entry, exact fingerprint,
+accepted identity, creation date, and revocation/rotation procedure will be
+published in `PROVENANCE.md` and associated with the maintainer's GitHub
+account. The repository will pin that fingerprint rather than trusting any key
+that happens to produce a GitHub “Verified” badge.
+
+Every `provenance-*` ref will be an annotated tag signed by that key. The
+workflow will verify the tag object locally against the pinned trust anchor,
+record the tag object ID and signer fingerprint, and separately verify the
+target commit/tree and GitHub's commit-verification result. A GitHub-signed
+merge commit and a maintainer-signed tag are complementary evidence, not
+interchangeable evidence.
+
+The same key will produce a detached signature over `release-manifest.json`.
+If no user-controlled trust anchor exists or either verification fails, the
+workflow may produce local/dry-run evidence but must not publish the snapshot
+described by this design.
+
+## Publication class and governance
+
+The project will define **provenance snapshot publication** as a separate class
+from a SemVer product release. It may use a GitHub prerelease object as an
+immutable evidence container, but it ships no product binaries, does not become
+the “latest” product release, and cannot waive any roadmap, security, support,
+or binary-release gate.
+
+`GOVERNANCE.md`, `SECURITY.md`, and the README will be amended before the first
+snapshot so their use of “release” distinguishes product releases from source-
+only provenance publications. The unsafe legacy `v*` workflow will be disabled
+from automatic publication until a separate product-release redesign satisfies
+the existing binary, checksum, SBOM, signature, provenance, and support
+requirements. That cross-platform redesign is not a prerequisite for creating
+the source-only provenance workflow.
+
+## Snapshot identity and release semantics
+
+The first snapshot will use these public identifier rules. Candidate date `D`,
+the annotated tag's UTC tagger date, CFF `date-released`, and GitHub publication
+date must be the same UTC date. The examples below apply only if the complete
+publication finishes on 2026-08-27 UTC:
+
+| Field | Value |
+| --- | --- |
+| Git tag | `provenance-YYYY.MM.DD.N` (example: `provenance-2026.08.27.1`) |
+| GitHub title | `Sovereign Founder OS — Public Provenance Snapshot YYYY-MM-DD` |
+| CFF version | `YYYY.MM.DD-provenance.N` |
+| CFF release date | `YYYY-MM-DD` |
+| Release kind | GitHub prerelease and immutable release |
+| Product maturity | Developer Preview; not a product release |
+| Release contents | Source/history evidence only; no product binaries |
+
+Release notes will state that the snapshot records already-public source,
+documentation, architecture, and history. They will explicitly deny production
+readiness, security certification, roadmap-gate completion, and exclusive legal
+rights over abstract ideas.
+
+A correction after publication creates a monotonically increasing new snapshot,
+for example `provenance-2026.08.27.2`. Published tag names and assets are never
+reused. Deletion is reserved for a genuine legal, privacy, credential, or
+malware emergency and does not imply that independent archives can be erased.
+
+## Release architecture
+
+```mermaid
+flowchart TD
+    A["Reviewed protected-main commit"] --> B["Validated provenance tag"]
+    B --> C["Tests and evidence build"]
+    C --> D["Draft GitHub Release"]
+    D --> E["Assets, hashes, SBOM, attestations"]
+    E --> F["Environment approval"]
+    F --> G["Immutable publication"]
+    G --> H["Zenodo DOI and Software Heritage archive"]
+    H --> I["Metadata backfill PR"]
+```
+
+### Trigger and trust boundary
+
+The provenance workflow will accept only signed annotated tags matching
+`provenance-YYYY.MM.DD.N`. It will fail unless the tag signature matches the
+pinned maintainer trust anchor, the tag resolves to a commit reachable from the
+protected default branch, GitHub reports the target commit as verified, and the
+candidate/tag/current UTC dates satisfy the same-day rule. A GitHub API
+preflight will inspect the default-branch ruleset and required checks rather
+than treating `merge-base` reachability alone as branch protection. A protected
+release environment will gate final publication. Repository rules will protect
+both `provenance-*` and future `v*` tags from movement or unauthorized creation.
+
+The workflow will check out and fetch the complete default-branch and tag
+history before signature, reachability, history, or bundle checks. Shallow
+history is not acceptable for this workflow.
+
+Actions will remain pinned to full commit SHAs. Permissions will be declared at
+job level and limited to the minimum required. Build jobs will be read-only;
+the attestation job alone receives OIDC and attestation permissions, while the
+two release-lifecycle jobs receive only the contents permission needed to stage
+or publish the release.
+
+### Required gates
+
+Before a draft release is created, the workflow will run or depend on fresh
+successful evidence for:
+
+- CFF schema validation and cross-file metadata consistency;
+- `cargo fmt --all --check`;
+- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`;
+- `cargo test --workspace --locked`;
+- the repository file-size guardrail;
+- frontend type checking;
+- dependency audit and full-history secret scanning;
+- GitHub API evidence that the candidate reached protected `main` through a PR
+  whose required checks, including dependency review, succeeded; dependency
+  review is not incorrectly rerun as a tag-only job;
+- workflow linting and release-script tests; and
+- verification that the tag target and recorded source commit are exact.
+
+The workflow will also preflight repository visibility and GitHub artifact-
+attestation availability, inspect the applicable branch/tag rulesets, and scan
+the complete reachable history for secrets, private material, unintended large
+objects, and missing third-party notices before creating a permanent history
+bundle or independent archive. Every action, workflow helper, SBOM generator,
+and workflow linter will be exact-version or full-SHA pinned in implementation.
+
+### Evidence assets
+
+The draft release will be complete before publication and contain:
+
+1. a normalized source tarball produced from the tag target using `git archive`
+   with a fixed prefix, `LC_ALL=C`, `TZ=UTC`, and `gzip -n -9`; the manifest
+   records exact Git and gzip versions;
+2. a Git bundle created from exactly `refs/tags/$TAG`, including its signed
+   annotated tag object and reachable history but excluding unrelated local and
+   remote refs;
+3. an SPDX or CycloneDX SBOM produced by an exact-pinned generator and scoped to
+   the `Cargo.lock` Rust dependency graph; GitHub Actions, runner packages, and
+   the ephemeral TypeScript checker are recorded separately and are not
+   misrepresented as part of that Rust SBOM;
+4. `VERIFY.md` with checksum, bundle, tag-signature, GitHub attestation, commit,
+   tree, and metadata verification commands;
+5. `release-manifest.json` containing the repository, tag ref/object, commit and
+   tree SHAs, maintainer signer identity/fingerprint, workflow identity/run,
+   toolchain, pinned action revisions, `Cargo.lock` hash, CFF hash, and hashes
+   of the four payload assets above, but not a hash of itself;
+6. a detached maintainer signature over `release-manifest.json`;
+7. `SHA256SUMS` covering the four payload assets, manifest, and detached
+   signature, while explicitly excluding `SHA256SUMS` itself; and
+8. GitHub artifact attestations for the source archive, history bundle, SBOM,
+   verification guide, manifest, detached signature, and checksum file.
+
+This acyclic layout is mandatory: no file is required to contain its own hash.
+The immutable-release attestation binds the complete final GitHub asset set,
+including `SHA256SUMS`.
+
+The bundle will be checked with `git bundle verify`, cloned into an empty
+temporary directory, checked with `git fsck --full`, and inspected to confirm
+that `refs/tags/$TAG`, the annotated tag object ID, target commit, tree, and tag
+signature match the release manifest. The workflow must use a complete clone
+before creating the bundle.
+
+The workflow will not claim bit-for-bit reproducibility for an asset unless it
+actually builds that asset twice in isolated jobs and compares identical
+digests. The Git bundle preserves object history but is treated as a hashed
+published artifact, not assumed reproducible output.
+
+### Draft-first publication
+
+A single `stage-draft` job, not the build matrix, will gather the completed
+workflow artifacts, create the draft, upload the complete asset set, and verify
+the uploaded names and hashes. A separate `publish` job will then wait for the
+protected environment approval, re-fetch and re-verify the unchanged draft,
+and publish it exactly once. Error masking, `--clobber`, and concurrent release
+creation are forbidden.
+
+Immutable releases must be enabled in repository settings before publication.
+After publication, GitHub's release attestation is verified and recorded. The
+existing automatic product-release path will remain disabled until a separate
+design and PR implement its binary-specific gather-then-publish gates. No `v*`
+product tag will be created as part of this provenance snapshot.
+
+## Independent archival flow
+
+Before GitHub publication, the owner will connect the public repository to
+Zenodo using the same GitHub identity. ORCID is desirable for identity
+disambiguation but is not a blocker and will never be guessed.
+
+After publication:
+
+1. wait for Zenodo to ingest the release and issue the exact version DOI;
+2. verify Zenodo's reported Software Heritage archival status;
+3. request Software Heritage “Save Code Now” directly if the integration has
+   not produced a usable archive visit;
+4. verify the DOI resolves to the expected title, author, version, date, license,
+   repository, and source archive;
+5. record the Zenodo version DOI and concept DOI as distinct identifiers, plus
+   the Software Heritage `swh:1:rev` identifier for the archived revision and,
+   when available, `swh:1:dir` for its source tree, archive visit, release URL,
+   commit/tree hashes, and manifest hash in `PROVENANCE.md`; and
+6. add the DOI to `CITATION.cff` through a normal reviewed PR without pretending
+   that the post-release commit was part of the earlier immutable snapshot.
+
+The evidence chain is incomplete, and will be described as incomplete, until
+both the GitHub immutable release and at least one independent archive record
+have been verified.
+
+## Future disclosure gate
+
+Independently archived public chronology can support a publication-priority
+record but destroys secrecy.
+Before a future architectural document exposes a potentially patentable or
+commercially secret mechanism, the maintainer will choose one of three paths:
+
+1. publish it deliberately and add it to the next provenance record;
+2. obtain qualified patent advice and file before public disclosure where
+   appropriate; or
+3. keep it outside the public repository under access control and appropriate
+   confidentiality obligations.
+
+No repository template may silently classify public material as a trade secret.
+Already-public Apache-2.0 material remains public and licensed under its existing
+terms.
+
+## Automation boundary
+
+The repository changes, validation scripts, deterministic evidence build, dry
+run, branch, commits, pull requests, and CI checks may be automated. The
+automation must stop before any step that would invent, extract, or impersonate
+a maintainer identity or grant new external authority.
+
+The following remain explicit owner actions or approvals:
+
+- create and retain the user-controlled signing key, then publish its public
+  trust anchor;
+- enable GitHub immutable releases and tag rulesets;
+- configure and approve the protected release environment;
+- connect and authorize Zenodo and optionally ORCID; and
+- approve final immutable publication after inspecting the staged draft.
+
+Until those actions are complete, automation may open and merge ordinary
+reviewed repository PRs and produce verified dry-run evidence, but it must not
+create the provenance tag or claim that an immutable/independent evidence chain
+exists.
+
+## Failure modes and responses
+
+| Failure | Required response |
+| --- | --- |
+| Metadata disagrees across CFF, manifest, tag, and release | Fail before draft creation |
+| Maintainer tag signature or pinned trust anchor is missing/invalid | Stop at dry run; do not create or publish the external snapshot |
+| Tag is not on protected `main` or target is not verified | Fail closed; do not create a release |
+| Candidate date, tagger date, current UTC date, or CFF date differs | Abandon the draft and prepare a newly dated candidate commit/tag |
+| Any test, scan, SBOM, checksum, or attestation step fails | Preserve logs; publish nothing |
+| Full-history privacy/licensing preflight finds unresolved material | Block permanent bundle/archive creation pending owner review |
+| One platform/job is delayed | Keep the release as a draft; never publish a partial set |
+| Immutable publication contains a non-emergency error | Publish a new numbered snapshot and cross-reference the superseded one |
+| Zenodo or Software Heritage ingestion fails | Keep GitHub evidence, report archival status honestly, and retry through the documented service path |
+| A third party removes required Apache notices | Preserve evidence and seek project-owner/legal review; do not make automated public accusations |
+| A third party independently reimplements an idea | Use the chronology record only for accurate attribution or legal review; do not claim copyright necessarily prohibits it |
+| Signing key is compromised | Publish revocation information through independent channels and rotate; never rewrite old evidence |
+
+## Verification and acceptance criteria
+
+Implementation is accepted only when all of the following are demonstrated:
+
+- the root provenance record contains no unsupported “first” or patent claims;
+- author, title, license, version, and date agree across repository metadata;
+- the maintainer tag and manifest signatures verify against the exact public
+  trust-anchor fingerprint recorded before snapshot publication;
+- future contribution-origin rules are explicit and prospective;
+- release scripts have positive and negative tests for tag, branch, metadata,
+  missing-asset, hash-mismatch, and double-publication cases;
+- workflow files pass `actionlint` or an equivalent pinned validator;
+- the standard repository validation commands pass from a clean checkout;
+- a dry run produces the complete evidence directory without creating a tag or
+  external release;
+- two normalized source-archive builds produce the same SHA-256 digest;
+- each payload asset appears once in both the manifest and `SHA256SUMS`; the
+  manifest and its detached signature also appear once in `SHA256SUMS`, which
+  excludes only itself;
+- GitHub verifies artifact and immutable-release attestations for the published
+  objects;
+- the public release is visibly immutable and is attached to the intended
+  commit;
+- Zenodo metadata resolves to the intended snapshot and DOI; and
+- a Software Heritage SWHID resolves to the archived project content.
+
+## Implementation sequence
+
+1. **Identity and publication-policy PR:** add the root provenance record;
+   tighten NOTICE, CFF, trademark, contribution-origin, governance, security,
+   and README wording; add metadata consistency tests; disable unsafe automatic
+   `v*` publication without claiming the future product pipeline is complete.
+2. **Provenance-workflow PR:** add deterministic source packaging, exact-scope
+   history bundle, SBOM, acyclic manifest/checksum/signature layout,
+   verification guide, workflow tests, dry-run mode, and artifact attestations.
+3. **Automated dry run and review:** generate and independently inspect the
+   evidence set; rerun all repository gates from the candidate commit. This is
+   the end of unattended automation when owner-controlled trust/settings are
+   absent.
+4. **Owner trust and repository settings:** publish the maintainer trust anchor,
+   enable immutable releases, protect release tags, configure the protected
+   environment, and connect Zenodo before publication.
+5. **Dated candidate PR:** set the exact candidate date/version in CFF and
+   provenance metadata, pass protected-branch checks, and merge on the intended
+   UTC publication date.
+6. **Snapshot publication:** create the signed provenance tag, let the workflow
+   stage the draft, approve only after asset verification, and publish on the
+   candidate UTC date.
+7. **Independent verification PR:** record the version/concept DOI and revision/
+   directory SWHIDs after they resolve; update CFF and provenance links without
+   modifying the immutable snapshot.
+8. **Separate product-release PR:** redesign the cross-platform `v*` pipeline
+   before any SemVer product tag, without retroactively treating the provenance
+   publication as a product release.
+
+Each implementation PR remains independently reviewable and uses conventional
+commit and branch names. No product tag is created until its roadmap gates are
+separately met.
+
+## Authoritative references
+
+- [WIPO Copyright Treaty, Articles 2 and 4](https://www.wipo.int/wipolex/en/text/295166)
+- [IPOS copyright overview](https://www.ipos.gov.sg/about-ip/copyright/introduction-copyright/)
+- [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+- [GitHub: Immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases)
+- [GitHub: Signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
+- [GitHub: Artifact attestations](https://docs.github.com/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds)
+- [SLSA build requirements](https://slsa.dev/spec/v1.2/build-requirements)
+- [GitHub: Citation files](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files)
+- [Zenodo: Enable a GitHub repository](https://help.zenodo.org/docs/github/enable-repository/)
+- [Zenodo: Archive a GitHub release](https://help.zenodo.org/docs/github/archive-software/github-upload/)
+- [Software Heritage persistent identifiers](https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html)
+- [Software Heritage Save Code Now](https://docs.softwareheritage.org/user/faq/index.html#save-code-now)
+- [IPOS public-disclosure guidance](https://ask.gov.sg/ipos/questions/clglxzrss00p5l408ir2trecl)
+- [IPOS trade-secret overview](https://www.ipos.gov.sg/about-ip/trade-secret/)

--- a/scripts/build-provenance-evidence.py
+++ b/scripts/build-provenance-evidence.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Build deterministic source and history evidence for one explicit ref."""
+
+from __future__ import annotations
+
+import argparse
+import platform
+import shutil
+import sys
+import zlib
+from pathlib import Path
+
+from provenance_evidence import (
+    EvidenceError,
+    SAFE_ID,
+    exact_ref_bundle,
+    normalized_source_archive,
+    parse_cargo_lock,
+    read_git_blob,
+    resolve_ref,
+    run_git,
+    sha256_bytes,
+    write_json,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", type=Path, required=True)
+    parser.add_argument("--ref", required=True)
+    parser.add_argument("--snapshot-id", required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--mode", choices=("dry-run", "publishable"), required=True)
+    parser.add_argument("--repository-url")
+    parser.add_argument("--workflow-ref", default="local")
+    parser.add_argument("--workflow-run-url", default="local")
+    return parser.parse_args()
+
+
+def build(args: argparse.Namespace) -> None:
+    root = args.repository.resolve()
+    output = args.output_dir.resolve()
+    if args.mode != "dry-run":
+        raise EvidenceError(
+            "publishable mode is locked until a maintainer trust anchor is configured"
+        )
+    if not SAFE_ID.fullmatch(args.snapshot_id):
+        raise EvidenceError("invalid snapshot ID")
+    if output.is_symlink():
+        raise EvidenceError("output directory must not be a symlink")
+    if output.exists() and (not output.is_dir() or any(output.iterdir())):
+        raise EvidenceError("output directory must be absent or empty")
+    output.mkdir(parents=True, exist_ok=True)
+
+    ref_object, commit, tree = resolve_ref(root, args.ref)
+    repository_url = args.repository_url
+    if not repository_url:
+        repository_url = run_git(root, "remote", "get-url", "origin")
+    materials: dict[str, dict[str, object]] = {}
+    material_bytes: dict[str, bytes] = {}
+    for name in ("Cargo.lock", "CITATION.cff"):
+        blob_id, content = read_git_blob(root, f"{commit}:{name}")
+        material_bytes[name] = content
+        materials[name] = {
+            "git_blob": blob_id,
+            "sha256": sha256_bytes(content),
+            "size": len(content),
+        }
+    package_counts = parse_cargo_lock(material_bytes["Cargo.lock"])
+    cargo_packages = [
+        {"name": name, "version": version}
+        for (name, version), count in sorted(package_counts.items())
+        for _ in range(count)
+    ]
+    source_name = f"{args.snapshot_id}-source.tar.gz"
+    bundle_name = f"{args.snapshot_id}.bundle"
+    normalized_source_archive(root, args.ref, output / source_name, args.snapshot_id)
+    exact_ref_bundle(root, args.ref, output / bundle_name)
+
+    write_json(
+        output / "build-metadata.json",
+        {
+            "schema_version": 1,
+            "snapshot_id": args.snapshot_id,
+            "mode": "dry-run",
+            "publishable": False,
+            "ref": args.ref,
+            "ref_object": ref_object,
+            "commit": commit,
+            "tree": tree,
+            "repository_url": repository_url,
+            "source_archive": source_name,
+            "git_bundle": bundle_name,
+            "materials": materials,
+            "cargo_lock_packages": cargo_packages,
+            "workflow": {
+                "ref": args.workflow_ref,
+                "run_url": args.workflow_run_url,
+            },
+            "tools": {
+                "git": run_git(root, "--version"),
+                "python": platform.python_version(),
+                "zlib_compile": zlib.ZLIB_VERSION,
+                "zlib_runtime": zlib.ZLIB_RUNTIME_VERSION,
+            },
+            "compression": {
+                "algorithm": "gzip",
+                "level": 9,
+                "filename": "",
+                "mtime": 0,
+            },
+        },
+        exclusive=True,
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        build(args)
+    except (EvidenceError, OSError, shutil.Error) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    print(f"Built unsigned dry-run evidence in {args.output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-workflows.sh
+++ b/scripts/check-workflows.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ACTIONLINT_VERSION="1.7.12"
+ACTIONLINT_LINUX_X86_64_SHA256="8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+
+if [[ "$(uname -s)" != "Linux" || "$(uname -m)" != "x86_64" ]]; then
+  echo "pinned actionlint bootstrap supports Linux x86_64 only" >&2
+  exit 1
+fi
+
+tool_dir="$(mktemp -d)"
+trap 'rm -rf -- "$tool_dir"' EXIT
+archive="$tool_dir/actionlint.tar.gz"
+url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+
+curl --proto '=https' --tlsv1.2 --fail --silent --show-error --location \
+  "$url" --output "$archive"
+echo "$ACTIONLINT_LINUX_X86_64_SHA256  $archive" | sha256sum --check --status
+tar --no-same-owner -xzf "$archive" -C "$tool_dir" actionlint
+"$tool_dir/actionlint"

--- a/scripts/finalize-provenance-evidence.py
+++ b/scripts/finalize-provenance-evidence.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Finalize an unsigned dry-run evidence directory with acyclic hashes."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import stat
+import sys
+from pathlib import Path
+
+from provenance_evidence import (
+    cargo_package_metadata,
+    EvidenceError,
+    SAFE_ID,
+    read_json,
+    require_regular_file,
+    sha256_file,
+    validate_cargo_lock_sbom,
+    write_json,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--evidence-dir", type=Path, required=True)
+    parser.add_argument("--sbom", type=Path, required=True)
+    parser.add_argument("--verify-guide", type=Path)
+    parser.add_argument("--sbom-generator", required=True)
+    parser.add_argument("--sbom-generator-version", required=True)
+    parser.add_argument("--sbom-generator-source", required=True)
+    return parser.parse_args()
+
+
+def _copy_new(source: Path, destination: Path) -> None:
+    require_regular_file(source)
+    if os.path.lexists(destination):
+        raise EvidenceError(f"refusing to overwrite existing {destination.name}")
+    with source.open("rb") as incoming, destination.open("xb") as outgoing:
+        while chunk := incoming.read(1024 * 1024):
+            outgoing.write(chunk)
+
+
+def finalize(args: argparse.Namespace) -> None:
+    evidence = args.evidence_dir.expanduser().absolute()
+    try:
+        evidence_mode = evidence.lstat().st_mode
+    except OSError as error:
+        raise EvidenceError("evidence directory is unavailable") from error
+    if not stat.S_ISDIR(evidence_mode) or evidence.is_symlink():
+        raise EvidenceError("evidence directory must be a real directory")
+    metadata = read_json(evidence / "build-metadata.json")
+    if metadata.get("mode") != "dry-run" or metadata.get("publishable") is not False:
+        raise EvidenceError("only explicitly non-publishable dry runs can be finalized")
+    snapshot_id = metadata.get("snapshot_id")
+    source_name = metadata.get("source_archive")
+    bundle_name = metadata.get("git_bundle")
+    if not all(isinstance(item, str) for item in (snapshot_id, source_name, bundle_name)):
+        raise EvidenceError("build metadata is missing required names")
+    if not SAFE_ID.fullmatch(snapshot_id):
+        raise EvidenceError("build metadata contains an unsafe snapshot ID")
+    builder_names = {source_name, bundle_name, "build-metadata.json"}
+    if {path.name for path in evidence.iterdir()} != builder_names:
+        raise EvidenceError("evidence directory contains unexpected pre-finalization entries")
+    for name in builder_names:
+        if Path(name).name != name:
+            raise EvidenceError(f"required payload is missing or unsafe: {name}")
+        require_regular_file(evidence / name)
+
+    expected_packages = cargo_package_metadata(metadata.get("cargo_lock_packages"))
+    materials = metadata.get("materials")
+    cargo_material = materials.get("Cargo.lock") if isinstance(materials, dict) else None
+    cargo_lock_sha256 = (
+        cargo_material.get("sha256") if isinstance(cargo_material, dict) else None
+    )
+    if not isinstance(cargo_lock_sha256, str):
+        raise EvidenceError("build metadata has no Cargo.lock material hash")
+
+    sbom_source = args.sbom.expanduser().absolute()
+    sbom_value = read_json(sbom_source)
+    sbom_suffix, covered_package_count = validate_cargo_lock_sbom(
+        sbom_value,
+        expected_packages,
+        cargo_lock_sha256,
+        args.sbom_generator,
+        args.sbom_generator_version,
+    )
+    sbom_name = f"{snapshot_id}.sbom.{sbom_suffix}"
+    _copy_new(sbom_source, evidence / sbom_name)
+
+    default_guide = Path(__file__).resolve().parent.parent / "docs/release/VERIFY.md"
+    guide = (args.verify_guide or default_guide).expanduser().absolute()
+    _copy_new(guide, evidence / "VERIFY.md")
+
+    roles = {
+        source_name: "normalized-source",
+        bundle_name: "exact-ref-git-bundle",
+        "build-metadata.json": "build-metadata",
+        sbom_name: "cargo-lock-sbom",
+        "VERIFY.md": "verification-guide",
+    }
+    assets = []
+    for name in sorted(roles):
+        path = evidence / name
+        assets.append(
+            {
+                "name": name,
+                "role": roles[name],
+                "sha256": sha256_file(path),
+                "size": path.stat().st_size,
+            }
+        )
+
+    manifest = {
+        "schema_version": 1,
+        "snapshot_id": snapshot_id,
+        "mode": "dry-run",
+        "publishable": False,
+        "repository_url": metadata.get("repository_url"),
+        "ref": metadata.get("ref"),
+        "ref_object": metadata.get("ref_object"),
+        "commit": metadata.get("commit"),
+        "tree": metadata.get("tree"),
+        "materials": metadata.get("materials"),
+        "build_context": {
+            "tools": metadata.get("tools"),
+            "compression": metadata.get("compression"),
+            "workflow": metadata.get("workflow"),
+        },
+        "sbom": {
+            "scope": "Cargo.lock dependency graph",
+            "format": sbom_suffix,
+            "generator": args.sbom_generator,
+            "generator_version": args.sbom_generator_version,
+            "generator_source": args.sbom_generator_source,
+            "covered_package_count": covered_package_count,
+            "cargo_lock_package_count": sum(expected_packages.values()),
+        },
+        "assets": assets,
+    }
+    manifest_path = evidence / "release-manifest.json"
+    write_json(manifest_path, manifest, exclusive=True)
+
+    checksummed = [asset["name"] for asset in assets] + [manifest_path.name]
+    lines = [f"{sha256_file(evidence / name)}  {name}" for name in sorted(checksummed)]
+    with (evidence / "SHA256SUMS").open("x", encoding="utf-8") as handle:
+        handle.write("\n".join(lines) + "\n")
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        finalize(args)
+    except (EvidenceError, OSError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    print(f"Finalized unsigned dry-run evidence in {args.evidence_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate-provenance-sbom.sh
+++ b/scripts/generate-provenance-sbom.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SYFT_VERSION="1.51.0"
+SYFT_LINUX_AMD64_SHA256="2a2e837a2c8d59ec9af5472ee22d3b04ee463c4e44476ecf993fd1e5ab6ebc7f"
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 INPUT_Cargo.lock OUTPUT.spdx.json" >&2
+  exit 2
+fi
+if [[ "$(uname -s)" != "Linux" || "$(uname -m)" != "x86_64" ]]; then
+  echo "pinned Syft bootstrap supports Linux x86_64 only" >&2
+  exit 1
+fi
+
+input="$1"
+output="$2"
+if [[ ! -f "$input" || -L "$input" || "$(basename -- "$input")" != "Cargo.lock" ]]; then
+  echo "SBOM input must be a regular non-symlink named Cargo.lock" >&2
+  exit 1
+fi
+if [[ -e "$output" || -L "$output" ]]; then
+  echo "refusing to overwrite SBOM output: $output" >&2
+  exit 1
+fi
+
+tool_dir="$(mktemp -d)"
+trap 'rm -rf -- "$tool_dir"' EXIT
+archive="$tool_dir/syft.tar.gz"
+url="https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz"
+input_dir="$(dirname -- "$(realpath -- "$input")")"
+output="$(realpath -m -- "$output")"
+
+curl --proto '=https' --tlsv1.2 --fail --silent --show-error --location \
+  "$url" --output "$archive"
+echo "$SYFT_LINUX_AMD64_SHA256  $archive" | sha256sum --check --status
+tar --no-same-owner -xzf "$archive" -C "$tool_dir" syft
+(
+  cd "$input_dir"
+  "$tool_dir/syft" scan file:Cargo.lock --output "spdx-json=$output"
+)

--- a/scripts/materialize-provenance-cargo-lock.py
+++ b/scripts/materialize-provenance-cargo-lock.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Materialize the exact Cargo.lock blob recorded by evidence metadata."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import stat
+import sys
+from pathlib import Path
+
+from provenance_evidence import (
+    EvidenceError,
+    read_git_blob,
+    read_json,
+    sha256_bytes,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", type=Path, required=True)
+    parser.add_argument("--metadata", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def materialize(args: argparse.Namespace) -> None:
+    repository = args.repository.resolve()
+    metadata = read_json(args.metadata.expanduser().absolute())
+    commit = metadata.get("commit")
+    if not isinstance(commit, str) or not re.fullmatch(r"[0-9a-f]{40}|[0-9a-f]{64}", commit):
+        raise EvidenceError("build metadata commit is not a full Git object ID")
+    materials = metadata.get("materials")
+    cargo_material = materials.get("Cargo.lock") if isinstance(materials, dict) else None
+    if not isinstance(cargo_material, dict):
+        raise EvidenceError("build metadata has no Cargo.lock material identity")
+
+    blob_id, content = read_git_blob(repository, f"{commit}:Cargo.lock")
+    if (
+        cargo_material.get("git_blob") != blob_id
+        or cargo_material.get("sha256") != sha256_bytes(content)
+        or cargo_material.get("size") != len(content)
+    ):
+        raise EvidenceError("recorded Cargo.lock material does not match the Git blob")
+
+    output = args.output.expanduser().absolute()
+    if output.name != "Cargo.lock":
+        raise EvidenceError("materialized output must be named Cargo.lock")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    parent_mode = output.parent.lstat().st_mode
+    if not stat.S_ISDIR(parent_mode) or output.parent.is_symlink():
+        raise EvidenceError("materialized output parent must be a real directory")
+    if os.path.lexists(output):
+        raise EvidenceError("refusing to overwrite materialized Cargo.lock")
+    with output.open("xb") as handle:
+        handle.write(content)
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        materialize(args)
+    except (EvidenceError, OSError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    print(f"Materialized recorded Cargo.lock at {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/provenance_evidence.py
+++ b/scripts/provenance_evidence.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Shared primitives for deterministic provenance evidence."""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import json
+import os
+import re
+import stat
+import subprocess
+import tomllib
+from collections import Counter
+from pathlib import Path
+
+
+SAFE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+
+class EvidenceError(RuntimeError):
+    """Raised when evidence cannot be built or verified safely."""
+
+
+def _git_environment() -> dict[str, str]:
+    environment = os.environ.copy()
+    environment.update({"LC_ALL": "C", "LANG": "C", "TZ": "UTC"})
+    return environment
+
+
+def run_git(root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=root,
+        env=_git_environment(),
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise EvidenceError(f"git {' '.join(args)} failed: {detail}")
+    return result.stdout.strip()
+
+
+def resolve_ref(root: Path, ref: str) -> tuple[str, str, str]:
+    if not ref.startswith("refs/") or any(char.isspace() for char in ref):
+        raise EvidenceError("ref must be an explicit full ref under refs/")
+    run_git(root, "check-ref-format", ref)
+    run_git(root, "show-ref", "--verify", ref)
+    ref_object = run_git(root, "rev-parse", "--verify", ref)
+    commit = run_git(root, "rev-parse", "--verify", f"{ref}^{{commit}}")
+    tree = run_git(root, "rev-parse", "--verify", f"{commit}^{{tree}}")
+    return ref_object, commit, tree
+
+
+def normalized_source_archive(
+    root: Path, ref: str, destination: Path, prefix: str
+) -> None:
+    if not SAFE_ID.fullmatch(prefix):
+        raise EvidenceError("snapshot ID is not safe for an archive prefix")
+    archive = subprocess.Popen(
+        ["git", "archive", "--format=tar", f"--prefix={prefix}/", ref],
+        cwd=root,
+        env=_git_environment(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert archive.stdout is not None
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with destination.open("wb") as raw:
+            with gzip.GzipFile(filename="", mode="wb", fileobj=raw, mtime=0, compresslevel=9) as zipped:
+                while chunk := archive.stdout.read(1024 * 1024):
+                    zipped.write(chunk)
+        stderr = archive.communicate()[1].decode("utf-8", errors="replace").strip()
+        if archive.returncode:
+            destination.unlink(missing_ok=True)
+            raise EvidenceError(f"git archive failed: {stderr}")
+    finally:
+        if archive.poll() is None:
+            archive.kill()
+            archive.wait()
+
+
+def exact_ref_bundle(root: Path, ref: str, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    run_git(root, "bundle", "create", str(destination), ref)
+    heads = run_git(root, "bundle", "list-heads", str(destination)).splitlines()
+    expected_suffix = f" {ref}"
+    if len(heads) != 1 or not heads[0].endswith(expected_suffix):
+        destination.unlink(missing_ok=True)
+        raise EvidenceError("bundle did not contain exactly the requested ref")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def read_git_blob(root: Path, object_spec: str) -> tuple[str, bytes]:
+    blob_id = run_git(root, "rev-parse", "--verify", object_spec)
+    if run_git(root, "cat-file", "-t", blob_id) != "blob":
+        raise EvidenceError(f"Git object is not a blob: {object_spec}")
+    result = subprocess.run(
+        ["git", "cat-file", "blob", blob_id],
+        cwd=root,
+        env=_git_environment(),
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode:
+        raise EvidenceError(
+            f"cannot read Git blob {object_spec}: "
+            f"{result.stderr.decode('utf-8', errors='replace').strip()}"
+        )
+    return blob_id, result.stdout
+
+
+def parse_cargo_lock(content: bytes) -> Counter[tuple[str, str]]:
+    try:
+        value = tomllib.loads(content.decode("utf-8"))
+    except (UnicodeDecodeError, tomllib.TOMLDecodeError) as error:
+        raise EvidenceError(f"cannot parse Cargo.lock package graph: {error}") from error
+    packages = value.get("package")
+    if not isinstance(packages, list) or not packages:
+        raise EvidenceError("Cargo.lock package graph is empty or malformed")
+    identities: Counter[tuple[str, str]] = Counter()
+    for package in packages:
+        if not isinstance(package, dict):
+            raise EvidenceError("Cargo.lock contains malformed package metadata")
+        name, version = package.get("name"), package.get("version")
+        if not isinstance(name, str) or not name or not isinstance(version, str) or not version:
+            raise EvidenceError("Cargo.lock contains a malformed package identity")
+        identities[(name, version)] += 1
+    return identities
+
+
+def cargo_package_metadata(value: object) -> Counter[tuple[str, str]]:
+    if not isinstance(value, list) or not value:
+        raise EvidenceError("build metadata has no Cargo.lock package graph")
+    identities: Counter[tuple[str, str]] = Counter()
+    for package in value:
+        if not isinstance(package, dict):
+            raise EvidenceError("malformed Cargo.lock package metadata")
+        name, version = package.get("name"), package.get("version")
+        if not isinstance(name, str) or not name or not isinstance(version, str) or not version:
+            raise EvidenceError("malformed Cargo.lock package identity")
+        identities[(name, version)] += 1
+    return identities
+
+
+def _require_exact_packages(
+    discovered: Counter[tuple[str, str]], expected: Counter[tuple[str, str]]
+) -> None:
+    missing = expected - discovered
+    unexpected = discovered - expected
+    if not missing and not unexpected:
+        return
+    details: list[str] = []
+    if missing:
+        examples = ", ".join(
+            f"{name}@{version}"
+            for (name, version), _count in sorted(missing.items())[:5]
+        )
+        details.append(f"missing {examples}")
+    if unexpected:
+        examples = ", ".join(
+            f"{name}@{version}"
+            for (name, version), _count in sorted(unexpected.items())[:5]
+        )
+        details.append(f"unexpected {examples}")
+    raise EvidenceError(
+        "SBOM does not cover Cargo.lock package graph exactly: " + "; ".join(details)
+    )
+
+
+def _validate_spdx_root(package: dict[str, object], cargo_lock_sha256: str) -> None:
+    expected_version = f"sha256:{cargo_lock_sha256}"
+    checksums = package.get("checksums")
+    sha256_checksums = (
+        [
+            checksum.get("checksumValue")
+            for checksum in checksums
+            if isinstance(checksum, dict) and checksum.get("algorithm") == "SHA256"
+        ]
+        if isinstance(checksums, list)
+        else []
+    )
+    if (
+        package.get("name") != "Cargo.lock"
+        or package.get("versionInfo") != expected_version
+        or sha256_checksums != [cargo_lock_sha256]
+    ):
+        raise EvidenceError("SPDX SBOM Cargo.lock document root has the wrong hash")
+
+
+def validate_cargo_lock_sbom(
+    value: dict[str, object],
+    expected_packages: Counter[tuple[str, str]],
+    cargo_lock_sha256: str,
+    generator: str,
+    generator_version: str,
+) -> tuple[str, int]:
+    if generator != "syft" or not generator_version:
+        raise EvidenceError("SBOM generator must identify the pinned Syft version")
+    expected_tool = f"Tool: syft-{generator_version}"
+    discovered: Counter[tuple[str, str]] = Counter()
+
+    if value.get("spdxVersion") != "SPDX-2.3":
+        raise EvidenceError("SBOM must be Syft SPDX 2.3 JSON")
+    packages = value.get("packages")
+    if not isinstance(packages, list):
+        raise EvidenceError("SPDX SBOM packages must be a list")
+    roots = 0
+    for package in packages:
+        if not isinstance(package, dict):
+            raise EvidenceError("SPDX SBOM contains malformed package metadata")
+        if package.get("primaryPackagePurpose") == "FILE":
+            roots += 1
+            _validate_spdx_root(package, cargo_lock_sha256)
+            continue
+        name, version = package.get("name"), package.get("versionInfo")
+        if not isinstance(name, str) or not name or not isinstance(version, str) or not version:
+            raise EvidenceError("SPDX SBOM contains a malformed package identity")
+        discovered[(name, version)] += 1
+    if roots != 1:
+        raise EvidenceError("SPDX SBOM must contain exactly one Cargo.lock document root")
+    creation_info = value.get("creationInfo")
+    creators = creation_info.get("creators") if isinstance(creation_info, dict) else None
+    tools = (
+        [
+            creator
+            for creator in creators
+            if isinstance(creator, str) and creator.startswith("Tool: ")
+        ]
+        if isinstance(creators, list)
+        else []
+    )
+    if tools != [expected_tool]:
+        raise EvidenceError("SPDX SBOM generator identity or version is inconsistent")
+
+    _require_exact_packages(discovered, expected_packages)
+    return "spdx.json", sum(discovered.values())
+
+
+def require_regular_file(path: Path) -> None:
+    try:
+        mode = path.lstat().st_mode
+    except OSError as error:
+        raise EvidenceError(f"required file is unavailable: {path.name}") from error
+    if not stat.S_ISREG(mode) or path.is_symlink():
+        raise EvidenceError(f"required file is not a regular non-symlink: {path.name}")
+
+
+def write_json(path: Path, value: object, *, exclusive: bool = False) -> None:
+    mode = "x" if exclusive else "w"
+    with path.open(mode, encoding="utf-8") as handle:
+        handle.write(json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False) + "\n")
+
+
+def read_json(path: Path) -> dict[str, object]:
+    require_regular_file(path)
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise EvidenceError(f"cannot read JSON {path.name}: {error}") from error
+    if not isinstance(value, dict):
+        raise EvidenceError(f"{path.name} must contain a JSON object")
+    return value

--- a/scripts/tests/__init__.py
+++ b/scripts/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Repository script tests."""

--- a/scripts/tests/test_provenance_evidence.py
+++ b/scripts/tests/test_provenance_evidence.py
@@ -1,0 +1,606 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[2]
+BUILD = ROOT / "scripts/build-provenance-evidence.py"
+FINALIZE = ROOT / "scripts/finalize-provenance-evidence.py"
+MATERIALIZE = ROOT / "scripts/materialize-provenance-cargo-lock.py"
+VERIFY = ROOT / "scripts/verify-provenance-evidence.py"
+
+
+class ProvenanceEvidenceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.base = Path(self.temporary.name)
+        self.repository = self.base / "repository"
+        self.repository.mkdir()
+        self.git("init", "-b", "main")
+        self.git("config", "user.name", "Fixture Author")
+        self.git("config", "user.email", "fixture@example.invalid")
+        (self.repository / "README.md").write_text("fixture\n", encoding="utf-8")
+        (self.repository / "CITATION.cff").write_text(
+            "cff-version: 1.2.0\ntitle: Fixture\n", encoding="utf-8"
+        )
+        cargo_lock = (
+            'version = 3\n\n[[package]]\nname = "fixture-dependency"\nversion = "1.2.3"\n'
+        )
+        (self.repository / "Cargo.lock").write_text(cargo_lock, encoding="utf-8")
+        self.git("add", "README.md", "CITATION.cff", "Cargo.lock")
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "GIT_AUTHOR_DATE": "2026-01-02T03:04:05Z",
+                "GIT_COMMITTER_DATE": "2026-01-02T03:04:05Z",
+            }
+        )
+        self.git("commit", "-m", "initial", environment=environment)
+        self.git("remote", "add", "origin", "https://example.invalid/fixture.git")
+        self.sbom = self.base / "sbom.json"
+        self.sbom.write_text(
+            json.dumps(
+                {
+                    "spdxVersion": "SPDX-2.3",
+                    "creationInfo": {"creators": ["Tool: syft-1.0.0"]},
+                    "packages": [
+                        {"name": "fixture-dependency", "versionInfo": "1.2.3"},
+                        {
+                            "name": "Cargo.lock",
+                            "SPDXID": "SPDXRef-DocumentRoot-File-Cargo.lock",
+                            "versionInfo": (
+                                "sha256:"
+                                + hashlib.sha256(cargo_lock.encode("utf-8")).hexdigest()
+                            ),
+                            "checksums": [
+                                {
+                                    "algorithm": "SHA256",
+                                    "checksumValue": hashlib.sha256(
+                                        cargo_lock.encode("utf-8")
+                                    ).hexdigest(),
+                                }
+                            ],
+                            "primaryPackagePurpose": "FILE",
+                        },
+                    ],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def git(self, *args: str, environment: dict[str, str] | None = None) -> str:
+        return subprocess.run(
+            ["git", *args],
+            cwd=self.repository,
+            env=environment,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        ).stdout.strip()
+
+    def command(self, script: Path, *args: str, succeeds: bool = True) -> subprocess.CompletedProcess[str]:
+        result = subprocess.run(
+            ["python3", str(script), *args],
+            cwd=ROOT,
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if succeeds and result.returncode:
+            self.fail(f"command failed: {result.stderr}")
+        if not succeeds and result.returncode == 0:
+            self.fail("command unexpectedly succeeded")
+        return result
+
+    def build(
+        self,
+        destination: Path,
+        mode: str = "dry-run",
+        ref: str = "refs/heads/main",
+    ) -> subprocess.CompletedProcess[str]:
+        return self.command(
+            BUILD,
+            "--repository",
+            str(self.repository),
+            "--ref",
+            ref,
+            "--snapshot-id",
+            "fixture-dry-run",
+            "--output-dir",
+            str(destination),
+            "--mode",
+            mode,
+            succeeds=mode == "dry-run",
+        )
+
+    def finalize(
+        self, destination: Path, succeeds: bool = True
+    ) -> subprocess.CompletedProcess[str]:
+        return self.command(
+            FINALIZE,
+            "--evidence-dir",
+            str(destination),
+            "--sbom",
+            str(self.sbom),
+            "--sbom-generator",
+            "syft",
+            "--sbom-generator-version",
+            "1.0.0",
+            "--sbom-generator-source",
+            "fixture-generator",
+            succeeds=succeeds,
+        )
+
+    def verify(self, destination: Path, succeeds: bool = True) -> subprocess.CompletedProcess[str]:
+        return self.command(
+            VERIFY,
+            "--evidence-dir",
+            str(destination),
+            succeeds=succeeds,
+        )
+
+    def rehash_evidence(self, destination: Path) -> None:
+        manifest_path = destination / "release-manifest.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        for asset in manifest["assets"]:
+            payload = destination / asset["name"]
+            asset["sha256"] = hashlib.sha256(payload.read_bytes()).hexdigest()
+            asset["size"] = payload.stat().st_size
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        names = [asset["name"] for asset in manifest["assets"]] + [manifest_path.name]
+        checksums = [
+            f"{hashlib.sha256((destination / name).read_bytes()).hexdigest()}  {name}"
+            for name in sorted(names)
+        ]
+        (destination / "SHA256SUMS").write_text(
+            "\n".join(checksums) + "\n", encoding="utf-8"
+        )
+
+    def test_source_archive_is_reproducible(self) -> None:
+        first = self.base / "first"
+        second = self.base / "second"
+        self.build(first)
+        self.build(second)
+        self.assertEqual(
+            (first / "fixture-dry-run-source.tar.gz").read_bytes(),
+            (second / "fixture-dry-run-source.tar.gz").read_bytes(),
+        )
+
+    def test_materialized_cargo_lock_comes_from_the_recorded_commit(self) -> None:
+        destination = self.base / "evidence"
+        self.build(destination)
+        expected = (self.repository / "Cargo.lock").read_bytes()
+        (self.repository / "Cargo.lock").write_text(
+            'version = 3\n\n[[package]]\nname = "dirty-worktree"\nversion = "9.9.9"\n',
+            encoding="utf-8",
+        )
+        materialized = self.base / "material" / "Cargo.lock"
+
+        self.command(
+            MATERIALIZE,
+            "--repository",
+            str(self.repository),
+            "--metadata",
+            str(destination / "build-metadata.json"),
+            "--output",
+            str(materialized),
+        )
+
+        self.assertEqual(expected, materialized.read_bytes())
+
+    def test_bundle_contains_exact_requested_ref(self) -> None:
+        destination = self.base / "evidence"
+        self.build(destination)
+        heads = self.git("bundle", "list-heads", str(destination / "fixture-dry-run.bundle"))
+        self.assertEqual(f"{self.git('rev-parse', 'HEAD')} refs/heads/main", heads)
+
+    def test_annotated_tag_preserves_tag_object_and_peels_to_commit(self) -> None:
+        self.git("tag", "--annotate", "fixture-tag", "--message", "fixture tag")
+        destination = self.base / "tag-evidence"
+        self.build(destination, ref="refs/tags/fixture-tag")
+        self.finalize(destination)
+        manifest = json.loads((destination / "release-manifest.json").read_text())
+        self.assertNotEqual(manifest["ref_object"], manifest["commit"])
+        self.verify(destination)
+
+    def test_finalize_writes_acyclic_sorted_hashes(self) -> None:
+        destination = self.base / "evidence"
+        self.build(destination)
+        self.finalize(destination)
+        manifest = json.loads((destination / "release-manifest.json").read_text())
+        self.assertFalse(manifest["publishable"])
+        asset_names = [asset["name"] for asset in manifest["assets"]]
+        self.assertEqual(sorted(asset_names), asset_names)
+        checksum_names = [
+            line.split("  ", 1)[1]
+            for line in (destination / "SHA256SUMS").read_text().splitlines()
+        ]
+        self.assertNotIn("SHA256SUMS", checksum_names)
+        self.assertIn("release-manifest.json", checksum_names)
+        self.verify(destination)
+
+    def test_tampered_payload_is_rejected(self) -> None:
+        destination = self.base / "evidence"
+        self.build(destination)
+        self.finalize(destination)
+        with (destination / "fixture-dry-run-source.tar.gz").open("ab") as handle:
+            handle.write(b"tampered")
+        result = self.verify(destination, succeeds=False)
+        self.assertIn("checksum mismatch", result.stderr)
+
+    def test_missing_payload_is_rejected(self) -> None:
+        destination = self.base / "evidence"
+        self.build(destination)
+        self.finalize(destination)
+        (destination / "fixture-dry-run.bundle").unlink()
+        result = self.verify(destination, succeeds=False)
+        self.assertIn("unavailable", result.stderr)
+
+    def test_unmanifested_payload_is_rejected(self) -> None:
+        destination = self.base / "evidence"
+        self.build(destination)
+        self.finalize(destination)
+        (destination / "unmanifested.txt").write_text("not evidence\n", encoding="utf-8")
+        result = self.verify(destination, succeeds=False)
+        self.assertIn("unmanifested", result.stderr)
+
+    def test_verification_is_standalone_after_source_repository_is_removed(self) -> None:
+        destination = self.base / "evidence"
+        self.build(destination)
+        self.finalize(destination)
+        shutil.rmtree(self.repository)
+        self.verify(destination)
+
+    def test_verifier_rejects_unsafe_source_path_without_touching_it(self) -> None:
+        destination = self.base / "evidence"
+        self.build(destination)
+        self.finalize(destination)
+        outside = self.base / "outside-source.tar.gz"
+        sentinel = b"must not be overwritten\n"
+        outside.write_bytes(sentinel)
+        metadata_path = destination / "build-metadata.json"
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        metadata["source_archive"] = str(outside)
+        metadata_path.write_text(
+            json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        self.rehash_evidence(destination)
+
+        result = subprocess.run(
+            ["python3", str(VERIFY), "--evidence-dir", str(destination)],
+            cwd=ROOT,
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        self.assertEqual(sentinel, outside.read_bytes())
+        self.assertNotEqual(0, result.returncode)
+
+    def test_verifier_rejects_bundle_path_outside_evidence_directory(self) -> None:
+        destination = self.base / "evidence"
+        self.build(destination)
+        self.finalize(destination)
+        outside = self.base / "outside.bundle"
+        shutil.copyfile(destination / "fixture-dry-run.bundle", outside)
+        metadata_path = destination / "build-metadata.json"
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        metadata["git_bundle"] = str(outside)
+        metadata_path.write_text(
+            json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        self.rehash_evidence(destination)
+
+        result = self.verify(destination, succeeds=False)
+
+        self.assertIn("bundle", result.stderr)
+
+    def test_verifier_rejects_manifest_role_substitution(self) -> None:
+        destination = self.base / "evidence"
+        self.build(destination)
+        self.finalize(destination)
+        manifest_path = destination / "release-manifest.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        roles = {asset["name"]: asset["role"] for asset in manifest["assets"]}
+        source_name = "fixture-dry-run-source.tar.gz"
+        bundle_name = "fixture-dry-run.bundle"
+        for asset in manifest["assets"]:
+            if asset["name"] == source_name:
+                asset["role"] = roles[bundle_name]
+            elif asset["name"] == bundle_name:
+                asset["role"] = roles[source_name]
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        self.rehash_evidence(destination)
+
+        result = self.verify(destination, succeeds=False)
+
+        self.assertIn("role", result.stderr)
+
+    def test_verifier_rejects_symlinked_evidence_asset(self) -> None:
+        destination = self.base / "evidence"
+        self.build(destination)
+        self.finalize(destination)
+        source = destination / "fixture-dry-run-source.tar.gz"
+        outside = self.base / "outside-source.tar.gz"
+        shutil.copyfile(source, outside)
+        source.unlink()
+        source.symlink_to(outside)
+
+        result = self.verify(destination, succeeds=False)
+
+        self.assertIn("regular non-symlink", result.stderr)
+
+    def test_verifier_validates_manifest_ref_before_using_the_bundle(self) -> None:
+        destination = self.base / "evidence"
+        self.build(destination)
+        self.finalize(destination)
+        unsafe_ref = "refs/heads/main^{commit}"
+        metadata_path = destination / "build-metadata.json"
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        metadata["ref"] = unsafe_ref
+        metadata_path.write_text(
+            json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        manifest_path = destination / "release-manifest.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest["ref"] = unsafe_ref
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        self.rehash_evidence(destination)
+
+        result = self.verify(destination, succeeds=False)
+
+        self.assertIn("check-ref-format", result.stderr)
+
+    def test_unsafe_snapshot_id_in_mutated_metadata_is_rejected(self) -> None:
+        destination = self.base / "evidence"
+        self.build(destination)
+        metadata_path = destination / "build-metadata.json"
+        metadata = json.loads(metadata_path.read_text())
+        metadata["snapshot_id"] = "../escape"
+        metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+        result = self.command(
+            FINALIZE,
+            "--evidence-dir",
+            str(destination),
+            "--sbom",
+            str(self.sbom),
+            "--sbom-generator",
+            "syft",
+            "--sbom-generator-version",
+            "1.0.0",
+            "--sbom-generator-source",
+            "fixture-generator",
+            succeeds=False,
+        )
+        self.assertIn("unsafe snapshot ID", result.stderr)
+
+    def test_symlinked_builder_payload_is_rejected_before_copy(self) -> None:
+        destination = self.base / "evidence"
+        self.build(destination)
+        source = destination / "fixture-dry-run-source.tar.gz"
+        source.unlink()
+        source.symlink_to(self.sbom)
+        result = self.finalize(destination, succeeds=False)
+        self.assertIn("regular non-symlink", result.stderr)
+
+    def test_revision_expression_is_not_accepted_as_a_ref(self) -> None:
+        result = self.command(
+            BUILD,
+            "--repository",
+            str(self.repository),
+            "--ref",
+            "refs/heads/main^{commit}",
+            "--snapshot-id",
+            "fixture-dry-run",
+            "--output-dir",
+            str(self.base / "invalid-ref"),
+            "--mode",
+            "dry-run",
+            succeeds=False,
+        )
+        self.assertIn("check-ref-format", result.stderr)
+
+    def test_incomplete_sbom_is_rejected(self) -> None:
+        destination = self.base / "evidence"
+        self.build(destination)
+        self.sbom.write_text(
+            json.dumps(
+                {
+                    "spdxVersion": "SPDX-2.3",
+                    "creationInfo": {"creators": ["Tool: syft-1.0.0"]},
+                    "packages": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = self.command(
+            FINALIZE,
+            "--evidence-dir",
+            str(destination),
+            "--sbom",
+            str(self.sbom),
+            "--sbom-generator",
+            "syft",
+            "--sbom-generator-version",
+            "1.0.0",
+            "--sbom-generator-source",
+            "fixture-generator",
+            succeeds=False,
+        )
+        self.assertIn("Cargo.lock", result.stderr)
+
+    def test_sbom_with_unrelated_package_is_rejected(self) -> None:
+        destination = self.base / "evidence"
+        self.build(destination)
+        sbom = json.loads(self.sbom.read_text(encoding="utf-8"))
+        sbom["packages"].append({"name": "unrelated", "versionInfo": "9.9.9"})
+        self.sbom.write_text(json.dumps(sbom) + "\n", encoding="utf-8")
+
+        result = self.finalize(destination, succeeds=False)
+
+        self.assertIn("unrelated", result.stderr)
+
+    def test_sbom_root_must_bind_the_recorded_cargo_lock_hash(self) -> None:
+        destination = self.base / "evidence"
+        self.build(destination)
+        sbom = json.loads(self.sbom.read_text(encoding="utf-8"))
+        root = next(package for package in sbom["packages"] if package["name"] == "Cargo.lock")
+        root["versionInfo"] = "sha256:" + "0" * 64
+        root["checksums"][0]["checksumValue"] = "0" * 64
+        self.sbom.write_text(json.dumps(sbom) + "\n", encoding="utf-8")
+
+        result = self.finalize(destination, succeeds=False)
+
+        self.assertIn("Cargo.lock", result.stderr)
+
+    def test_sbom_root_rejects_conflicting_cargo_lock_hashes(self) -> None:
+        destination = self.base / "evidence"
+        self.build(destination)
+        sbom = json.loads(self.sbom.read_text(encoding="utf-8"))
+        root = next(package for package in sbom["packages"] if package["name"] == "Cargo.lock")
+        root["checksums"].append(
+            {"algorithm": "SHA256", "checksumValue": "0" * 64}
+        )
+        self.sbom.write_text(json.dumps(sbom) + "\n", encoding="utf-8")
+
+        result = self.finalize(destination, succeeds=False)
+
+        self.assertIn("Cargo.lock", result.stderr)
+
+    def test_verifier_revalidates_sbom_against_bundled_cargo_lock(self) -> None:
+        destination = self.base / "evidence"
+        self.build(destination)
+        self.finalize(destination)
+        sbom_path = destination / "fixture-dry-run.sbom.spdx.json"
+        sbom = json.loads(sbom_path.read_text(encoding="utf-8"))
+        sbom["packages"] = [
+            package for package in sbom["packages"] if package["name"] != "fixture-dependency"
+        ]
+        sbom_path.write_text(json.dumps(sbom) + "\n", encoding="utf-8")
+        self.rehash_evidence(destination)
+
+        result = self.verify(destination, succeeds=False)
+
+        self.assertIn("Cargo.lock", result.stderr)
+
+    def test_verifier_rejects_sbom_generator_version_substitution(self) -> None:
+        destination = self.base / "evidence"
+        self.build(destination)
+        self.finalize(destination)
+        manifest_path = destination / "release-manifest.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest["sbom"]["generator_version"] = "9.9.9"
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        self.rehash_evidence(destination)
+
+        result = self.verify(destination, succeeds=False)
+
+        self.assertIn("generator", result.stderr)
+
+    def test_verifier_rejects_metadata_package_graph_substitution(self) -> None:
+        destination = self.base / "evidence"
+        self.build(destination)
+        self.finalize(destination)
+        metadata_path = destination / "build-metadata.json"
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        metadata["cargo_lock_packages"] = []
+        metadata_path.write_text(
+            json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        self.rehash_evidence(destination)
+
+        result = self.verify(destination, succeeds=False)
+
+        self.assertIn("package graph", result.stderr)
+
+    def test_verifier_rejects_publishable_build_metadata(self) -> None:
+        destination = self.base / "evidence"
+        self.build(destination)
+        self.finalize(destination)
+        metadata_path = destination / "build-metadata.json"
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        metadata["mode"] = "publishable"
+        metadata["publishable"] = True
+        metadata_path.write_text(
+            json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        self.rehash_evidence(destination)
+
+        result = self.verify(destination, succeeds=False)
+
+        self.assertIn("dry-run", result.stderr)
+
+    def test_verifier_rejects_unknown_evidence_schema_versions(self) -> None:
+        destination = self.base / "evidence"
+        self.build(destination)
+        self.finalize(destination)
+        metadata_path = destination / "build-metadata.json"
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        metadata["schema_version"] = 999
+        metadata_path.write_text(
+            json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        manifest_path = destination / "release-manifest.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest["schema_version"] = 999
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        self.rehash_evidence(destination)
+
+        result = self.verify(destination, succeeds=False)
+
+        self.assertIn("schema", result.stderr)
+
+    def test_verifier_rejects_boolean_evidence_schema_versions(self) -> None:
+        destination = self.base / "evidence"
+        self.build(destination)
+        self.finalize(destination)
+        metadata_path = destination / "build-metadata.json"
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        metadata["schema_version"] = True
+        metadata_path.write_text(
+            json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        manifest_path = destination / "release-manifest.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest["schema_version"] = True
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        self.rehash_evidence(destination)
+
+        result = self.verify(destination, succeeds=False)
+
+        self.assertIn("schema", result.stderr)
+
+    def test_publishable_mode_is_locked_without_trust_anchor(self) -> None:
+        result = self.build(self.base / "evidence", mode="publishable")
+        self.assertIn("trust anchor", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_validate_provenance.py
+++ b/scripts/tests/test_validate_provenance.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[1] / "validate-provenance.py"
+SPEC = importlib.util.spec_from_file_location("validate_provenance", SCRIPT)
+assert SPEC and SPEC.loader
+validator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validator)
+
+
+class ProvenanceValidatorTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.write_valid_fixture()
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def write(self, relative: str, text: str) -> None:
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+
+    def write_valid_fixture(self) -> None:
+        self.write(
+            "CITATION.cff",
+            """cff-version: 1.2.0
+title: Sovereign Founder OS
+authors:
+  - family-names: Xu
+    given-names: Franz
+repository-code: https://github.com/IcantFind-a-username/Sovereign-Founder-OS
+license: Apache-2.0
+""",
+        )
+        self.write(
+            "PROVENANCE.md",
+            "Franz Xu maintainer's representation; abstract ideas. "
+            "No immutable provenance snapshot has been published",
+        )
+        self.write("NOTICE", "Franz Xu PROVENANCE.md Apache License, Version 2.0")
+        self.write("README.md", "PROVENANCE.md provenance record")
+        self.write("CONTRIBUTING.md", "Developer Certificate of Origin Signed-off-by")
+        self.write("TRADEMARK.md", "No registration is claimed")
+        self.write("GOVERNANCE.md", "SemVer product releases Provenance snapshots")
+        self.write("SECURITY.md", "Provenance snapshots")
+        self.write(".github/workflows/release.yml", "on: workflow_dispatch\npermissions: {}\n")
+        self.write(
+            ".github/workflows/provenance-dry-run.yml",
+            """on: workflow_dispatch
+permissions:
+  contents: read
+jobs:
+  evidence:
+    steps:
+      - uses: actions/example@0123456789abcdef0123456789abcdef01234567
+      - run: echo UNSIGNED-DRY-RUN
+      - run: echo github.event.repository.default_branch
+      - run: python3 scripts/materialize-provenance-cargo-lock.py
+      - run: echo sha256:2a2e837a2c8d59ec9af5472ee22d3b04ee463c4e44476ecf993fd1e5ab6ebc7f
+""",
+        )
+
+    def test_undated_metadata_is_valid_before_candidate_freeze(self) -> None:
+        self.assertEqual([], validator.validate_repository(self.root))
+
+    def test_candidate_fields_must_appear_together(self) -> None:
+        with (self.root / "CITATION.cff").open("a", encoding="utf-8") as handle:
+            handle.write("version: 2026.08.27-provenance.1\n")
+        self.assertIn(
+            "CITATION.cff: version and date-released must appear together",
+            validator.validate_cff(self.root),
+        )
+
+    def test_candidate_version_and_date_must_agree(self) -> None:
+        with (self.root / "CITATION.cff").open("a", encoding="utf-8") as handle:
+            handle.write(
+                "version: 2026.08.27-provenance.1\n"
+                "date-released: 2026-08-28\n"
+            )
+        self.assertIn(
+            "CITATION.cff: snapshot version and release date disagree",
+            validator.validate_cff(self.root),
+        )
+
+    def test_well_formed_candidate_is_valid(self) -> None:
+        with (self.root / "CITATION.cff").open("a", encoding="utf-8") as handle:
+            handle.write(
+                "version: 2026.08.27-provenance.2\n"
+                "date-released: 2026-08-27\n"
+            )
+        self.assertEqual([], validator.validate_cff(self.root))
+
+    def test_missing_policy_marker_is_rejected(self) -> None:
+        self.write("TRADEMARK.md", "Trademark policy")
+        self.assertTrue(
+            any("TRADEMARK.md: missing required marker" in error for error in validator.validate_repository(self.root))
+        )
+
+    def test_absolute_idea_claim_is_rejected(self) -> None:
+        with (self.root / "README.md").open("a", encoding="utf-8") as handle:
+            handle.write("\nCopyright protects the ideas.\n")
+        self.assertTrue(
+            any("forbidden overclaim" in error for error in validator.validate_repository(self.root))
+        )
+
+    def test_unsafe_release_publisher_is_rejected(self) -> None:
+        self.write(".github/workflows/release.yml", "permissions:\n  contents: write\n")
+        self.assertTrue(
+            any("unsafe publisher" in error for error in validator.validate_repository(self.root))
+        )
+
+    def test_movable_action_tag_is_rejected(self) -> None:
+        workflow = self.root / ".github/workflows/provenance-dry-run.yml"
+        workflow.write_text(
+            workflow.read_text(encoding="utf-8").replace(
+                "actions/example@0123456789abcdef0123456789abcdef01234567",
+                "actions/example@v7",
+            ),
+            encoding="utf-8",
+        )
+        self.assertTrue(
+            any("not pinned" in error for error in validator.validate_repository(self.root))
+        )
+
+    def test_workflow_must_materialize_the_recorded_cargo_lock(self) -> None:
+        workflow = self.root / ".github/workflows/provenance-dry-run.yml"
+        workflow.write_text(
+            workflow.read_text(encoding="utf-8").replace(
+                "python3 scripts/materialize-provenance-cargo-lock.py",
+                "echo scan mutable Cargo.lock",
+            ),
+            encoding="utf-8",
+        )
+
+        self.assertTrue(
+            any(
+                "materialize-provenance-cargo-lock.py" in error
+                for error in validator.validate_repository(self.root)
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate-provenance.py
+++ b/scripts/validate-provenance.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Validate repository-local provenance invariants.
+
+This intentionally checks only project policy invariants. Full CITATION.cff
+schema validation is performed separately in CI.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+EXPECTED = {
+    "title": "Sovereign Founder OS",
+    "repository-code": "https://github.com/IcantFind-a-username/Sovereign-Founder-OS",
+    "license": "Apache-2.0",
+}
+SNAPSHOT_VERSION = re.compile(r"^(\d{4})\.(\d{2})\.(\d{2})-provenance\.([1-9]\d*)$")
+RELEASE_DATE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def parse_top_level_cff(text: str) -> dict[str, str]:
+    """Return unindented scalar CFF fields needed by this validator."""
+    fields: dict[str, str] = {}
+    for line in text.splitlines():
+        if not line or line[0].isspace() or line.startswith("#"):
+            continue
+        match = re.match(r"^([a-z][a-z0-9-]*):\s*(.*?)\s*$", line)
+        if match and match.group(2) not in {"", ">", ">-", "|", "|-"}:
+            fields[match.group(1)] = match.group(2).strip("'\"")
+    return fields
+
+
+def validate_cff(root: Path) -> list[str]:
+    path = root / "CITATION.cff"
+    if not path.is_file():
+        return ["CITATION.cff: missing"]
+    text = path.read_text(encoding="utf-8")
+    fields = parse_top_level_cff(text)
+    errors = [
+        f"CITATION.cff: {key} must be {expected!r}"
+        for key, expected in EXPECTED.items()
+        if fields.get(key) != expected
+    ]
+    if "family-names: Xu" not in text or "given-names: Franz" not in text:
+        errors.append("CITATION.cff: author must identify Franz Xu")
+
+    version = fields.get("version")
+    released = fields.get("date-released")
+    if bool(version) != bool(released):
+        errors.append("CITATION.cff: version and date-released must appear together")
+    elif version and released:
+        match = SNAPSHOT_VERSION.fullmatch(version)
+        if not match:
+            errors.append("CITATION.cff: invalid provenance snapshot version")
+        elif not RELEASE_DATE.fullmatch(released):
+            errors.append("CITATION.cff: invalid date-released")
+        elif released != f"{match.group(1)}-{match.group(2)}-{match.group(3)}":
+            errors.append("CITATION.cff: snapshot version and release date disagree")
+    return errors
+
+
+def _read(root: Path, relative: str, errors: list[str]) -> str:
+    path = root / relative
+    if not path.is_file():
+        errors.append(f"{relative}: missing")
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def validate_document_markers(root: Path) -> list[str]:
+    errors: list[str] = []
+    required = {
+        "PROVENANCE.md": [
+            "Franz Xu",
+            "maintainer's representation",
+            "abstract ideas",
+            "No immutable provenance snapshot has been published",
+        ],
+        "NOTICE": ["Franz Xu", "PROVENANCE.md", "Apache License"],
+        "README.md": ["PROVENANCE.md", "provenance record"],
+        "CONTRIBUTING.md": ["Developer Certificate of Origin", "Signed-off-by"],
+        "TRADEMARK.md": ["No registration is claimed"],
+        "GOVERNANCE.md": ["SemVer product releases", "Provenance snapshots"],
+        "SECURITY.md": ["Provenance snapshots"],
+    }
+    documents: dict[str, str] = {}
+    for relative, markers in required.items():
+        text = _read(root, relative, errors)
+        documents[relative] = text
+        for marker in markers:
+            if marker not in text:
+                errors.append(f"{relative}: missing required marker {marker!r}")
+
+    forbidden = {
+        "independently verified authorship",
+        "copyright protects the ideas",
+        "registered trademark",
+        "original and proprietary",
+    }
+    for relative, text in documents.items():
+        lowered = text.lower()
+        for phrase in forbidden:
+            if phrase in lowered:
+                errors.append(f"{relative}: forbidden overclaim {phrase!r}")
+
+    workflow = _read(root, ".github/workflows/release.yml", errors)
+    for forbidden_workflow in ("contents: write", "gh release", "--clobber", 'tags: ["v*"]'):
+        if forbidden_workflow in workflow:
+            errors.append(f".github/workflows/release.yml: unsafe publisher contains {forbidden_workflow!r}")
+    provenance_workflow = _read(root, ".github/workflows/provenance-dry-run.yml", errors)
+    for marker in (
+        "permissions:\n  contents: read",
+        "github.event.repository.default_branch",
+        "materialize-provenance-cargo-lock.py",
+        "UNSIGNED-DRY-RUN",
+        "sha256:2a2e837a2c8d59ec9af5472ee22d3b04ee463c4e44476ecf993fd1e5ab6ebc7f",
+    ):
+        if marker not in provenance_workflow:
+            errors.append(
+                ".github/workflows/provenance-dry-run.yml: "
+                f"missing trust-boundary marker {marker!r}"
+            )
+    for forbidden_workflow in ("contents: write", "gh release", "git push", "--clobber"):
+        if forbidden_workflow in provenance_workflow:
+            errors.append(
+                ".github/workflows/provenance-dry-run.yml: "
+                f"unsafe operation contains {forbidden_workflow!r}"
+            )
+
+    workflow_directory = root / ".github/workflows"
+    if workflow_directory.is_dir():
+        for path in sorted(workflow_directory.glob("*.yml")):
+            for line_number, line in enumerate(
+                path.read_text(encoding="utf-8").splitlines(), start=1
+            ):
+                match = re.search(r"\buses:\s*[^\s@]+@([^\s#]+)", line)
+                if match and not re.fullmatch(r"[0-9a-f]{40}", match.group(1)):
+                    errors.append(
+                        f"{path.relative_to(root)}:{line_number}: action is not pinned "
+                        "to a full commit SHA"
+                    )
+    return errors
+
+
+def validate_repository(root: Path) -> list[str]:
+    return validate_cff(root) + validate_document_markers(root)
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parent.parent
+    errors = validate_repository(root)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    print("Provenance metadata validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify-provenance-evidence.py
+++ b/scripts/verify-provenance-evidence.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Verify an unsigned provenance dry-run against its repository ref."""
+
+from __future__ import annotations
+
+import argparse
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+from provenance_evidence import (
+    cargo_package_metadata,
+    EvidenceError,
+    SAFE_ID,
+    normalized_source_archive,
+    parse_cargo_lock,
+    read_git_blob,
+    read_json,
+    require_regular_file,
+    run_git,
+    sha256_bytes,
+    sha256_file,
+    validate_cargo_lock_sbom,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--evidence-dir", type=Path, required=True)
+    return parser.parse_args()
+
+
+def _verify_checksums(evidence: Path) -> set[str]:
+    checksum_path = evidence / "SHA256SUMS"
+    require_regular_file(checksum_path)
+    lines = checksum_path.read_text(encoding="utf-8").splitlines()
+    seen: set[str] = set()
+    for line in lines:
+        if "  " not in line:
+            raise EvidenceError("malformed SHA256SUMS line")
+        expected, name = line.split("  ", 1)
+        if Path(name).name != name or name == "SHA256SUMS" or name in seen:
+            raise EvidenceError(f"unsafe or duplicate checksum entry: {name}")
+        path = evidence / name
+        require_regular_file(path)
+        if sha256_file(path) != expected:
+            raise EvidenceError(f"checksum mismatch: {name}")
+        seen.add(name)
+    return seen
+
+
+def verify(args: argparse.Namespace) -> None:
+    evidence = args.evidence_dir.expanduser().absolute()
+    try:
+        evidence_mode = evidence.lstat().st_mode
+    except OSError as error:
+        raise EvidenceError("evidence directory is unavailable") from error
+    if not stat.S_ISDIR(evidence_mode) or evidence.is_symlink():
+        raise EvidenceError("evidence directory must be a real directory")
+    checksum_names = _verify_checksums(evidence)
+    manifest = read_json(evidence / "release-manifest.json")
+    metadata = read_json(evidence / "build-metadata.json")
+    for label, document in (("manifest", manifest), ("build metadata", metadata)):
+        schema_version = document.get("schema_version")
+        if type(schema_version) is not int or schema_version != 1:
+            raise EvidenceError(f"{label} must use evidence schema version 1")
+        if document.get("mode") != "dry-run" or document.get("publishable") is not False:
+            raise EvidenceError(f"{label} must describe a non-publishable dry-run")
+
+    assets = manifest.get("assets")
+    if not isinstance(assets, list):
+        raise EvidenceError("manifest assets must be a list")
+    expected_names: set[str] = set()
+    for asset in assets:
+        if (
+            not isinstance(asset, dict)
+            or not isinstance(asset.get("name"), str)
+            or not isinstance(asset.get("role"), str)
+        ):
+            raise EvidenceError("malformed manifest asset")
+        name = asset["name"]
+        if Path(name).name != name or name in expected_names:
+            raise EvidenceError(f"unsafe or duplicate manifest asset: {name}")
+        path = evidence / name
+        require_regular_file(path)
+        if sha256_file(path) != asset.get("sha256") or path.stat().st_size != asset.get("size"):
+            raise EvidenceError(f"manifest payload mismatch: {name}")
+        expected_names.add(name)
+
+    required_checksums = expected_names | {"release-manifest.json"}
+    if checksum_names != required_checksums:
+        raise EvidenceError("SHA256SUMS entries do not exactly match the manifest")
+    actual_names = {path.name for path in evidence.iterdir()}
+    permitted_names = required_checksums | {"SHA256SUMS"}
+    if actual_names != permitted_names:
+        raise EvidenceError("evidence directory contains an unmanifested or missing file")
+
+    ref = manifest.get("ref")
+    ref_object = manifest.get("ref_object")
+    commit = manifest.get("commit")
+    tree = manifest.get("tree")
+    if not all(isinstance(item, str) for item in (ref, ref_object, commit, tree)):
+        raise EvidenceError("manifest ref identity is incomplete")
+    for key in (
+        "snapshot_id",
+        "repository_url",
+        "ref",
+        "ref_object",
+        "commit",
+        "tree",
+        "materials",
+    ):
+        if metadata.get(key) != manifest.get(key):
+            raise EvidenceError(f"build metadata disagrees on {key}")
+    expected_build_context = {
+        "tools": metadata.get("tools"),
+        "compression": metadata.get("compression"),
+        "workflow": metadata.get("workflow"),
+    }
+    if manifest.get("build_context") != expected_build_context:
+        raise EvidenceError("manifest build context disagrees with build metadata")
+    sbom_context = manifest.get("sbom")
+    if not isinstance(sbom_context, dict) or sbom_context.get("scope") != (
+        "Cargo.lock dependency graph"
+    ):
+        raise EvidenceError("manifest SBOM context is incomplete")
+
+    bundle_name = metadata.get("git_bundle")
+    source_name = metadata.get("source_archive")
+    if not isinstance(bundle_name, str) or not isinstance(source_name, str):
+        raise EvidenceError("build metadata payload names are invalid")
+    snapshot_id = manifest.get("snapshot_id")
+    if not isinstance(snapshot_id, str) or not SAFE_ID.fullmatch(snapshot_id):
+        raise EvidenceError("manifest snapshot ID is unsafe")
+    expected_source_name = f"{snapshot_id}-source.tar.gz"
+    expected_bundle_name = f"{snapshot_id}.bundle"
+    sbom_format = sbom_context.get("format")
+    if sbom_format != "spdx.json":
+        raise EvidenceError("manifest SBOM format is unsupported")
+    expected_sbom_name = f"{snapshot_id}.sbom.{sbom_format}"
+    if source_name != expected_source_name:
+        raise EvidenceError("build metadata source archive name is unsafe")
+    if bundle_name != expected_bundle_name:
+        raise EvidenceError("build metadata Git bundle name is unsafe")
+    expected_roles = {
+        expected_source_name: "normalized-source",
+        expected_bundle_name: "exact-ref-git-bundle",
+        "build-metadata.json": "build-metadata",
+        expected_sbom_name: "cargo-lock-sbom",
+        "VERIFY.md": "verification-guide",
+    }
+    actual_roles = {asset["name"]: asset["role"] for asset in assets}
+    if actual_roles != expected_roles:
+        raise EvidenceError("manifest asset names or roles do not match the evidence schema")
+    with tempfile.TemporaryDirectory() as temporary:
+        imported = Path(temporary) / "imported.git"
+        imported.mkdir()
+        run_git(imported, "init", "--bare", ".")
+        if not ref.startswith("refs/") or any(char.isspace() for char in ref):
+            raise EvidenceError("manifest ref must be an explicit full ref under refs/")
+        run_git(imported, "check-ref-format", ref)
+        bundle = evidence / bundle_name
+        run_git(imported, "bundle", "verify", str(bundle))
+        heads = run_git(imported, "bundle", "list-heads", str(bundle)).splitlines()
+        if heads != [f"{ref_object} {ref}"]:
+            raise EvidenceError("Git bundle advertised ref does not match the manifest")
+        imported_ref = "refs/evidence/imported"
+        run_git(imported, "fetch", "--no-tags", str(bundle), f"{ref}:{imported_ref}")
+        run_git(imported, "fsck", "--full", "--strict")
+        actual_ref_object = run_git(imported, "rev-parse", "--verify", imported_ref)
+        actual_commit = run_git(
+            imported, "rev-parse", "--verify", f"{imported_ref}^{{commit}}"
+        )
+        actual_tree = run_git(imported, "rev-parse", "--verify", f"{actual_commit}^{{tree}}")
+        if (actual_ref_object, actual_commit, actual_tree) != (ref_object, commit, tree):
+            raise EvidenceError("imported bundle identity does not match the manifest")
+
+        materials = manifest.get("materials")
+        if not isinstance(materials, dict):
+            raise EvidenceError("manifest materials are missing")
+        material_contents: dict[str, bytes] = {}
+        for name in ("Cargo.lock", "CITATION.cff"):
+            material = materials.get(name)
+            if not isinstance(material, dict):
+                raise EvidenceError(f"manifest material is missing: {name}")
+            blob_id, content = read_git_blob(imported, f"{commit}:{name}")
+            material_contents[name] = content
+            if (
+                material.get("git_blob") != blob_id
+                or material.get("sha256") != sha256_bytes(content)
+                or material.get("size") != len(content)
+            ):
+                raise EvidenceError(f"manifest material mismatch: {name}")
+
+        cargo_packages = parse_cargo_lock(material_contents["Cargo.lock"])
+        if cargo_package_metadata(metadata.get("cargo_lock_packages")) != cargo_packages:
+            raise EvidenceError(
+                "build metadata Cargo.lock package graph disagrees with the bundled blob"
+            )
+        generator = sbom_context.get("generator")
+        generator_version = sbom_context.get("generator_version")
+        generator_source = sbom_context.get("generator_source")
+        if not all(
+            isinstance(item, str) and item
+            for item in (generator, generator_version, generator_source)
+        ):
+            raise EvidenceError("manifest SBOM generator context is incomplete")
+        sbom_value = read_json(evidence / expected_sbom_name)
+        actual_format, covered_package_count = validate_cargo_lock_sbom(
+            sbom_value,
+            cargo_packages,
+            sha256_bytes(material_contents["Cargo.lock"]),
+            generator,
+            generator_version,
+        )
+        expected_package_count = sum(cargo_packages.values())
+        if actual_format != sbom_format:
+            raise EvidenceError("manifest SBOM format disagrees with the SBOM payload")
+        if (
+            sbom_context.get("covered_package_count") != covered_package_count
+            or sbom_context.get("cargo_lock_package_count") != expected_package_count
+        ):
+            raise EvidenceError("manifest SBOM package counts are inconsistent")
+
+        rebuilt = Path(temporary) / "rebuilt-source.tar.gz"
+        normalized_source_archive(imported, commit, rebuilt, str(manifest["snapshot_id"]))
+        if sha256_file(rebuilt) != sha256_file(evidence / source_name):
+            raise EvidenceError("source archive is not the normalized archive for the ref")
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        verify(args)
+    except (EvidenceError, OSError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    print("Unsigned dry-run evidence verification passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add a project provenance/chronology record, citation metadata, DCO sign-off policy, and accurate trademark/release boundaries
- add deterministic source evidence plus an exact-ref Git bundle, Cargo.lock-bound Syft SPDX SBOM, acyclic manifest/checksums, and standalone verification
- disable unsafe automatic product publication and add a read-only unsigned dry-run workflow with optional default-branch GitHub attestations
- pin GitHub Actions and Syft delivery by immutable commit/content digests

## Evidence boundary

- the repository remains Apache-2.0
- this records exact code/document expression, repository chronology, and the maintainer's representation; it does **not** claim exclusive ownership of abstract ideas or independently prove originality
- no immutable provenance tag, GitHub Release, DOI, maintainer signature, or publishable snapshot is created here
- publishable mode remains fail-closed until a maintainer-controlled signing trust anchor is configured

## Verification

- 37 focused Python provenance/validator tests
- adversarial path, symlink, ref, schema, role, checksum, package-graph, and generator-identity cases
- real Syft 1.51.0 end-to-end run: recorded Git blob → 228-package SPDX → finalizer → standalone verifier
- CFF 1.2 schema, actionlint, Python bytecode, Shell syntax, and file-size guardrail
- cargo fmt, clippy, workspace tests, release build, and frontend TypeScript check
- two independent final security reviews: no Critical or Important findings