### PR TITLE
chore: remove local identifiers and stop tracking installed agent tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,13 @@ notes/
 
 # Automation harness local logs
 .harness/
+
+# Locally installed agent tooling. The project's own skills
+# (.claude/skills/iterate, .claude/skills/plan-feature) are tracked on
+# purpose, so this ignores the installed ones by name rather than the whole
+# directory — a project skill must never be hidden by accident. Add a line
+# here when you install another.
+/.agents/
+# (a symlink into .agents/, so no trailing slash — that would not match)
+/.claude/skills/ui-ux-pro-max
+/skills-lock.json

--- a/docs/handoff/codex/reports/S0-01-record-repair.md
+++ b/docs/handoff/codex/reports/S0-01-record-repair.md
@@ -6,7 +6,7 @@ attempt or independent acceptance. Outcome: **blocked**, diagnostic
 
 ## Actual Git evidence
 
-The inspected checkout is `/Users/franz/Soverign Founder OS`, branch
+The inspected checkout is this repository's working tree, branch
 `docs/founder-os-execution-blueprint`, initially clean at
 `780975956f14ba24fcbe64e66a63010cde23684f`. Git uses SHA-1. Its actual linear
 history is:

--- a/docs/handoff/codex/reports/S0-01-recovery-design.md
+++ b/docs/handoff/codex/reports/S0-01-recovery-design.md
@@ -22,7 +22,7 @@ revision；不需要产品 RFC 变更，不改任何 Rust 安全接口。
 
 ## 已核对基线与历史
 
-实际 repo：`/Users/franz/Soverign Founder OS`；分支
+实际 repo：本仓库工作树；分支
 `docs/founder-os-execution-blueprint`；本报告写入前工作树干净，HEAD 为
 `38544604a78332e22b165ea5b79980396ea328f5`。Git object format 为历史报告所述
 SHA-1，以下均为本次 Git 读取到的完整提交。


### PR DESCRIPTION
Preparing the repository for review by people outside the project.

Two handoff reports recorded the absolute path of the machine they were written on, naming its user account. The path was never the evidence — the branch and commit SHAs beside it are — so both now name the working tree instead. `git grep /Users/` matches nothing.

Locally installed agent skills (`.agents/`, its `.claude/skills` symlink, `skills-lock.json`) were untracked but unignored, so any `git add -A` would have committed a few hundred vendored data files into a public repository. They are ignored **by name** rather than by ignoring `.claude/skills`, because the project's own skills (`iterate`, `plan-feature`) live there and are tracked on purpose. The symlink entry deliberately carries no trailing slash, which would not match a symlink.

Verified: the three installed paths are ignored, both project skills remain visible to git.