### PR TITLE
test(ui): pin the loopback HTTP boundary that 1C0 must change

### DIFF
--- a/apps/cli/tests/support/ui_server.rs
+++ b/apps/cli/tests/support/ui_server.rs
@@ -1,0 +1,148 @@
+//! A minimal harness that runs the real loopback UI server over real HTTP.
+//!
+//! Every approval test in this repository so far drives `Store::decide`
+//! directly, so the network surface — the one Program 1C0 must change — has
+//! never been exercised in either direction. This starts the shipped binary
+//! on an ephemeral loopback port against a throwaway state directory and
+//! speaks HTTP to it, so a test can assert what the server actually accepts.
+//!
+//! State is redirected by `HOME`/`XDG_DATA_HOME` because `sovereign ui` has no
+//! `--root` flag yet (tracked in the backlog); `dirs::data_local_dir()` follows
+//! them on both macOS and Linux. A test must never touch the owner's real data.
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::TcpStream;
+use std::process::{Child, ChildStdout, Command, Stdio};
+use std::time::Duration;
+
+/// How long to wait for the child to report its bound port. Generous on
+/// purpose: nothing here asserts that the server starts quickly, and the
+/// budget exists only so a child that reports nothing fails instead of
+/// hanging the suite. A child that dies closes the pipe and fails at once.
+const STARTUP_BUDGET: Duration = Duration::from_secs(30);
+
+const READY_PREFIX: &str = "sovereign-ui listening on http://127.0.0.1:";
+
+pub struct UiServer {
+    child: Child,
+    port: u16,
+    // Held so the directory outlives the server; dropping it removes the state.
+    _home: tempfile::TempDir,
+}
+
+pub struct Response {
+    pub status: u16,
+    pub body: Vec<u8>,
+}
+
+impl Response {
+    pub fn json(&self) -> serde_json::Value {
+        serde_json::from_slice(&self.body).expect("response body is JSON")
+    }
+}
+
+impl UiServer {
+    pub fn start() -> Self {
+        let home = tempfile::tempdir().expect("temp home");
+        let mut child = Command::new(env!("CARGO_BIN_EXE_sovereign"))
+            .args(["ui", "--port", "0", "--no-open"])
+            .env("HOME", home.path())
+            .env("XDG_DATA_HOME", home.path().join(".local/share"))
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn sovereign ui");
+        let stdout = child.stdout.take().expect("child stdout");
+        let port = read_port(stdout);
+        Self {
+            child,
+            port,
+            _home: home,
+        }
+    }
+
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// A POST the app's own frontend could have sent: correct `Host`, correct
+    /// `Content-Type`, and no credential of any kind, because none exists.
+    pub fn post(&self, path: &str, body: &serde_json::Value) -> Response {
+        let body = serde_json::to_vec(body).expect("serialize body");
+        self.exchange("POST", path, &self.default_headers(body.len()), &body)
+    }
+
+    pub fn default_headers(&self, length: usize) -> Vec<(String, String)> {
+        vec![
+            ("Host".into(), format!("127.0.0.1:{}", self.port)),
+            ("Content-Type".into(), "application/json".into()),
+            ("Content-Length".into(), length.to_string()),
+            ("Connection".into(), "close".into()),
+        ]
+    }
+
+    pub fn exchange(
+        &self,
+        method: &str,
+        path: &str,
+        headers: &[(String, String)],
+        body: &[u8],
+    ) -> Response {
+        let mut raw = format!("{method} {path} HTTP/1.1\r\n");
+        for (name, value) in headers {
+            raw.push_str(&format!("{name}: {value}\r\n"));
+        }
+        raw.push_str("\r\n");
+        let mut stream = TcpStream::connect(("127.0.0.1", self.port)).expect("connect");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(10)))
+            .expect("read timeout");
+        stream.write_all(raw.as_bytes()).expect("write head");
+        stream.write_all(body).expect("write body");
+        stream.flush().expect("flush");
+        let mut raw = Vec::new();
+        stream.read_to_end(&mut raw).expect("read response");
+        parse(&raw)
+    }
+}
+
+impl Drop for UiServer {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn read_port(stdout: ChildStdout) -> u16 {
+    let (sender, receiver) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines() {
+            let Ok(line) = line else { return };
+            if let Some(port) = line.trim_end().strip_prefix(READY_PREFIX) {
+                let _ = sender.send(port.parse::<u16>());
+                return;
+            }
+        }
+        // EOF without the line: the child died. Dropping the sender
+        // disconnects the receiver, which fails immediately rather than
+        // waiting out the budget.
+    });
+    receiver
+        .recv_timeout(STARTUP_BUDGET)
+        .expect("server reported no port before it exited or the budget expired")
+        .expect("server reported an unparsable port")
+}
+
+fn parse(raw: &[u8]) -> Response {
+    let mut headers = [httparse::EMPTY_HEADER; 32];
+    let mut response = httparse::Response::new(&mut headers);
+    let parsed = response.parse(raw).expect("parse response");
+    let body_at = match parsed {
+        httparse::Status::Complete(offset) => offset,
+        httparse::Status::Partial => panic!("incomplete HTTP response"),
+    };
+    Response {
+        status: response.code.expect("status code"),
+        body: raw[body_at..].to_vec(),
+    }
+}

--- a/apps/cli/tests/ui_http_boundary.rs
+++ b/apps/cli/tests/ui_http_boundary.rs
@@ -1,0 +1,154 @@
+//! The loopback API's HTTP boundary, pinned as it behaves today.
+//!
+//! Program 1C0 changes exactly this surface. Until these tests existed, no
+//! test drove it at all: every approval test called `Store::decide` directly,
+//! so both what the server accepts and what it refuses were unverified.
+
+#[path = "support/ui_server.rs"]
+mod ui_server;
+
+use serde_json::json;
+use ui_server::UiServer;
+
+/// Drive the shipped flow up to a pending approval and return its id.
+fn pending_approval(server: &UiServer) -> String {
+    let venture = server.post(
+        "/api/workspace/venture",
+        &json!({ "name": "Boundary Co", "service": "Pinning the HTTP surface" }),
+    );
+    assert_eq!(venture.status, 200, "venture: {:?}", venture.json());
+
+    let customer = server.post(
+        "/api/workspace/customer",
+        &json!({ "name": "A Customer", "email": "", "notes": "" }),
+    );
+    let state = customer.json();
+    assert_eq!(state["ok"], true, "customer: {state}");
+    let customer_id = state["workspace"]["customers"][0]["id"]
+        .as_str()
+        .expect("customer id")
+        .to_owned();
+
+    let offer = server.post(
+        "/api/workspace/offer",
+        &json!({ "customer_id": customer_id }),
+    );
+    let state = offer.json();
+    assert_eq!(state["ok"], true, "offer: {state}");
+    let document_id = state["workspace"]["documents"][0]["id"]
+        .as_str()
+        .expect("document id")
+        .to_owned();
+
+    let requested = server.post(
+        "/api/workspace/request-send",
+        &json!({ "document_id": document_id }),
+    );
+    let state = requested.json();
+    assert_eq!(state["ok"], true, "request-send: {state}");
+    state["workspace"]["approvals"][0]["id"]
+        .as_str()
+        .expect("approval id")
+        .to_owned()
+}
+
+/// A POST that carries no credential of any kind approves a real send, and
+/// the backend signs it as the owner's decision.
+///
+/// This pins today's boundary, and it is the whole reason the product cannot
+/// yet claim that only the owner approves: the server has no way to tell the
+/// founder from any other process on this machine, so an agent, a script, or
+/// a page in another local app can produce owner-signed approval evidence.
+///
+/// **When this test fails, the 1C0 boundary landed. Invert it — assert the
+/// unauthenticated POST is refused — do not delete it.**
+#[test]
+fn an_unauthenticated_local_post_can_approve_today_1c0_pin() {
+    let server = UiServer::start();
+    let approval_id = pending_approval(&server);
+
+    let decided = server.post(
+        "/api/workspace/decide",
+        &json!({ "approval_id": approval_id, "approve": true }),
+    );
+    assert_eq!(decided.status, 200);
+    let state = decided.json();
+    assert_eq!(state["ok"], true, "decide: {state}");
+
+    let approval = &state["workspace"]["approvals"][0];
+    assert_eq!(approval["id"], approval_id.as_str());
+    assert_eq!(
+        approval["status"], "approved",
+        "an anonymous POST approved a send: {approval}"
+    );
+    assert!(
+        !approval["evidence"].is_null(),
+        "and the backend signed owner evidence for it: {approval}"
+    );
+}
+
+/// A request that reaches the loopback port with someone else's `Host` is
+/// refused: a browser on this machine can be pointed at 127.0.0.1 by a remote
+/// page, but it still sends that page's `Host`.
+#[test]
+fn a_foreign_host_header_is_refused() {
+    let server = UiServer::start();
+    let body = serde_json::to_vec(&json!({ "name": "x", "service": "y" })).expect("body");
+    let headers = vec![
+        ("Host".into(), "evil.example".into()),
+        ("Content-Type".into(), "application/json".into()),
+        ("Content-Length".into(), body.len().to_string()),
+        ("Connection".into(), "close".into()),
+    ];
+
+    let response = server.exchange("POST", "/api/workspace/venture", &headers, &body);
+    let state = response.json();
+    assert_eq!(state["ok"], false, "{state}");
+    assert_eq!(state["error"], "forbidden host");
+}
+
+/// Mutations must be JSON. Requiring the header keeps a plain HTML form —
+/// which cannot set it — from driving the API cross-origin.
+#[test]
+fn a_mutation_without_a_json_content_type_is_refused() {
+    let server = UiServer::start();
+    let body = serde_json::to_vec(&json!({ "name": "x", "service": "y" })).expect("body");
+    let headers = vec![
+        ("Host".into(), format!("127.0.0.1:{}", server.port())),
+        (
+            "Content-Type".into(),
+            "application/x-www-form-urlencoded".into(),
+        ),
+        ("Content-Length".into(), body.len().to_string()),
+        ("Connection".into(), "close".into()),
+    ];
+
+    let response = server.exchange("POST", "/api/workspace/venture", &headers, &body);
+    let state = response.json();
+    assert_eq!(state["ok"], false, "{state}");
+    assert!(
+        state["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("Content-Type")),
+        "{state}"
+    );
+}
+
+/// The body cap is enforced on the bytes read, not on a declared length, so
+/// an oversized body cannot exhaust memory before it is rejected.
+#[test]
+fn a_body_over_the_cap_is_refused() {
+    let server = UiServer::start();
+    let padding = "x".repeat(64 * 1024 + 1);
+    let body = serde_json::to_vec(&json!({ "name": padding, "service": "y" })).expect("body");
+    assert!(body.len() > 64 * 1024);
+
+    let response = server.exchange(
+        "POST",
+        "/api/workspace/venture",
+        &server.default_headers(body.len()),
+        &body,
+    );
+    let state = response.json();
+    assert_eq!(state["ok"], false, "{state}");
+}

--- a/crates/consultant-playground/tests/support/transport.rs
+++ b/crates/consultant-playground/tests/support/transport.rs
@@ -565,8 +565,40 @@ mod transport_capture_regressions {
         );
         // The fixture holds this listener until process termination. A new
         // bind independently proves cleanup released its OS-owned resource.
-        let listener = TcpListener::bind(("127.0.0.1", server.port)).unwrap();
-        drop(listener);
+        //
+        // Once released, the port is an ordinary free ephemeral port that any
+        // process may take — including a server another test binary spawned,
+        // since cargo runs these binaries in parallel. So a failed bind alone
+        // does not mean the fixture leaked: it means either that, or someone
+        // else got there first. Distinguish the two rather than failing on
+        // whichever process won a race.
+        assert_released(server.port);
+    }
+
+    /// The port is free, or somebody else now owns it. Both prove the fixture
+    /// let it go; only "nothing is listening and we still cannot bind" is the
+    /// leak this checks for.
+    fn assert_released(port: u16) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            match TcpListener::bind(("127.0.0.1", port)) {
+                Ok(listener) => return drop(listener),
+                Err(error) if error.kind() == io::ErrorKind::AddrInUse => {
+                    if TcpStream::connect(("127.0.0.1", port)).is_ok() {
+                        // Another listener answers here now. The fixture's own
+                        // socket is gone, which is what this asserts.
+                        return;
+                    }
+                    assert!(
+                        Instant::now() < deadline,
+                        "port {port} is neither bindable nor listening: the \
+                         fixture did not release it"
+                    );
+                    thread::sleep(Duration::from_millis(50));
+                }
+                Err(error) => panic!("unexpected bind error on port {port}: {error:?}"),
+            }
+        }
     }
 
     fn captured_child(mode: &str) -> (ChildServer, TcpStream) {

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -805,7 +805,7 @@ while the controller routes eligible design/review cards to the strong role.
   matrix doc exists with the schema and an honest empty-real-matrix note, and
   `./scripts/test_changed.sh` prints ALL GREEN.
 
-- [ ] **P2 | `apps/cli/src/` | Stand up an HTTP-layer test boundary for the loopback API and pin today's posture.**
+- [x] **P2 | `apps/cli/src/` | Stand up an HTTP-layer test boundary for the loopback API and pin today's posture.** Landed 2026-09-09 (`apps/cli/tests/ui_http_boundary.rs`, `tests/support/ui_server.rs`).
   There are no HTTP tests at all — ui.rs has no `#[test]` and no
   `apps/cli/tests/` dir exists, so the exact network surface 1C0 must change
   is untested in both directions; every approve test drives `Store::decide`


### PR DESCRIPTION
`ui.rs` had no test of any kind. Every approval test called `Store::decide` directly, so the network surface Program 1C0 replaces was unverified in both directions.

Four tests now drive the shipped binary over real HTTP on an ephemeral loopback port against a throwaway state directory. Three pin refusals that already work: a foreign `Host`, a mutation without a JSON content type, a body over the 64 KiB cap.

The fourth pins the hole. `an_unauthenticated_local_post_can_approve_today_1c0_pin` drives the real flow to a pending send, then approves it with a POST carrying **no credential of any kind** — and it succeeds, with the backend recording signed owner evidence for a decision it cannot attribute to the owner. Writing that down as a passing test makes the gap something the suite asserts rather than a sentence in the README, and makes it impossible to close 1C0 without this test failing. Its doc comment says to invert it then, not delete it.

Second commit fixes a latent race this surfaced: `assert_reaped_and_joined` proved cleanup by rebinding the child's port, but once released that is an ordinary free ephemeral port any parallel test binary may take. The probe now distinguishes "released" from "someone else won the race" and only fails on a genuinely stuck resource. Verified with twelve cores saturated.