### PR TITLE
test(durability): add fault injection, then prove the vault, ledger, and outbox fail closed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1406,6 +1406,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sovereign-contracts",
+ "sovereign-fault-testing",
  "sovereign-identity",
  "tempfile",
  "thiserror 2.0.18",
@@ -1504,6 +1505,7 @@ dependencies = [
  "hex",
  "serde",
  "sha2",
+ "sovereign-fault-testing",
  "tempfile",
  "thiserror 2.0.18",
 ]
@@ -1612,6 +1614,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "sovereign-fault-testing",
  "tempfile",
  "thiserror 2.0.18",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1520,6 +1520,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "sovereign-fault-testing"
+version = "0.1.0"
+dependencies = [
+ "tempfile",
+]
+
+[[package]]
 name = "sovereign-identity"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/authority",
     "crates/contracts",
     "crates/effects",
+    "crates/fault-testing",
     "crates/execution",
     "crates/identity",
     "crates/model",

--- a/crates/audit-ledger/Cargo.toml
+++ b/crates/audit-ledger/Cargo.toml
@@ -19,4 +19,5 @@ uuid = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+sovereign-fault-testing = { path = "../fault-testing" }
 tempfile = "3"

--- a/crates/audit-ledger/src/lib.rs
+++ b/crates/audit-ledger/src/lib.rs
@@ -318,4 +318,110 @@ mod tests {
         let loaded = AuditLedger::load(&path, device.public_key_b64()).unwrap();
         assert_eq!(loaded.events().len(), 1);
     }
+
+    fn one_event_ledger(device: &DeviceIdentity) -> AuditLedger {
+        let mut ledger = AuditLedger::new();
+        ledger
+            .append(
+                AppendInput {
+                    venture_id: "ven_1".into(),
+                    actor_id: "agent".into(),
+                    action: "execute".into(),
+                    resource: "email:draft".into(),
+                    capability_id: None,
+                    payload: serde_json::json!({}),
+                    policy_decision_hash: None,
+                },
+                device,
+            )
+            .unwrap();
+        ledger
+    }
+
+    /// The durable half of an append is `save`, and nothing made it fail
+    /// before this: the chain's tamper-evidence was proven only against
+    /// writes that succeeded. A ledger directory that has gone away must
+    /// surface the error, leave no partial chain, and leave the chain that
+    /// was already on disk intact and verifiable.
+    #[test]
+    fn append_fails_closed_when_the_ledger_directory_is_unavailable() {
+        let dir = tempdir().unwrap();
+        let ledger_dir = dir.path().join("audit");
+        std::fs::create_dir(&ledger_dir).unwrap();
+        let path = ledger_dir.join("ledger.json");
+        let device = DeviceIdentity::generate();
+
+        let mut ledger = one_event_ledger(&device);
+        ledger.save(&path).unwrap();
+        let before = std::fs::read(&path).unwrap();
+
+        // Extend in memory. The in-memory append always succeeds; `save` is
+        // the step that can fail, and the point is that a failed save leaves
+        // the durable chain exactly as it was.
+        ledger
+            .append(
+                AppendInput {
+                    venture_id: "ven_1".into(),
+                    actor_id: "agent".into(),
+                    action: "execute".into(),
+                    resource: "email:send".into(),
+                    capability_id: None,
+                    payload: serde_json::json!({}),
+                    policy_decision_hash: None,
+                },
+                &device,
+            )
+            .unwrap();
+
+        let blocked = sovereign_fault_testing::BlockedPath::block(&ledger_dir).unwrap();
+        assert!(
+            ledger.save(&path).is_err(),
+            "saving into an unavailable directory must fail, not report success"
+        );
+        drop(blocked);
+
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            before,
+            "the chain already on disk must be untouched"
+        );
+        assert!(
+            !ledger_dir.join("ledger.tmp").exists(),
+            "temp file left behind"
+        );
+        let reloaded =
+            AuditLedger::load(&path, device.public_key_b64()).expect("the saved chain reloads");
+        reloaded.verify_chain().expect("and still verifies");
+        assert_eq!(
+            reloaded.events.len(),
+            1,
+            "the event whose save failed must not be on disk"
+        );
+    }
+
+    /// A crash can leave a temp file from a save that never completed. It is
+    /// not part of the chain and must never be trusted or block the next
+    /// save; the write replaces it.
+    #[test]
+    fn a_stale_temp_file_is_ignored_and_replaced_on_the_next_append() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("ledger.json");
+        let device = DeviceIdentity::generate();
+
+        let stale = dir.path().join("ledger.tmp");
+        std::fs::write(&stale, b"[not json at all").unwrap();
+
+        let ledger = one_event_ledger(&device);
+        ledger
+            .save(&path)
+            .expect("a stale temp must not block the save");
+
+        assert!(
+            !stale.exists(),
+            "the stale temp must be gone, not merely ignored"
+        );
+        let reloaded = AuditLedger::load(&path, device.public_key_b64()).unwrap();
+        reloaded.verify_chain().unwrap();
+        assert_eq!(reloaded.events.len(), 1);
+    }
 }

--- a/crates/effects/Cargo.toml
+++ b/crates/effects/Cargo.toml
@@ -14,4 +14,5 @@ sha2 = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+sovereign-fault-testing = { path = "../fault-testing" }
 tempfile = "3"

--- a/crates/effects/src/lib.rs
+++ b/crates/effects/src/lib.rs
@@ -417,4 +417,58 @@ mod tests {
         let written = std::fs::read(dir.path().join("outbox").join("doc.txt")).unwrap();
         assert_eq!(written, b"second");
     }
+
+    /// The outbox is where an approved effect becomes a real file, and until
+    /// now no test made that write fail. An unavailable outbox must surface
+    /// the error and leave nothing at all behind — neither a partial `.eml`
+    /// nor the dot-prefixed temp it writes through.
+    #[test]
+    fn write_message_fails_closed_when_the_outbox_is_unavailable() {
+        let dir = tempdir().unwrap();
+        let outbox = dir.path().join("outbox");
+        let broker = OutboxBroker::open(&outbox).unwrap();
+
+        let blocked = sovereign_fault_testing::BlockedPath::block(&outbox).unwrap();
+        assert!(
+            broker
+                .write_message("msg-1", EffectDataClass::Amber, b"never written")
+                .is_err(),
+            "writing into an unavailable outbox must fail, not report success"
+        );
+        drop(blocked);
+
+        let names: Vec<_> = std::fs::read_dir(&outbox)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            names.is_empty(),
+            "a failed write must leave no file and no temp: {names:?}"
+        );
+    }
+
+    /// A revoke that cannot remove the file must say so. Reporting success
+    /// while the message is still sitting in the outbox would let the product
+    /// tell a founder that a send was withdrawn when it was not.
+    #[test]
+    fn revoke_reports_failure_when_the_outbox_is_unavailable() {
+        let dir = tempdir().unwrap();
+        let outbox = dir.path().join("outbox");
+        let broker = OutboxBroker::open(&outbox).unwrap();
+        let receipt = broker
+            .write_message("msg-1", EffectDataClass::Amber, b"delivered")
+            .unwrap();
+
+        let blocked = sovereign_fault_testing::BlockedPath::block(&outbox).unwrap();
+        assert!(
+            broker.revoke(&receipt.relative_path).is_err(),
+            "a revoke that removed nothing must not report success"
+        );
+        drop(blocked);
+
+        assert!(
+            outbox.join(&receipt.relative_path).is_file(),
+            "the message is still there, which is exactly why revoke had to fail"
+        );
+    }
 }

--- a/crates/fault-testing/Cargo.toml
+++ b/crates/fault-testing/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "sovereign-fault-testing"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+# Never published, and never a production dependency: this crate exists only
+# so tests can make real operations fail. A `[dependencies]` edge to it from
+# any shipping crate is a defect. `no_production_crate_depends_on_this` in
+# src/tests.rs parses every workspace manifest and fails on one.
+publish = false
+
+[dependencies]
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/fault-testing/src/lib.rs
+++ b/crates/fault-testing/src/lib.rs
@@ -1,0 +1,142 @@
+//! Shared fault injection for tests.
+//!
+//! Durability claims — "the entry survives a failed write", "the chain still
+//! verifies", "no partial file is left behind" — are only worth as much as the
+//! failures they were tested against. Today every crate hand-rolls its own
+//! corruption helper, nothing injects a *failing write*, and only
+//! `crates/sandbox` kills a real child. These three primitives are that
+//! missing half, in one place so each crate tests the same fault.
+//!
+//! This is a dev-dependency. No shipping crate may depend on it.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+
+/// Makes a filesystem location unavailable for the guard's lifetime, and puts
+/// back whatever was there when it drops.
+///
+/// It works by putting a regular file where a directory is expected, so every
+/// write beneath it fails with `ENOTDIR`. That is deliberate: the obvious
+/// alternative, removing the write permission, is a silent no-op for root, and
+/// both the project's containers and nightly CI run as root — a chmod-based
+/// guard would report success while injecting nothing. A regular file denies
+/// every uid equally.
+#[derive(Debug)]
+pub struct BlockedPath {
+    path: PathBuf,
+    /// Where the original directory was moved, if one existed.
+    stashed: Option<PathBuf>,
+}
+
+impl BlockedPath {
+    /// Block `path`. It may be an existing directory, which is moved aside and
+    /// restored on drop, or a location that does not exist yet, which is the
+    /// case when the code under test is expected to create it.
+    pub fn block(path: impl AsRef<Path>) -> io::Result<Self> {
+        let path = path.as_ref().to_path_buf();
+        let stashed = match fs::symlink_metadata(&path) {
+            Ok(metadata) if metadata.is_dir() => {
+                let stashed = sibling(&path, ".blocked-original");
+                fs::rename(&path, &stashed)?;
+                Some(stashed)
+            }
+            Ok(_) => {
+                return Err(io::Error::other(format!(
+                    "{} is not a directory; blocking it would prove nothing",
+                    path.display()
+                )))
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+            Err(error) => return Err(error),
+        };
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&path, b"blocked by sovereign-fault-testing")?;
+        Ok(Self { path, stashed })
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for BlockedPath {
+    fn drop(&mut self) {
+        // Best effort by necessity: a panicking drop would replace the test's
+        // real failure with this one. A leftover blocker is confined to the
+        // test's own temporary directory.
+        let _ = fs::remove_file(&self.path);
+        if let Some(stashed) = &self.stashed {
+            let _ = fs::rename(stashed, &self.path);
+        }
+    }
+}
+
+/// Flip one byte of a file in place, leaving its length unchanged.
+///
+/// A changed byte and a changed length are different faults: this one survives
+/// every length check and is caught only by a hash or a signature.
+pub fn corrupt_byte(path: impl AsRef<Path>, offset: usize) -> io::Result<()> {
+    let path = path.as_ref();
+    let mut bytes = fs::read(path)?;
+    let len = bytes.len();
+    let byte = bytes.get_mut(offset).ok_or_else(|| {
+        io::Error::other(format!(
+            "offset {offset} is past the end of {} ({len} bytes)",
+            path.display()
+        ))
+    })?;
+    *byte = byte.wrapping_add(1);
+    fs::write(path, &bytes)
+}
+
+/// Drop the last `n` bytes of a file: the truncation an interrupted write
+/// leaves behind.
+pub fn truncate_by(path: impl AsRef<Path>, n: u64) -> io::Result<()> {
+    let path = path.as_ref();
+    let len = fs::metadata(path)?.len();
+    let shorter = len.checked_sub(n).ok_or_else(|| {
+        io::Error::other(format!(
+            "cannot remove {n} bytes from {} ({len} bytes)",
+            path.display()
+        ))
+    })?;
+    fs::OpenOptions::new()
+        .write(true)
+        .open(path)?
+        .set_len(shorter)
+}
+
+/// Run one `#[ignore]`d test in a fresh copy of this test binary, so the
+/// caller can kill it mid-operation and inspect what it left on disk.
+///
+/// The worker is an ignored test guarded by `marker`, so it never runs in an
+/// ordinary `cargo test`; it runs only when this function sets that variable.
+/// The child's stdout is piped so the caller can wait for a progress marker
+/// before killing it, rather than sleeping and hoping.
+pub fn respawn_self(worker_test_name: &str, marker: (&str, &str)) -> io::Result<Child> {
+    Command::new(std::env::current_exe()?)
+        .args([
+            "--exact",
+            worker_test_name,
+            "--test-threads=1",
+            "--ignored",
+            "--nocapture",
+        ])
+        .env(marker.0, marker.1)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+}
+
+fn sibling(path: &Path, suffix: &str) -> PathBuf {
+    let mut name = path.file_name().unwrap_or_default().to_os_string();
+    name.push(suffix);
+    path.with_file_name(name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/fault-testing/src/tests.rs
+++ b/crates/fault-testing/src/tests.rs
@@ -1,0 +1,201 @@
+use super::*;
+use std::io::{BufRead, BufReader};
+
+/// The point of the whole guard. If this passes while running as root, the
+/// injection is real; a chmod-based guard would silently inject nothing there
+/// and every test built on it would false-green.
+#[test]
+fn blocking_a_directory_makes_writes_beneath_it_fail() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = dir.path().join("store");
+    fs::create_dir(&store).unwrap();
+    fs::write(store.join("existing"), b"kept").unwrap();
+
+    let blocked = BlockedPath::block(&store).unwrap();
+    let error = fs::write(store.join("new"), b"denied").unwrap_err();
+    assert!(
+        matches!(
+            error.kind(),
+            io::ErrorKind::NotADirectory | io::ErrorKind::AlreadyExists | io::ErrorKind::Other
+        ),
+        "a blocked directory must refuse writes, got {error:?}"
+    );
+    assert!(store.is_file(), "the blocker itself must be a regular file");
+
+    drop(blocked);
+    assert!(store.is_dir(), "the original directory must come back");
+    assert_eq!(fs::read(store.join("existing")).unwrap(), b"kept");
+    fs::write(store.join("new"), b"allowed").unwrap();
+}
+
+/// Blocking a location that does not exist yet is the case where the code
+/// under test is the thing that would have created it.
+#[test]
+fn blocking_a_missing_location_denies_its_creation_and_leaves_nothing_behind() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = dir.path().join("not-created-yet");
+
+    let blocked = BlockedPath::block(&store).unwrap();
+    assert!(fs::create_dir_all(&store).is_err());
+    assert!(fs::write(store.join("entry"), b"denied").is_err());
+
+    drop(blocked);
+    assert!(
+        !store.exists(),
+        "a location that did not exist must not exist afterwards"
+    );
+}
+
+/// Blocking a regular file would prove nothing — writes to it still succeed —
+/// so the guard refuses rather than injecting a fault that is not one.
+#[test]
+fn blocking_a_regular_file_is_refused() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("a-file");
+    fs::write(&file, b"content").unwrap();
+
+    assert!(BlockedPath::block(&file).is_err());
+    assert_eq!(fs::read(&file).unwrap(), b"content");
+}
+
+#[test]
+fn corrupt_byte_changes_one_byte_and_keeps_the_length() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("entry");
+    fs::write(&path, b"0123456789").unwrap();
+
+    corrupt_byte(&path, 4).unwrap();
+    let after = fs::read(&path).unwrap();
+    assert_eq!(after.len(), 10);
+    assert_eq!(&after[..4], b"0123");
+    assert_ne!(after[4], b'4');
+    assert_eq!(&after[5..], b"56789");
+}
+
+#[test]
+fn corrupt_byte_past_the_end_is_an_error_not_a_silent_no_op() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("entry");
+    fs::write(&path, b"short").unwrap();
+
+    assert!(corrupt_byte(&path, 99).is_err());
+    assert_eq!(fs::read(&path).unwrap(), b"short");
+}
+
+#[test]
+fn truncate_by_removes_exactly_the_tail() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("entry");
+    fs::write(&path, b"0123456789").unwrap();
+
+    truncate_by(&path, 3).unwrap();
+    assert_eq!(fs::read(&path).unwrap(), b"0123456");
+}
+
+#[test]
+fn truncate_by_more_than_the_file_holds_is_an_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("entry");
+    fs::write(&path, b"short").unwrap();
+
+    assert!(truncate_by(&path, 99).is_err());
+    assert_eq!(fs::read(&path).unwrap(), b"short");
+}
+
+const WORKER_MARKER: (&str, &str) = ("SOVEREIGN_FAULT_TESTING_WORKER", "1");
+
+/// Proves the respawn actually re-entered this binary and ran the ignored
+/// worker: the parent reads the marker the child printed, then kills it while
+/// it is still alive, which is the whole point of the primitive.
+#[test]
+fn respawn_self_runs_the_ignored_worker_and_can_be_killed_at_its_marker() {
+    let mut child = respawn_self("tests::worker_that_waits_to_be_killed", WORKER_MARKER).unwrap();
+    let stdout = child.stdout.take().unwrap();
+
+    let mut reached = false;
+    for line in BufReader::new(stdout).lines() {
+        if line.unwrap().contains("worker-ready") {
+            reached = true;
+            break;
+        }
+    }
+    assert!(reached, "the worker never reported that it started");
+
+    child.kill().unwrap();
+    let status = child.wait().unwrap();
+    assert!(!status.success(), "a killed worker must not report success");
+}
+
+/// The worker half. `#[ignore]` keeps it out of ordinary runs, and the marker
+/// keeps it from doing anything even if someone runs the ignored set by hand.
+#[test]
+#[ignore = "spawned by respawn_self; not a standalone test"]
+fn worker_that_waits_to_be_killed() {
+    if std::env::var(WORKER_MARKER.0).as_deref() != Ok(WORKER_MARKER.1) {
+        return;
+    }
+    println!("worker-ready");
+    // Bounded so a parent that regresses and never kills cannot hang CI.
+    std::thread::sleep(std::time::Duration::from_secs(30));
+}
+
+/// The crate's whole safety property: it may appear under `[dev-dependencies]`
+/// anywhere, and under `[dependencies]` nowhere. A production edge would ship
+/// fault injection inside the product.
+///
+/// Parsing the manifests catches the mistake at the moment it is written,
+/// which `cargo build` does not: a dev-dependency and a real dependency build
+/// exactly the same way.
+#[test]
+fn no_production_crate_depends_on_this() {
+    let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .to_path_buf();
+
+    let mut manifests = Vec::new();
+    collect_manifests(&workspace.join("crates"), &mut manifests);
+    collect_manifests(&workspace.join("apps"), &mut manifests);
+    collect_manifests(&workspace.join("tests"), &mut manifests);
+    assert!(
+        manifests.len() > 10,
+        "found only {} manifests; the scan is not reaching the workspace",
+        manifests.len()
+    );
+
+    for manifest in manifests {
+        let text = fs::read_to_string(&manifest).unwrap();
+        let mut section = "";
+        for line in text.lines() {
+            let trimmed = line.trim();
+            if trimmed.starts_with('[') {
+                section = trimmed;
+            }
+            if trimmed.starts_with("sovereign-fault-testing") {
+                assert_ne!(
+                    section,
+                    "[dependencies]",
+                    "{} depends on the fault-injection crate in production",
+                    manifest.display()
+                );
+            }
+        }
+    }
+}
+
+fn collect_manifests(dir: &Path, found: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            let manifest = path.join("Cargo.toml");
+            if manifest.is_file() {
+                found.push(manifest);
+            }
+            collect_manifests(&path, found);
+        }
+    }
+}

--- a/crates/vault/Cargo.toml
+++ b/crates/vault/Cargo.toml
@@ -18,4 +18,5 @@ thiserror = { workspace = true }
 base64 = { workspace = true }
 
 [dev-dependencies]
+sovereign-fault-testing = { path = "../fault-testing" }
 tempfile = "3"

--- a/crates/vault/src/lib.rs
+++ b/crates/vault/src/lib.rs
@@ -76,6 +76,8 @@ impl Vault {
                 entries: Vec::new(),
             }
         };
+        #[cfg(unix)]
+        restrict_existing(&root, &manifest.entries);
         Ok(Self {
             root,
             key,
@@ -128,7 +130,7 @@ fn write_atomic(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
     use std::io::Write;
     let temp_path = path.with_extension("tmp");
     let result = (|| {
-        let mut file = std::fs::File::create(&temp_path)?;
+        let mut file = create_owner_only(&temp_path)?;
         file.write_all(bytes)?;
         file.sync_all()?;
         drop(file);
@@ -190,6 +192,49 @@ fn generate_key() -> [u8; 32] {
     let mut key = [0u8; 32];
     rand::thread_rng().fill_bytes(&mut key);
     key
+}
+
+/// Create a file only this user can read. `File::create` takes the ambient
+/// umask, which on a default account is 0644 — for `vault.key` that is the
+/// master key readable by every local account. The device signing key in
+/// `crates/identity` has always been 0600; this brings the vault's own files
+/// to the same footing.
+///
+/// The temp file is created with the mode, and `rename` carries it to the
+/// destination, so the target is never briefly world-readable.
+fn create_owner_only(path: &std::path::Path) -> std::io::Result<std::fs::File> {
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    options.open(path)
+}
+
+/// Tighten what a vault created before this existed. Modes are all that
+/// change; the on-disk format is untouched.
+///
+/// This narrows who can read the files from here on. It cannot undo an
+/// earlier exposure: a key that was 0644 on a shared machine must be treated
+/// as having been readable, and rotating it is a separate decision.
+#[cfg(unix)]
+fn restrict_existing(root: &std::path::Path, entries: &[String]) {
+    use std::os::unix::fs::PermissionsExt;
+    let set = |path: std::path::PathBuf, mode: u32| {
+        if path.exists() {
+            // Best effort: a vault on a filesystem without Unix modes still
+            // opens. Failing here would deny access to readable data.
+            let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(mode));
+        }
+    };
+    set(root.to_path_buf(), 0o700);
+    set(root.join("vault.key"), 0o600);
+    set(root.join("manifest.json"), 0o600);
+    for entry in entries {
+        set(root.join(format!("{entry}.enc")), 0o600);
+    }
 }
 
 fn save_key(path: &std::path::Path, key: &[u8; 32]) -> Result<(), VaultError> {
@@ -405,5 +450,131 @@ mod tests {
             Err(VaultError::InvalidEntryName(_))
         ));
         assert!(!dir.path().join("outside.enc").exists());
+    }
+
+    /// The master key must not be readable by other local accounts, and
+    /// neither must the ciphertext or the manifest. `File::create` and
+    /// `create_dir_all` take the ambient umask, which on a default account
+    /// left `vault.key` at 0644 inside a 0755 directory.
+    ///
+    /// This does not make the vault safe against someone who can read the
+    /// disk as this user — the key still sits beside its ciphertext by
+    /// design at this stage, and RFC 0005 is what changes that. It removes
+    /// the weaker exposure: every other account on the machine.
+    #[cfg(unix)]
+    #[test]
+    fn every_vault_file_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("vault");
+        let mut vault = Vault::init(&root).unwrap();
+        vault.put("secret", b"plaintext").unwrap();
+
+        let mode = |path: std::path::PathBuf| {
+            std::fs::metadata(&path)
+                .unwrap_or_else(|error| panic!("{}: {error}", path.display()))
+                .permissions()
+                .mode()
+                & 0o777
+        };
+        assert_eq!(mode(root.clone()), 0o700, "vault root");
+        assert_eq!(mode(root.join("vault.key")), 0o600, "master key");
+        assert_eq!(mode(root.join("manifest.json")), 0o600, "manifest");
+        assert_eq!(mode(root.join("secret.enc")), 0o600, "entry");
+    }
+
+    /// A vault created by an older build keeps its 0644 key until something
+    /// tightens it. Opening it is that something.
+    #[cfg(unix)]
+    #[test]
+    fn opening_an_older_vault_tightens_what_it_already_holds() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("vault");
+        let mut vault = Vault::init(&root).unwrap();
+        vault.put("secret", b"plaintext").unwrap();
+        drop(vault);
+
+        // Exactly what a default umask produced before this change.
+        let loosen = |path: std::path::PathBuf, mode: u32| {
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).unwrap()
+        };
+        loosen(root.join("vault.key"), 0o644);
+        loosen(root.join("manifest.json"), 0o644);
+        loosen(root.join("secret.enc"), 0o644);
+        loosen(root.clone(), 0o755);
+
+        let reopened = Vault::init(&root).unwrap();
+        assert_eq!(reopened.get("secret").unwrap(), b"plaintext");
+
+        let mode = |path: std::path::PathBuf| {
+            std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+        };
+        assert_eq!(mode(root.clone()), 0o700, "vault root");
+        assert_eq!(mode(root.join("vault.key")), 0o600, "master key");
+        assert_eq!(mode(root.join("manifest.json")), 0o600, "manifest");
+        assert_eq!(mode(root.join("secret.enc")), 0o600, "entry");
+    }
+
+    /// A vault whose root has gone away must fail the write, leave no debris,
+    /// and still hold everything it held before. Until now no test made a
+    /// vault write fail at all, so "writes replace atomically" was only ever
+    /// checked on writes that succeeded.
+    #[test]
+    fn put_fails_closed_when_the_vault_root_is_unavailable() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("vault");
+        let mut vault = Vault::init(&root).unwrap();
+        vault.put("first", b"stored before the fault").unwrap();
+
+        let blocked = sovereign_fault_testing::BlockedPath::block(&root).unwrap();
+        assert!(
+            vault.put("second", b"never written").is_err(),
+            "a put into an unavailable root must fail, not report success"
+        );
+        drop(blocked);
+
+        let names: Vec<_> = std::fs::read_dir(&root)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            !names.iter().any(|name| name.ends_with(".tmp")),
+            "a failed write left debris behind: {names:?}"
+        );
+        assert!(!root.join("second.enc").exists());
+
+        let reopened = Vault::init(&root).unwrap();
+        assert_eq!(reopened.get("first").unwrap(), b"stored before the fault");
+        assert_eq!(reopened.list(), ["first"]);
+    }
+
+    /// `put` publishes the entry and then the manifest, so a crash between
+    /// them leaves a readable blob the manifest does not list. That tear must
+    /// not lose data: the entry still decrypts, `list` tells the truth about
+    /// what the manifest knows, and the next write reconciles the two.
+    #[test]
+    fn a_torn_entry_absent_from_the_manifest_stays_readable_and_heals_on_next_put() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("vault");
+        let mut vault = Vault::init(&root).unwrap();
+        vault.put("a", b"first entry").unwrap();
+        drop(vault);
+
+        // Exactly the state a crash between the two renames leaves: b.enc is
+        // published, the manifest still lists only a.
+        std::fs::copy(root.join("a.enc"), root.join("b.enc")).unwrap();
+
+        let mut reopened = Vault::init(&root).unwrap();
+        assert_eq!(reopened.list(), ["a"], "list reports the manifest");
+        assert_eq!(
+            reopened.get("b").unwrap(),
+            b"first entry",
+            "the torn entry must still decrypt"
+        );
+
+        reopened.put("b", b"second entry").unwrap();
+        assert_eq!(reopened.list(), ["a", "b"], "the next put reconciles them");
+        assert_eq!(reopened.get("b").unwrap(), b"second entry");
     }
 }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -848,7 +848,7 @@ while the controller routes eligible design/review cards to the strong role.
   pass in `cargo test -p sovereign-adversarial-tests` and the honesty texts
   match the tested reality.
 
-- [ ] **P2 | `crates/fault-testing/` | Stand up the shared fault-injection dev crate.**
+- [x] **P2 | `crates/fault-testing/` | Stand up the shared fault-injection dev crate.** Landed 2026-09-09; unblocks the vault/ledger/effects entries below.
   First slice of ROADMAP v0.1's "add process-kill, concurrency, and
   filesystem-fault tests" (ROADMAP.md:190-191). Today every crate hand-rolls
   corruption helpers, no test injects a *failing write*, and only

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -872,7 +872,7 @@ while the controller routes eligible design/review cards to the strong role.
   `cargo build --workspace --locked` shows no production dependency edge to
   the new crate.
 
-- [ ] **P2 | `crates/vault/` | Inject write failures and pin the entry/manifest tear semantics.**
+- [x] **P2 | `crates/vault/` | Inject write failures and pin the entry/manifest tear semantics.** Landed 2026-09-09.
   Blocked on the `crates/fault-testing` entry above. `put` performs two
   separate atomic renames (`<name>.enc` then `manifest.json`,
   src/lib.rs:86-97, 114-119), and no test makes a vault write fail. Done
@@ -885,7 +885,7 @@ while the controller routes eligible design/review cards to the strong role.
   and a later `put("b", …)` re-lists it; `cargo test -p sovereign-vault`
   passes.
 
-- [ ] **P2 | `crates/audit-ledger/` | Inject append failures and prove the chain survives.**
+- [x] **P2 | `crates/audit-ledger/` | Inject append failures and prove the chain survives.** Landed 2026-09-09; the durable step is `save`, so that is what the fault targets.
   Blocked on the `crates/fault-testing` entry above. No test today makes an
   append fail (`src/lib.rs:188` is only checked on the success path). Done
   when: `append_fails_closed_when_the_ledger_directory_is_unavailable`
@@ -895,7 +895,7 @@ while the controller routes eligible design/review cards to the strong role.
   stale `.tmp` beside the ledger and asserts the next append succeeds and
   removes or replaces it; `cargo test -p sovereign-audit-ledger` passes.
 
-- [ ] **P2 | `crates/effects/` | Inject outbox write failures and surface revoke failures.**
+- [x] **P2 | `crates/effects/` | Inject outbox write failures and surface revoke failures.** Landed 2026-09-09; `revoke` already propagated removal errors, so no fix was needed — only the test proving it.
   Blocked on the `crates/fault-testing` entry above. `write_exclusive_atomic`
   (src/lib.rs:218-238) has no failing-write coverage, and `revoke`
   (src/lib.rs:155-176) must be checked for swallowed removal errors — if it
@@ -1079,7 +1079,7 @@ while the controller routes eligible design/review cards to the strong role.
   `crates/identity/tests/public_api.rs` exercises key lifecycle through the
   public API only and passes.
 
-- [ ] **P2 | `crates/vault/` | Create the vault key, manifest, and entry files with owner-only permissions.**
+- [x] **P2 | `crates/vault/` | Create the vault key, manifest, and entry files with owner-only permissions.** Landed 2026-09-09; opening an older vault also tightens what it already holds.
   `write_atomic` (src/lib.rs:118-137) uses `std::fs::File::create` with no mode
   and `init` (src/lib.rs:51) uses `create_dir_all`, so under a default umask the
   master key `vault.key` (src/lib.rs:52-59, 160-163) lands at 0644 inside a 0755


### PR DESCRIPTION
Every durability claim in this repository was proven on the happy path. Nothing made a write actually fail, each crate hand-rolled its own corruption helper, and only `crates/sandbox` killed a real child.

**`crates/fault-testing`** (`publish = false`, dev-dependency only) adds three primitives. `BlockedPath` makes a location unavailable by putting a regular file where a directory is expected, so writes beneath it fail with ENOTDIR — deliberately not chmod, which is a silent no-op for root, and both the containers and nightly CI run as root. `corrupt_byte`/`truncate_by` separate a flipped byte from a short file. `respawn_self` re-enters the test binary at one `#[ignore]`d worker, piping stdout so a caller kills it at a progress marker instead of sleeping.

`no_production_crate_depends_on_this` parses every workspace manifest, because `cargo build` cannot catch this — a dev-dependency and a real dependency build identically. Verified to have teeth by adding such an edge to `crates/vault`: it failed and named the manifest.

**Then the four queued consumers.** The vault created files at the ambient umask, so the master key sat at 0644 in a 0755 directory while the device signing key beside it has always been 0600; files are now owner-only and opening an older vault tightens what it holds. Only modes change. This cannot undo an earlier exposure, and does not address the key sitting beside its ciphertext — that is deliberate at this stage and is RFC 0005's subject.

The vault now fails a `put` into an unavailable root leaving no `.tmp`, and the tear its two renames can produce keeps the entry readable and heals on the next write. The ledger's durable step is `save`, so that is what is made to fail: the chain on disk is untouched, no temp survives, and the event whose save failed is not in the reloaded chain. The outbox leaves neither a partial `.eml` nor its temp, and a revoke that cannot remove the file reports it. `revoke` already propagated removal errors, so the queued "fix it if it swallows them" was unnecessary — this pins that it stays true.