### PR TITLE
test(scripts): add the checked owner-effect test runners

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -766,7 +766,7 @@ while the controller routes eligible design/review cards to the strong role.
   NOT present, stop and release with a diagnosis instead of implementing —
   that would be the authority entries' scope.
 
-- [ ] **P2 | `scripts/`, `docs/` | Owner-session Task 1 remainder: the checked test-manifest runners and their self-tests.**
+- [x] **P2 | `scripts/`, `docs/` | Owner-session Task 1 remainder: the checked test-manifest runners and their self-tests.** Landed 2026-09-09; both self-tests run in `test_changed.sh`'s always-on block. The TSV is seeded with the two Task 2 approval-retention rows, which are the only owner-effect tests that exist yet.
   RFC 0006 and its freeze gate landed 2026-08-26; this is the mechanical
   scaffolding re-sliced out of plan Task 1. Follow
   `docs/superpowers/plans/2026-08-14-owner-session-exact-effect-v1-implementation.md`

--- a/scripts/owner-effect-tests.tsv
+++ b/scripts/owner-effect-tests.tsv
@@ -1,0 +1,21 @@
+# The owner-session / exact-effect test manifest.
+#
+# Every test the owner-effect plan requires is registered here with the exact
+# Cargo profile it must run under, so no RED or GREEN block can report success
+# from a command that quietly ran a different feature set — or ran nothing.
+# The runner infers no defaults: a row's profile is the literal flags the
+# command must carry.
+#
+# Columns, tab-separated: task, package, target, profile, test_name
+# profile is exactly one of:
+#   no-default-features
+#   owner-effect-fixture
+#   owner-effect-fixture,fault-injection
+#   fault-injection
+#   legacy-experimental
+#
+# Rows are added by the task that makes them pass, never in advance: a row for
+# a test that does not exist yet fails the runner, which is the point.
+task	package	target	profile	test_name
+2	sovereign-capability	approval_v2	no-default-features	durable_approval_survives_token_expiry_purge_until_approval_expiry
+2	sovereign-capability	approval_v2	no-default-features	expired_approval_purges_at_approval_expiry

--- a/scripts/run-owner-effect-regression.sh
+++ b/scripts/run-owner-effect-regression.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Checked wrapper for the supplemental Cargo commands the owner-session plan
+# runs outside the manifest:
+#
+#   run-owner-effect-regression.sh -- cargo test -p <pkg> --no-default-features ...
+#
+# The manifest runner covers registered rows. This covers the package- and
+# workspace-wide commands beside them, and exists for the same reason: a raw
+# `cargo test` in a RED, GREEN, checkpoint, or final block can report success
+# having run nothing at all. It judges the command before running it and the
+# transcript afterwards, and preserves the underlying exit status so a real
+# failure still fails.
+#
+# Refused: a command that is not `cargo test`; one without
+# `--no-default-features`, since the plan requires every command to declare its
+# feature set rather than inherit one; Cargo feature/target diagnostics; a
+# target skipped for unsatisfied required-features; a fully filtered run; and
+# an aggregate of zero executed tests.
+#
+# Portability: bash 3.2 (stock macOS).
+set -euo pipefail
+
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 3 ] ||
+  { [ "${BASH_VERSINFO[0]}" -eq 3 ] && [ "${BASH_VERSINFO[1]}" -lt 2 ]; }; then
+  echo "unsupported bash: need 3.2 or newer, got ${BASH_VERSION:-non-bash shell}" >&2
+  exit 3
+fi
+
+completed=0
+on_exit() {
+  status=$?
+  if [ "$completed" -eq 0 ] && [ "$status" -eq 0 ]; then
+    echo "run-owner-effect-regression: INCOMPLETE — exited before finishing" >&2
+    exit 1
+  fi
+}
+trap on_exit EXIT
+
+if [ "${1:-}" != "--" ]; then
+  echo "usage: run-owner-effect-regression.sh -- cargo test [args...]" >&2
+  exit 2
+fi
+shift
+
+if [ $# -eq 0 ]; then
+  echo "run-owner-effect-regression: no command given" >&2
+  exit 2
+fi
+if [ "$1" != "cargo" ] || [ "${2:-}" != "test" ]; then
+  echo "run-owner-effect-regression: only 'cargo test' may be wrapped, got: $*" >&2
+  exit 2
+fi
+
+# The command must declare its feature set. Inheriting the default set is
+# exactly how a command silently runs something other than what was intended.
+saw_no_default=0
+for arg in "$@"; do
+  if [ "$arg" = "--no-default-features" ]; then
+    saw_no_default=1
+  fi
+done
+if [ "$saw_no_default" -eq 0 ]; then
+  echo "run-owner-effect-regression: the command must carry --no-default-features" >&2
+  echo "  got: $*" >&2
+  exit 2
+fi
+
+echo "run-owner-effect-regression: $*"
+set +e
+output=$("$@" 2>&1)
+status=$?
+set -e
+printf '%s\n' "$output"
+
+fail() { echo "run-owner-effect-regression: FAIL — $1" >&2; exit 1; }
+
+# Cargo could not run what was asked; the status alone does not say so.
+printf '%s' "$output" | grep -Fq "does not have the feature" &&
+  fail "Cargo rejected a feature — the requested profile never ran"
+printf '%s' "$output" | grep -Fq "none of the selected packages contains these features" &&
+  fail "Cargo rejected the feature set — the requested profile never ran"
+printf '%s' "$output" | grep -Fq "no target named" &&
+  fail "Cargo could not find the named target"
+printf '%s' "$output" | grep -Fq "did not match any targets" &&
+  fail "the target filter matched nothing"
+printf '%s' "$output" | grep -Fq "skipping due to unsatisfied required-features" &&
+  fail "a target was skipped for unsatisfied required-features"
+
+# Aggregate the result lines. Zero executed across every binary is the
+# transcript that reads as a clean pass while proving nothing.
+if ! printf '%s' "$output" | grep -Eq "^test result:"; then
+  fail "no test result line — nothing ran"
+fi
+executed=$(printf '%s\n' "$output" |
+  sed -n 's/^test result: [a-zA-Z]*\. \([0-9][0-9]*\) passed; \([0-9][0-9]*\) failed.*/\1 \2/p' |
+  awk '{total += $1 + $2} END {print total + 0}')
+if [ "${executed:-0}" -eq 0 ]; then
+  fail "zero tests executed across every binary"
+fi
+
+completed=1
+if [ "$status" -ne 0 ]; then
+  echo "run-owner-effect-regression: the command failed ($executed test(s) ran); preserving exit $status" >&2
+  exit "$status"
+fi
+echo "run-owner-effect-regression: OK — $executed test(s) executed"

--- a/scripts/run-owner-effect-tests.sh
+++ b/scripts/run-owner-effect-tests.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# Checked runner for the owner-session / exact-effect test manifest
+# (scripts/owner-effect-tests.tsv). The owner-session implementation plan
+# requires that no RED, GREEN, checkpoint, or final block can report a vacuous
+# success, so this runner refuses to infer anything:
+#
+#   - a row's `profile` column is the literal flag set the command must carry;
+#     the runner never supplies a default feature set;
+#   - Cargo's own "no such feature" / "no target named" diagnostics are
+#     failures, not noise — they mean the command did not run what was asked;
+#   - zero executed tests, a filtered-to-nothing run, or a target skipped for a
+#     missing required-feature is a failure, because each looks like success;
+#   - on a nonzero run, the task-specific RED diagnostic must appear, so a test
+#     that fails for an unrelated reason cannot be read as the expected RED;
+#   - `--require-profile <p>` (repeatable) makes an `--all` run fail unless the
+#     manifest's profile set is exactly the profiles named, so the final
+#     command declares its complete feature set instead of inheriting one.
+#
+# Portability: bash 3.2 (stock macOS) — no associative arrays, no `mapfile`.
+#
+# Honesty rules this runner itself obeys (backlog lesson 8):
+#   - an EXIT-trap completion marker, so a premature abort cannot exit 0;
+#   - a run that executed zero rows fails rather than reporting success.
+set -euo pipefail
+
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 3 ] ||
+  { [ "${BASH_VERSINFO[0]}" -eq 3 ] && [ "${BASH_VERSINFO[1]}" -lt 2 ]; }; then
+  echo "unsupported bash: need 3.2 or newer, got ${BASH_VERSION:-non-bash shell}" >&2
+  exit 3
+fi
+
+MANIFEST="${OWNER_EFFECT_MANIFEST:-scripts/owner-effect-tests.tsv}"
+VALID_PROFILES="no-default-features owner-effect-fixture owner-effect-fixture,fault-injection fault-injection legacy-experimental"
+
+completed=0
+on_exit() {
+  status=$?
+  if [ "$completed" -eq 0 ] && [ "$status" -eq 0 ]; then
+    echo "run-owner-effect-tests: INCOMPLETE — exited before finishing" >&2
+    exit 1
+  fi
+}
+trap on_exit EXIT
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: run-owner-effect-tests.sh --all [--require-profile <profile>]...
+       run-owner-effect-tests.sh --task <n> [--red <diagnostic>] [--require-profile <p>]...
+
+  --all              run every row in the manifest
+  --task <n>         run only the rows whose task column is <n>
+  --red <text>       expect failure; the text must appear in the output
+  --require-profile  the manifest's profile set must be exactly these
+USAGE
+  exit 2
+}
+
+mode=""
+task=""
+red=""
+required_profiles=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --all) mode="all" ;;
+    --task) shift; [ $# -gt 0 ] || usage; mode="task"; task="$1" ;;
+    --red) shift; [ $# -gt 0 ] || usage; red="$1" ;;
+    --require-profile)
+      shift; [ $# -gt 0 ] || usage
+      required_profiles="$required_profiles $1" ;;
+    *) usage ;;
+  esac
+  shift
+done
+[ -n "$mode" ] || usage
+
+if [ ! -f "$MANIFEST" ]; then
+  echo "run-owner-effect-tests: missing manifest $MANIFEST" >&2
+  exit 1
+fi
+
+# --- read the manifest ----------------------------------------------------
+rows=""
+profiles_seen=""
+while IFS=$'\t' read -r r_task r_package r_target r_profile r_test; do
+  case "$r_task" in ''|'#'*|task) continue ;; esac
+  if [ -z "$r_package" ] || [ -z "$r_target" ] || [ -z "$r_profile" ] || [ -z "$r_test" ]; then
+    echo "run-owner-effect-tests: incomplete row for task $r_task" >&2
+    exit 1
+  fi
+  case " $VALID_PROFILES " in
+    *" $r_profile "*) ;;
+    *) echo "run-owner-effect-tests: unknown profile '$r_profile' (row: $r_test)" >&2; exit 1 ;;
+  esac
+  case " $profiles_seen " in
+    *" $r_profile "*) ;;
+    *) profiles_seen="$profiles_seen $r_profile" ;;
+  esac
+  if [ "$mode" = "all" ] || [ "$r_task" = "$task" ]; then
+    rows="$rows$r_task|$r_package|$r_target|$r_profile|$r_test
+"
+  fi
+done < "$MANIFEST"
+
+# --- the declared feature set must match the manifest exactly --------------
+if [ -n "$required_profiles" ]; then
+  for p in $profiles_seen; do
+    case " $required_profiles " in
+      *" $p "*) ;;
+      *) echo "FAIL  manifest uses profile '$p', which --require-profile did not declare" >&2
+         exit 1 ;;
+    esac
+  done
+  for p in $required_profiles; do
+    case " $profiles_seen " in
+      *" $p "*) ;;
+      *) echo "FAIL  --require-profile named '$p', which the manifest does not use" >&2
+         exit 1 ;;
+    esac
+  done
+fi
+
+if [ -z "$rows" ]; then
+  echo "run-owner-effect-tests: no rows selected — a run that tests nothing is a failure" >&2
+  exit 1
+fi
+
+# --- list before executing, so the reader sees what was asked for ---------
+echo "run-owner-effect-tests: registered rows"
+printf '%s' "$rows" | while IFS='|' read -r t pkg tgt prof name; do
+  [ -n "$t" ] || continue
+  echo "  task $t  $pkg::$tgt  [$prof]  $name"
+done
+
+profile_flags() { # <profile> -> the literal flags a command must carry
+  if [ "$1" = "no-default-features" ]; then
+    echo "--no-default-features"
+  else
+    echo "--no-default-features --features $1"
+  fi
+}
+
+executed=0
+failures=0
+printf '%s' "$rows" > "${TMPDIR:-/tmp}/owner-effect-rows.$$"
+while IFS='|' read -r t pkg tgt prof name; do
+  [ -n "$t" ] || continue
+  flags=$(profile_flags "$prof")
+  echo
+  echo "== task $t: cargo test -p $pkg --test $tgt $flags -- --exact $name"
+  set +e
+  output=$(cargo test -p "$pkg" --test "$tgt" $flags -- --exact "$name" --nocapture 2>&1)
+  status=$?
+  set -e
+  printf '%s\n' "$output"
+
+  # Cargo could not run what was asked. Never a pass, whatever the status.
+  if printf '%s' "$output" | grep -Fq "does not have the feature" ||
+     printf '%s' "$output" | grep -Fq "no target named" ||
+     printf '%s' "$output" | grep -Fq "error: package ID specification" ||
+     printf '%s' "$output" | grep -Fq "did not match any targets"; then
+    echo "FAIL  Cargo rejected the profile or target for $name"
+    failures=$((failures + 1))
+    continue
+  fi
+  # A target skipped for a missing required-feature prints nothing and exits 0.
+  if printf '%s' "$output" | grep -Fq "skipping due to unsatisfied required-features"; then
+    echo "FAIL  $tgt was skipped for unsatisfied required-features"
+    failures=$((failures + 1))
+    continue
+  fi
+  # Zero executed, or filtered to nothing, both look exactly like success.
+  if printf '%s' "$output" | grep -Eq "^test result: ok\. 0 passed"; then
+    echo "FAIL  $name matched no test — the filter or the name is wrong"
+    failures=$((failures + 1))
+    continue
+  fi
+  if ! printf '%s' "$output" | grep -Eq "^test result:"; then
+    echo "FAIL  no test result line — nothing ran"
+    failures=$((failures + 1))
+    continue
+  fi
+
+  executed=$((executed + 1))
+  if [ "$status" -ne 0 ]; then
+    if [ -z "$red" ]; then
+      echo "FAIL  $name failed and no --red diagnostic was expected"
+      failures=$((failures + 1))
+    elif printf '%s' "$output" | grep -Fq -- "$red"; then
+      echo "RED   $name failed with the expected diagnostic"
+    else
+      echo "FAIL  $name failed, but not with the expected RED diagnostic: $red"
+      failures=$((failures + 1))
+    fi
+  elif [ -n "$red" ]; then
+    echo "FAIL  $name passed, but a RED diagnostic was expected: $red"
+    failures=$((failures + 1))
+  fi
+done < "${TMPDIR:-/tmp}/owner-effect-rows.$$"
+rm -f "${TMPDIR:-/tmp}/owner-effect-rows.$$"
+
+echo
+if [ "$executed" -eq 0 ]; then
+  echo "run-owner-effect-tests: executed nothing — that is a failure, not a pass" >&2
+  exit 1
+fi
+if [ "$failures" -ne 0 ]; then
+  echo "run-owner-effect-tests: FAILED ($failures of $executed rows)" >&2
+  exit 1
+fi
+
+completed=1
+echo "run-owner-effect-tests: OK — $executed row(s), profiles:$profiles_seen"

--- a/scripts/test_changed.sh
+++ b/scripts/test_changed.sh
@@ -144,6 +144,13 @@ fi
 if [ "${GATE_SELFTEST_RUNNING:-0}" != "1" ]; then
   run_step "gate-self-test" env GATE_SELFTEST_RUNNING=1 \
     ./scripts/tests/gate_portability_test.sh
+  # The owner-effect runners exist to stop a vacuous cargo success from being
+  # read as a pass. A checked runner nobody checks is worth nothing, so their
+  # self-tests run here, on every session, not only when someone remembers.
+  run_step "owner-effect-runner-selftests" env GATE_SELFTEST_RUNNING=1 \
+    ./scripts/tests/run-owner-effect-tests.sh
+  run_step "owner-effect-regression-selftest" env GATE_SELFTEST_RUNNING=1 \
+    ./scripts/tests/run-owner-effect-regression.sh
 fi
 run_step "file-size" ./scripts/check-file-size.sh
 run_step "fmt" cargo fmt --all --check

--- a/scripts/tests/run-owner-effect-regression.sh
+++ b/scripts/tests/run-owner-effect-regression.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Self-test for scripts/run-owner-effect-regression.sh.
+#
+# The wrapper has two jobs that pull in opposite directions: refuse transcripts
+# that only look like success, and get out of the way of a genuine failure by
+# preserving its exit status. A self-test that checked "did it exit nonzero"
+# would conflate them, so each case here asserts *which* outcome happened —
+# the wrapper's own refusal, a preserved underlying status, or a clean pass.
+#
+# Transcripts are fed through a stub `cargo` on PATH, so the real script runs.
+#
+# Portability: bash 3.2 (stock macOS).
+set -euo pipefail
+
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 3 ] ||
+  { [ "${BASH_VERSINFO[0]}" -eq 3 ] && [ "${BASH_VERSINFO[1]}" -lt 2 ]; }; then
+  echo "unsupported bash: need 3.2 or newer, got ${BASH_VERSION:-non-bash shell}" >&2
+  exit 3
+fi
+
+WRAPPER="$(cd "$(dirname "$0")/.." && pwd)/run-owner-effect-regression.sh"
+[ -x "$WRAPPER" ] || { echo "missing $WRAPPER" >&2; exit 1; }
+
+completed=0
+WORK=$(mktemp -d)
+on_exit() {
+  status=$?
+  rm -rf "$WORK"
+  if [ "$completed" -eq 0 ] && [ "$status" -eq 0 ]; then
+    echo "run-owner-effect-regression self-test: INCOMPLETE — exited before finishing" >&2
+    exit 1
+  fi
+}
+trap on_exit EXIT
+
+checked=0
+failed=0
+
+# <name> <transcript> <cargo exit> <expected wrapper exit> [command args...]
+scenario() {
+  name="$1"; transcript="$2"; code="$3"; want="$4"; shift 4
+  checked=$((checked + 1))
+
+  bin="$WORK/$checked/bin"
+  mkdir -p "$bin"
+  {
+    echo '#!/usr/bin/env bash'
+    echo "cat <<'TRANSCRIPT'"
+    printf '%s\n' "$transcript"
+    echo 'TRANSCRIPT'
+    echo "exit $code"
+  } > "$bin/cargo"
+  chmod +x "$bin/cargo"
+
+  set +e
+  PATH="$bin:$PATH" "$WRAPPER" -- "$@" > "$WORK/$checked/out" 2>&1
+  got=$?
+  set -e
+
+  if [ "$got" -ne "$want" ]; then
+    echo "FAIL  $name: expected exit $want, got $got"
+    sed 's/^/        /' "$WORK/$checked/out"
+    failed=1
+  else
+    echo "ok    $name (exit $got)"
+  fi
+}
+
+PASSING='running 3 tests
+test a ... ok
+test b ... ok
+test c ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s'
+
+# A real run that passed.
+scenario "a real passing run exits 0" "$PASSING" 0 0 \
+  cargo test -p sovereign-stub --no-default-features
+
+# A real failure must reach the caller unchanged, not be replaced by the
+# wrapper's own status. This is the case the wrapper must not swallow.
+scenario "a genuine failure preserves the underlying exit status" \
+'running 2 tests
+test a ... ok
+test b ... FAILED
+
+test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out' \
+  101 101 cargo test -p sovereign-stub --no-default-features
+
+# Zero executed: cargo exits 0 and says "ok".
+scenario "zero executed tests is the wrapper's own failure" \
+'running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 9 filtered out; finished in 0.00s' \
+  0 1 cargo test -p sovereign-stub --no-default-features
+
+# Several binaries, none of which ran anything.
+scenario "zero across every binary is refused" \
+'test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 7 filtered out; finished in 0.00s' \
+  0 1 cargo test --workspace --no-default-features
+
+# A target skipped for a missing required-feature prints no result at all.
+scenario "a skipped required-features target is refused" \
+'   Compiling sovereign-stub v0.1.0
+warning: skipping due to unsatisfied required-features: `owner-effect-fixture`' \
+  0 1 cargo test -p sovereign-stub --no-default-features
+
+# Cargo could not honour the requested feature set.
+scenario "an unknown feature is refused" \
+'error: none of the selected packages contains these features: owner-effect-fixture' \
+  101 1 cargo test -p sovereign-stub --no-default-features --features owner-effect-fixture
+
+# The command did not declare its feature set: refused before running.
+scenario "a command without --no-default-features is refused before it runs" \
+  "$PASSING" 0 2 cargo test -p sovereign-stub
+
+# Only `cargo test` may be wrapped.
+scenario "a non-cargo-test command is refused" "$PASSING" 0 2 \
+  cargo build --no-default-features
+scenario "a non-cargo command is refused" "$PASSING" 0 2 \
+  make --no-default-features
+
+echo
+if [ "$checked" -lt 8 ]; then
+  echo "run-owner-effect-regression self-test: only $checked scenarios ran" >&2
+  exit 1
+fi
+if [ "$failed" -ne 0 ]; then
+  echo "run-owner-effect-regression self-test: FAILED" >&2
+  exit 1
+fi
+
+completed=1
+echo "run-owner-effect-regression self-test: OK — $checked scenarios"

--- a/scripts/tests/run-owner-effect-tests.sh
+++ b/scripts/tests/run-owner-effect-tests.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Self-test for scripts/run-owner-effect-tests.sh.
+#
+# A checked runner is only worth something if it actually rejects the shapes it
+# claims to reject, and every one of those shapes is a transcript that reads as
+# success: zero tests executed, a target skipped for a missing feature, a
+# filter that matched nothing, a failure with the wrong diagnostic. So each
+# case here feeds the real runner a real transcript through a stub `cargo` on
+# PATH — the runner's own code path, not a copy of its logic — and only the one
+# case that genuinely passed may exit 0.
+#
+# Portability: bash 3.2 (stock macOS).
+set -euo pipefail
+
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 3 ] ||
+  { [ "${BASH_VERSINFO[0]}" -eq 3 ] && [ "${BASH_VERSINFO[1]}" -lt 2 ]; }; then
+  echo "unsupported bash: need 3.2 or newer, got ${BASH_VERSION:-non-bash shell}" >&2
+  exit 3
+fi
+
+RUNNER="$(cd "$(dirname "$0")/.." && pwd)/run-owner-effect-tests.sh"
+[ -x "$RUNNER" ] || { echo "missing $RUNNER" >&2; exit 1; }
+
+completed=0
+on_exit() {
+  status=$?
+  if [ "$completed" -eq 0 ] && [ "$status" -eq 0 ]; then
+    echo "run-owner-effect-tests self-test: INCOMPLETE — exited before finishing" >&2
+    exit 1
+  fi
+}
+trap on_exit EXIT
+
+WORK=$(mktemp -d)
+cleanup() { rm -rf "$WORK"; }
+trap 'cleanup; on_exit' EXIT
+
+checked=0
+failed=0
+
+# Build a stub cargo that prints $2 and exits $3, then run the runner against a
+# one-row manifest with the given profile.
+scenario() { # <name> <transcript> <exit> <expect: pass|fail> [extra runner args...]
+  name="$1"; transcript="$2"; code="$3"; expect="$4"; shift 4
+  checked=$((checked + 1))
+
+  bin="$WORK/$checked/bin"
+  mkdir -p "$bin"
+  {
+    echo '#!/usr/bin/env bash'
+    echo "cat <<'TRANSCRIPT'"
+    printf '%s\n' "$transcript"
+    echo 'TRANSCRIPT'
+    echo "exit $code"
+  } > "$bin/cargo"
+  chmod +x "$bin/cargo"
+
+  manifest="$WORK/$checked/manifest.tsv"
+  printf 'task\tpackage\ttarget\tprofile\ttest_name\n' > "$manifest"
+  printf '9\tsovereign-stub\tstub_target\tno-default-features\ta_stub_test\n' >> "$manifest"
+
+  set +e
+  PATH="$bin:$PATH" OWNER_EFFECT_MANIFEST="$manifest" \
+    "$RUNNER" --all "$@" > "$WORK/$checked/out" 2>&1
+  status=$?
+  set -e
+
+  if [ "$expect" = "pass" ] && [ "$status" -ne 0 ]; then
+    echo "FAIL  $name: expected the runner to accept this, it exited $status"
+    sed 's/^/        /' "$WORK/$checked/out"
+    failed=1
+  elif [ "$expect" = "fail" ] && [ "$status" -eq 0 ]; then
+    echo "FAIL  $name: the runner accepted a transcript it must reject"
+    sed 's/^/        /' "$WORK/$checked/out"
+    failed=1
+  else
+    echo "ok    $name"
+  fi
+}
+
+# The one transcript that genuinely ran the test and passed.
+scenario "a real passing run is accepted" \
+'running 1 test
+test a_stub_test ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s' \
+  0 pass
+
+# Zero executed. Cargo exits 0 and prints "ok" — the failure this whole runner
+# exists for.
+scenario "zero executed tests is refused" \
+'running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 12 filtered out; finished in 0.00s' \
+  0 fail
+
+# A filter that matched nothing looks identical to a clean run.
+scenario "a filtered-to-nothing run is refused" \
+'running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s' \
+  0 fail
+
+# A target skipped for a missing required-feature: exit 0, no tests, no result.
+scenario "a target skipped for required-features is refused" \
+'   Compiling sovereign-stub v0.1.0
+warning: skipping due to unsatisfied required-features: `owner-effect-fixture`' \
+  0 fail
+
+# Cargo could not honour the profile at all.
+scenario "an unknown feature is refused" \
+'error: none of the selected packages contains these features: owner-effect-fixture
+the package sovereign-stub does not have the feature owner-effect-fixture' \
+  101 fail
+
+# Cargo could not find the target named in the manifest.
+scenario "an unknown target is refused" \
+'error: no target named `stub_target` in default-run packages' \
+  101 fail
+
+# No result line at all: the command produced nothing to judge.
+scenario "output with no test result line is refused" \
+'   Compiling sovereign-stub v0.1.0
+    Finished test profile in 0.4s' \
+  0 fail
+
+# A genuine failure carrying the diagnostic the task expects: a valid RED.
+scenario "a RED with the expected diagnostic is accepted" \
+'running 1 test
+test a_stub_test ... FAILED
+
+failures:
+---- a_stub_test stdout ----
+assertion failed: the owner was not authenticated
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out' \
+  101 pass --red "the owner was not authenticated"
+
+# A failure for some other reason must not be read as the expected RED.
+scenario "a failure with the wrong diagnostic is refused" \
+'running 1 test
+test a_stub_test ... FAILED
+
+failures:
+---- a_stub_test stdout ----
+assertion failed: something entirely unrelated broke
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out' \
+  101 fail --red "the owner was not authenticated"
+
+# A test that passes while a RED was expected is not a RED.
+scenario "a pass where a RED was expected is refused" \
+'running 1 test
+test a_stub_test ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out' \
+  0 fail --red "the owner was not authenticated"
+
+# The final command must declare the manifest's complete feature set.
+scenario "an incomplete --require-profile set is refused" \
+'running 1 test
+test a_stub_test ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out' \
+  0 fail --require-profile fault-injection
+
+scenario "a matching --require-profile set is accepted" \
+'running 1 test
+test a_stub_test ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out' \
+  0 pass --require-profile no-default-features
+
+echo
+if [ "$checked" -lt 10 ]; then
+  echo "run-owner-effect-tests self-test: only $checked scenarios ran; the suite is not intact" >&2
+  exit 1
+fi
+if [ "$failed" -ne 0 ]; then
+  echo "run-owner-effect-tests self-test: FAILED" >&2
+  exit 1
+fi
+
+completed=1
+echo "run-owner-effect-tests self-test: OK — $checked scenarios"


### PR DESCRIPTION
The owner-session plan requires that no RED, GREEN, checkpoint, or final block can report a vacuous success. Every later task in that plan runs Cargo commands whose failure modes all look like passes, so the runners come **before** the fixture code they will check.

**`run-owner-effect-tests.sh`** executes the rows in `scripts/owner-effect-tests.tsv` and infers nothing — a row's `profile` column is the literal flag set the command must carry. It refuses every transcript that reads as success while proving nothing: zero executed tests, a filter that matched nothing, a target skipped for unsatisfied required-features, a Cargo feature/target diagnostic, output with no result line at all.

On a nonzero run it requires the task's expected RED diagnostic, so a test failing for an unrelated reason cannot be mistaken for the failure the task is driving at — and a test that *passes* when a RED was expected is equally a failure. Repeated `--require-profile` makes a run fail unless the manifest's profile set is exactly what the command declared, so the final command states its complete feature set rather than inheriting one.

**`run-owner-effect-regression.sh`** wraps the supplemental commands beside the manifest. It has two jobs that pull against each other: refuse the vacuous transcripts, and stay out of the way of a genuine failure by preserving its exit status. The self-test asserts *which* of the two happened in every case, rather than only that the exit was nonzero — which would conflate them.

Both self-tests feed real transcripts through a stub `cargo` on PATH, so they exercise the scripts rather than a copy of their logic. Twelve scenarios and nine. Both now run in `test_changed.sh`'s always-on block: a checked runner nobody checks is worth nothing.

The manifest is seeded with the two Task 2 approval-retention rows — the only owner-effect tests that exist yet — and verified against them for real. Rows are added by the task that makes them pass; a row for a test that does not exist fails the runner, which is the point.

bash 3.2 throughout, with the EXIT-trap completion marker and the zero-inputs-fails rule the other gates use.