### PR TITLE
feat(authority): open the store only with the lock in hand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,6 +1193,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redb"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1429,6 +1438,7 @@ version = "0.1.0"
 dependencies = [
  "hex",
  "hmac",
+ "redb",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/authority/Cargo.toml
+++ b/crates/authority/Cargo.toml
@@ -17,7 +17,7 @@ default = []
 fault-injection = []
 # RFC 0006's synthetic broker. Non-default for the same reason: a default
 # build must contain no broker mode and no entry point.
-owner-effect-fixture = ["dep:hmac"]
+owner-effect-fixture = ["dep:hmac", "dep:redb"]
 
 [dependencies]
 hex = { workspace = true }
@@ -26,6 +26,9 @@ hex = { workspace = true }
 # resolved graph is exactly the reviewed one. Default features off — hmac's
 # default pulls std conveniences this does not use.
 hmac = { version = "=0.12.1", default-features = false, optional = true }
+# Exact-pinned and optional, like hmac. Redb is ACID: it gives the fixture a
+# transactional store, and nothing about authenticity or encryption.
+redb = { version = "=4.1.0", optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
@@ -56,4 +59,8 @@ required-features = ["owner-effect-fixture"]
 
 [[test]]
 name = "broker_process_lock"
+required-features = ["owner-effect-fixture"]
+
+[[test]]
+name = "broker_store"
 required-features = ["owner-effect-fixture"]

--- a/crates/authority/src/broker/mod.rs
+++ b/crates/authority/src/broker/mod.rs
@@ -16,6 +16,7 @@ pub mod bootstrap;
 pub mod listener;
 pub mod process_lock;
 pub mod protocol;
+pub mod store;
 pub mod supervisor;
 
 /// The hidden subcommand the fixture re-execs itself as. Named here so the
@@ -83,6 +84,21 @@ pub fn run_owner_effect_fixture_broker(
         }
         Err(process_lock::LockError::Unavailable) => {
             return Err(emit(diagnostics, protocol::Diagnostic::LockUnavailable))
+        }
+    };
+    // Only with the lock in hand. `OwnedStore::open` takes a `&HeldLock` and
+    // has no other constructor, so this ordering cannot be skipped by a later
+    // caller who did not read the comment.
+    let _store = match store::OwnedStore::open(root.path(), &_lock) {
+        Ok(store) => store,
+        Err(store::StoreError::AlreadyOpen) => {
+            return Err(emit(
+                diagnostics,
+                protocol::Diagnostic::BrokerAlreadyRunning,
+            ))
+        }
+        Err(store::StoreError::Unavailable) => {
+            return Err(emit(diagnostics, protocol::Diagnostic::StoreUnavailable))
         }
     };
     Err(BrokerExit::NotImplemented)

--- a/crates/authority/src/broker/protocol.rs
+++ b/crates/authority/src/broker/protocol.rs
@@ -45,6 +45,8 @@ pub enum Diagnostic {
     BrokerAlreadyRunning,
     /// Exclusivity could not be established, which is not permission.
     LockUnavailable,
+    /// The store could not be opened; ownership is unknown, not granted.
+    StoreUnavailable,
 }
 
 impl Diagnostic {
@@ -63,6 +65,7 @@ impl Diagnostic {
             Diagnostic::SupervisorUnauthenticated => "E-SUPERVISOR-UNAUTHENTICATED",
             Diagnostic::BrokerAlreadyRunning => "E-BROKER-ALREADY-RUNNING",
             Diagnostic::LockUnavailable => "E-LOCK-UNAVAILABLE",
+            Diagnostic::StoreUnavailable => "E-STORE-UNAVAILABLE",
         }
     }
 }

--- a/crates/authority/src/broker/store.rs
+++ b/crates/authority/src/broker/store.rs
@@ -1,0 +1,93 @@
+//! Opening the store, and the ordering that makes the broker its sole writer.
+//!
+//! Redb enforces one writer per database within a process and refuses a second
+//! open of the same file. That is a real guarantee and it is not the one this
+//! module is about: it says nothing about a *second process* that opens the
+//! file after the first has exited, or about a caller that never went through
+//! the broker at all. The process lock covers those, and this type exists to
+//! make the ordering unforgeable rather than merely documented.
+//!
+//! `open` takes a `&HeldLock`. There is no other constructor. So a store
+//! cannot be opened by code that has not already proved exclusivity, and the
+//! borrow keeps the lock alive for as long as the store is — the two cannot
+//! come apart, which is exactly the failure a comment would not prevent.
+
+use super::process_lock::HeldLock;
+// `begin_read` lives on a trait in redb 4, not on the type.
+use redb::{Database, ReadableDatabase};
+use std::path::Path;
+
+/// Fixed name beside the lock. Two brokers that disagreed about which file is
+/// the store would each own a different one and both believe they were alone.
+pub const STORE_FILE: &str = "authority.redb";
+
+#[derive(Debug)]
+pub enum StoreError {
+    /// Another handle already has this database open.
+    AlreadyOpen,
+    /// The file could not be opened or created, or is not a redb database.
+    Unavailable,
+}
+
+/// A database this process alone may write, for as long as the lock is held.
+pub struct OwnedStore<'lock> {
+    database: Database,
+    // Not read, and not removable: it is what ties the store's lifetime to the
+    // lock's. Dropping the lock first would make "sole writer" a claim about
+    // the past.
+    _lock: &'lock HeldLock,
+}
+
+impl std::fmt::Debug for OwnedStore<'_> {
+    /// Value-free. A database handle's own `Debug` prints its path, and a path
+    /// is a detail of the owner's machine that nothing here needs to log.
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("OwnedStore(<redacted>)")
+    }
+}
+
+impl<'lock> OwnedStore<'lock> {
+    /// Open the store. Reachable only with a held lock, by construction.
+    pub fn open(root: &Path, lock: &'lock HeldLock) -> Result<Self, StoreError> {
+        let path = root.join(STORE_FILE);
+        let database = match Database::create(&path) {
+            Ok(database) => database,
+            Err(redb::DatabaseError::DatabaseAlreadyOpen) => return Err(StoreError::AlreadyOpen),
+            // Every other error leaves ownership unknown, which is not
+            // ownership. No fallback to read-only and no fresh store: either
+            // would turn a corrupt or unexpected file into a silent new one.
+            Err(_) => return Err(StoreError::Unavailable),
+        };
+        Ok(Self {
+            database,
+            _lock: lock,
+        })
+    }
+
+    /// The one write helper. Redb's write transactions are already two-phase
+    /// and durable on commit; funnelling every write through here means there
+    /// is a single place to reason about, rather than one per call site.
+    pub fn write<T>(
+        &self,
+        body: impl FnOnce(&redb::WriteTransaction) -> Result<T, StoreError>,
+    ) -> Result<T, StoreError> {
+        let transaction = self
+            .database
+            .begin_write()
+            .map_err(|_| StoreError::Unavailable)?;
+        let value = body(&transaction)?;
+        transaction.commit().map_err(|_| StoreError::Unavailable)?;
+        Ok(value)
+    }
+
+    pub fn read<T>(
+        &self,
+        body: impl FnOnce(&redb::ReadTransaction) -> Result<T, StoreError>,
+    ) -> Result<T, StoreError> {
+        let transaction = self
+            .database
+            .begin_read()
+            .map_err(|_| StoreError::Unavailable)?;
+        body(&transaction)
+    }
+}

--- a/crates/authority/tests/broker_store.rs
+++ b/crates/authority/tests/broker_store.rs
@@ -1,0 +1,140 @@
+//! Opening the store, and the ordering that makes the broker its sole writer.
+//!
+//! Redb refuses a second open of the same file within a process, which is a
+//! real guarantee and not the one at issue here. What these tests are about is
+//! that the store cannot be reached without the process lock — so a second
+//! *process*, or a caller that never went through the broker, is stopped by
+//! the lock rather than by luck — and that failures leave ownership unknown
+//! instead of silently creating a fresh database.
+
+#![cfg(feature = "owner-effect-fixture")]
+
+use sovereign_authority::broker::process_lock::acquire;
+use sovereign_authority::broker::store::{OwnedStore, StoreError, STORE_FILE};
+
+#[test]
+fn a_locked_root_yields_a_store() {
+    let dir = tempfile::tempdir().unwrap();
+    let lock = acquire(dir.path()).unwrap();
+    let store = OwnedStore::open(dir.path(), &lock).expect("a locked root must open");
+    assert!(
+        dir.path().join(STORE_FILE).is_file(),
+        "the store must be a real file beside the lock"
+    );
+    // Value-free rendering: a database's own Debug prints its path.
+    assert_eq!(format!("{store:?}"), "OwnedStore(<redacted>)");
+}
+
+/// The ordering is enforced by the type, not by a comment. `open` takes a
+/// `&HeldLock` and there is no other constructor, so this test is really a
+/// statement about what the API permits: without a lock there is nothing to
+/// pass, and the code below would not compile.
+#[test]
+fn the_store_cannot_be_opened_without_a_held_lock() {
+    let dir = tempfile::tempdir().unwrap();
+    // Deliberately not compiled, and deliberately written out so a reader can
+    // see what is being claimed:
+    //
+    //     OwnedStore::open(dir.path(), /* no lock exists to pass */);
+    //
+    // What is testable at runtime is the consequence: nothing created the
+    // store, because nothing could.
+    assert!(!dir.path().join(STORE_FILE).exists());
+}
+
+/// Two opens in one process: redb's own guarantee, asserted so a later change
+/// that swapped the backend cannot quietly lose it.
+#[test]
+fn a_second_open_in_one_process_is_refused() {
+    let dir = tempfile::tempdir().unwrap();
+    let lock = acquire(dir.path()).unwrap();
+    let _first = OwnedStore::open(dir.path(), &lock).unwrap();
+    assert!(
+        matches!(
+            OwnedStore::open(dir.path(), &lock),
+            Err(StoreError::AlreadyOpen)
+        ),
+        "redb must refuse a second open of the same database"
+    );
+}
+
+/// A file that is not a redb database must not be replaced by a fresh one.
+/// Creating a new store over unrecognised bytes is how a corrupt or
+/// unexpected file becomes an empty, apparently healthy one.
+#[test]
+fn an_unrecognised_file_is_unavailable_not_recreated() {
+    let dir = tempfile::tempdir().unwrap();
+    let lock = acquire(dir.path()).unwrap();
+    let path = dir.path().join(STORE_FILE);
+    std::fs::write(&path, b"this is not a database").unwrap();
+
+    assert!(
+        matches!(
+            OwnedStore::open(dir.path(), &lock),
+            Err(StoreError::Unavailable)
+        ),
+        "an unrecognised file must fail closed"
+    );
+    assert_eq!(
+        std::fs::read(&path).unwrap(),
+        b"this is not a database",
+        "the original file must be left exactly as it was"
+    );
+}
+
+/// An unusable root fails closed rather than being reported as a second
+/// broker — the same distinction the lock makes, kept at this layer too.
+#[test]
+fn an_unavailable_root_fails_closed() {
+    let dir = tempfile::tempdir().unwrap();
+    let store_dir = dir.path().join("store");
+    std::fs::create_dir(&store_dir).unwrap();
+    let lock = acquire(&store_dir).unwrap();
+    let blocked = sovereign_fault_testing::BlockedPath::block(&store_dir).unwrap();
+
+    match OwnedStore::open(blocked.path(), &lock) {
+        Err(StoreError::Unavailable) => {}
+        Err(StoreError::AlreadyOpen) => panic!("an unusable root was reported as already open"),
+        Ok(_) => panic!("an unusable root opened a store"),
+    }
+}
+
+/// Writes commit, and survive being reopened by a later broker. This is the
+/// only reason any of the ordering above matters.
+#[test]
+fn a_committed_write_survives_reopening() {
+    const TABLE: redb::TableDefinition<&str, &str> = redb::TableDefinition::new("fixture");
+    let dir = tempfile::tempdir().unwrap();
+
+    {
+        let lock = acquire(dir.path()).unwrap();
+        let store = OwnedStore::open(dir.path(), &lock).unwrap();
+        store
+            .write(|transaction| {
+                let mut table = transaction
+                    .open_table(TABLE)
+                    .map_err(|_| StoreError::Unavailable)?;
+                table
+                    .insert("key", "value")
+                    .map_err(|_| StoreError::Unavailable)?;
+                Ok(())
+            })
+            .expect("the write must commit");
+    }
+
+    let lock = acquire(dir.path()).unwrap();
+    let store = OwnedStore::open(dir.path(), &lock).unwrap();
+    let value = store
+        .read(|transaction| {
+            let table = transaction
+                .open_table(TABLE)
+                .map_err(|_| StoreError::Unavailable)?;
+            let found = table
+                .get("key")
+                .map_err(|_| StoreError::Unavailable)?
+                .map(|entry| entry.value().to_owned());
+            Ok(found)
+        })
+        .unwrap();
+    assert_eq!(value.as_deref(), Some("value"));
+}

--- a/scripts/check-owner-effect-crypto-profile.sh
+++ b/scripts/check-owner-effect-crypto-profile.sh
@@ -65,6 +65,13 @@ else
   echo "FAIL  hmac must be taken with default-features = false"
   fail=1
 fi
+checked=$((checked + 1))
+if grep -Fq 'redb = { version = "=4.1.0"' crates/authority/Cargo.toml; then
+  echo "ok    redb is pinned with ="
+else
+  echo "FAIL  crates/authority/Cargo.toml must pin redb as =4.1.0"
+  fail=1
+fi
 
 # --- 2. the lock holds those versions --------------------------------------
 echo "== lock file"
@@ -121,12 +128,15 @@ default_tree=$(cargo tree -p sovereign-authority -e normal --locked 2>&1) || {
   echo "check-owner-effect-crypto-profile: cargo tree (default) failed" >&2
   exit 2
 }
-if printf '%s' "$default_tree" | grep -qE '^[^a-zA-Z]*hmac v'; then
-  echo "FAIL  hmac is in the default dependency graph; it must be fixture-only"
-  fail=1
-else
-  echo "ok    hmac is absent from a default build"
-fi
+for crate in hmac redb; do
+  checked=$((checked + 1))
+  if printf '%s' "$default_tree" | grep -qE "^[^a-zA-Z]*$crate v"; then
+    echo "FAIL  $crate is in the default dependency graph; it must be fixture-only"
+    fail=1
+  else
+    echo "ok    $crate is absent from a default build"
+  fi
+done
 
 echo
 if [ "$checked" -lt 8 ]; then

--- a/scripts/owner-effect-tests.tsv
+++ b/scripts/owner-effect-tests.tsv
@@ -55,3 +55,9 @@ task	package	target	profile	test_name
 4	sovereign-authority	broker_process_lock	owner-effect-fixture	dropping_the_lock_releases_it
 4	sovereign-authority	broker_process_lock	owner-effect-fixture	an_unusable_root_is_unavailable_not_already_running
 4	sovereign-authority	broker_process_lock	owner-effect-fixture	the_lock_is_held_across_processes_and_survives_being_killed
+4	sovereign-authority	broker_store	owner-effect-fixture	a_locked_root_yields_a_store
+4	sovereign-authority	broker_store	owner-effect-fixture	the_store_cannot_be_opened_without_a_held_lock
+4	sovereign-authority	broker_store	owner-effect-fixture	a_second_open_in_one_process_is_refused
+4	sovereign-authority	broker_store	owner-effect-fixture	an_unrecognised_file_is_unavailable_not_recreated
+4	sovereign-authority	broker_store	owner-effect-fixture	an_unavailable_root_fails_closed
+4	sovereign-authority	broker_store	owner-effect-fixture	a_committed_write_survives_reopening


### PR DESCRIPTION
The sixth slice of RFC 0006's broker, and the one that completes the chain: a bootstrap frame, a classified root, a bound port, an authenticated supervisor, an exclusive lock, and **only now** a database.

## Why redb's own guarantee was not enough

Redb refuses a second open of the same file within a process. Real, and not the guarantee needed here: it says nothing about a second *process* opening the file after the first exits, or about a caller that never went through the broker at all. The lock covers those, so what mattered was making the **ordering unforgeable rather than documented**.

`OwnedStore::open` takes a `&HeldLock` and there is no other constructor. Code that has not proved exclusivity has nothing to pass, and the borrow keeps the lock alive for exactly as long as the store — a store outliving its lock would make "sole writer" a claim about the past, and a comment would not have prevented it.

## Failures leave ownership unknown, not resolved

A file that is not a redb database fails closed and is left **byte-for-byte as it was**. Creating a fresh store over unrecognised bytes is how a corrupt or unexpected file becomes an empty, apparently healthy one. No read-only fallback, no retry.

Redb is ACID. It is not authenticity and not encryption, and the module says so where someone might otherwise assume it.

## Pins

`redb` is pinned exactly at the version RFC 0006 froze and is optional, like `hmac`. The crypto-profile gate now checks both pins and asserts both are absent from a default build. I had first pinned a version I picked rather than the one the plan froze — the plan's own text caught it.