### PR TITLE
ci(owner-effect): build every feature profile, and record the webauthn decision

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -789,6 +789,21 @@ while the controller routes eligible design/review cards to the strong role.
 
 - [x] **P2 | `scripts/`, `docs/` | Owner-session Task 1 remainder: origin preflight harness and mechanism-matrix doc.**
 
+
+- [ ] **P2 | `crates/owner/` | Owner-session Task 5 remainder: the WebAuthn adapter, pending a dependency decision.** `needs:fable`
+  The fixture ceremony's *logic* landed 2026-09-10 (#68-#70): the frozen
+  configuration, the session lifetime, and the one-credential registry with
+  its 300-second one-use ceremonies. Those take `user_verified`, the
+  credential id and the returned handle as inputs, so every property is
+  already tested without a WebAuthn implementation.
+  What is missing is the adapter that turns a real browser response into
+  those inputs, which the plan pins as `webauthn-rs = "=0.5.5"`. Measured
+  before adding it: that pin resolves **116 packages**. They would be optional
+  and absent from a default build, but they still enter the audited lock file
+  and every one of them is dependency-review surface. That is a judgement
+  about audit burden rather than a coding step, so it is left for the owner
+  rather than taken silently. Decide, then implement `ceremony.rs` and the
+  `cfg(test)` virtual-authenticator adapter against it.
 - [ ] **P2 | `crates/authority/`, `apps/cli/` | Owner-session Task 4 remainder: migration gate and broker-build check.**
   The broker's core chain landed 2026-09-10 across six slices (#59-#66):
   bootstrap frame, root classification, loopback bind under one fixed

--- a/scripts/check-owner-effect-profile-builds.sh
+++ b/scripts/check-owner-effect-profile-builds.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Every feature profile the owner-effect work uses must actually build.
+#
+# Cargo features are additive and unify across a build, which makes two
+# opposite mistakes easy and both invisible day to day:
+#
+#   - a fixture module quietly becomes *required*, because something outside
+#     the gate started referring to it. The default build still works on a
+#     developer's machine, where the fixture feature has been on all day, and
+#     breaks for everyone else;
+#   - two features that are fine alone stop compiling together, because each
+#     assumed it was the only one enabled. Nothing exercises the combination
+#     until the first person needs both.
+#
+# The manifest names five profiles. This builds each one and fails on the
+# first that does not, so "it compiles" is a checked claim about every
+# combination rather than about whichever one was last used.
+#
+# It builds tests as well as libraries: a `required-features` target that no
+# longer compiles is exactly as broken as a library that does not, and is
+# easier to miss because nothing runs it.
+#
+# Portability: bash 3.2 (stock macOS).
+set -euo pipefail
+
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 3 ] ||
+  { [ "${BASH_VERSINFO[0]}" -eq 3 ] && [ "${BASH_VERSINFO[1]}" -lt 2 ]; }; then
+  echo "unsupported bash: need 3.2 or newer, got ${BASH_VERSION:-non-bash shell}" >&2
+  exit 3
+fi
+
+completed=0
+on_exit() {
+  status=$?
+  if [ "$completed" -eq 0 ] && [ "$status" -eq 0 ]; then
+    echo "check-owner-effect-profile-builds: INCOMPLETE — exited before finishing" >&2
+    exit 1
+  fi
+}
+trap on_exit EXIT
+
+PACKAGES="-p sovereign-authority -p sovereign-owner -p sovereign-cli"
+
+# The profiles the manifest's `profile` column may name, plus the default
+# build and the two-feature combination nothing else exercises.
+#
+# Each line: <label>|<extra cargo flags>
+PROFILES="default|
+no-default-features|--no-default-features
+fault-injection|--no-default-features --features fault-injection
+owner-effect-fixture|--no-default-features --features owner-effect-fixture
+owner-effect-fixture,fault-injection|--no-default-features --features owner-effect-fixture,fault-injection"
+
+fail=0
+checked=0
+
+while IFS='|' read -r label flags; do
+  [ -n "$label" ] || continue
+  checked=$((checked + 1))
+  printf '%-38s ' "$label"
+  # `fault-injection` exists on authority only, so a profile naming it is
+  # built for the package that has it rather than the whole set.
+  case "$label" in
+    *fault-injection*) packages="-p sovereign-authority" ;;
+    *) packages="$PACKAGES" ;;
+  esac
+  # shellcheck disable=SC2086 — the flags are a deliberate word list.
+  if cargo build $packages --all-targets $flags --locked >/dev/null 2>&1; then
+    echo "ok"
+  else
+    echo "FAILED"
+    echo "    cargo build $packages --all-targets $flags --locked" >&2
+    # Re-run visibly so the failure is in the log rather than only its name.
+    # shellcheck disable=SC2086
+    cargo build $packages --all-targets $flags --locked 2>&1 | tail -20 >&2
+    fail=1
+  fi
+done <<PROFILES_EOF
+$PROFILES
+PROFILES_EOF
+
+echo
+if [ "$checked" -lt 5 ]; then
+  echo "check-owner-effect-profile-builds: only $checked profiles built" >&2
+  exit 1
+fi
+if [ "$fail" -ne 0 ]; then
+  echo "check-owner-effect-profile-builds: FAILED" >&2
+  exit 1
+fi
+
+completed=1
+echo "check-owner-effect-profile-builds: OK — $checked profiles"

--- a/scripts/test_changed.sh
+++ b/scripts/test_changed.sh
@@ -161,6 +161,7 @@ if [ "${GATE_SELFTEST_RUNNING:-0}" != "1" ]; then
   run_step "clippy(owner-effect-fixture)" cargo clippy \
     -p sovereign-authority -p sovereign-owner -p sovereign-cli --all-targets \
     --features owner-effect-fixture --locked -- -D warnings
+  run_step "owner-effect-profile-builds" ./scripts/check-owner-effect-profile-builds.sh
 fi
 run_step "file-size" ./scripts/check-file-size.sh
 run_step "fmt" cargo fmt --all --check


### PR DESCRIPTION
Cargo features are additive and unify across a build, which makes two opposite mistakes easy and both invisible day to day.

A fixture module can quietly become **required**, because something outside the gate started referring to it — the default build still works on the machine where that feature has been on all day, and breaks for everyone else. And two features that are fine alone can stop compiling **together**, because each assumed it was the only one enabled; nothing exercises the combination until someone needs both.

The gate builds all five profiles the manifest can name, including the `owner-effect-fixture,fault-injection` combination that nothing had ever built. It builds `--all-targets`, because a `required-features` test that no longer compiles is exactly as broken as a library that does not — and easier to miss, since nothing runs it.

Verified by making fixture code refer to a `fault-injection` item: the fixture-only profile failed while the combination still passed, which is precisely the shape the gate exists to separate.

## Why Task 5's WebAuthn adapter is not here

The ceremony's **logic** landed in #68–#70 and is fully tested: the registry takes `user_verified`, the credential id and the returned handle as inputs, so a WebAuthn implementation is not needed to prove any of its properties.

What is missing is the adapter that produces those inputs from a browser response, which the plan pins as `webauthn-rs = "=0.5.5"`. **That pin resolves 116 packages.** They would be optional and absent from a default build — and they would still enter the audited lock file and become dependency-review surface.

That is a judgement about audit burden rather than a coding step, so it is the owner's to make rather than mine to take quietly at the point it became convenient. The backlog entry records the measurement and what to do once it is decided.