### PR TITLE
ci(owner-effect): stop the next secret-bearing type from deriving Debug

### DIFF
--- a/scripts/check-owner-effect-value-free.sh
+++ b/scripts/check-owner-effect-value-free.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# No fixture type may print its own secrets.
+#
+# Several types in this work carry key material: a launch key, a connection
+# key, a session cookie and its CSRF partner. Each has a hand-written `Debug`
+# that prints `<redacted>`, and each has a test proving it. That is the state
+# today and it is not what keeps it true — the next struct to hold a key will
+# be written by someone who reaches for `#[derive(Debug)]` because every other
+# struct in the file has one, and the first time anyone notices is when a key
+# appears in a log.
+#
+# So the rule is checked structurally: a struct in the fixture's own modules
+# that holds a secret-shaped field must not derive `Debug`. It must write one,
+# where the choice about what to print is deliberate and visible in review.
+#
+# This is a lint, not a proof. It cannot see a secret stored under a name it
+# does not recognise, and it is not trying to — it removes the failure that
+# happens by habit, which is the one that actually happens.
+#
+# Portability: bash 3.2 (stock macOS).
+set -euo pipefail
+
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 3 ] ||
+  { [ "${BASH_VERSINFO[0]}" -eq 3 ] && [ "${BASH_VERSINFO[1]}" -lt 2 ]; }; then
+  echo "unsupported bash: need 3.2 or newer, got ${BASH_VERSION:-non-bash shell}" >&2
+  exit 3
+fi
+
+SCANNED="crates/authority/src/broker
+crates/owner/src"
+
+# Field names that mean "this is secret". Deliberately short: a longer list
+# invites the belief that it is exhaustive.
+SECRET_FIELDS="key,cookie,csrf,launch_key,secret,token,password"
+
+completed=0
+on_exit() {
+  status=$?
+  if [ "$completed" -eq 0 ] && [ "$status" -eq 0 ]; then
+    echo "check-owner-effect-value-free: INCOMPLETE — exited before finishing" >&2
+    exit 1
+  fi
+}
+trap on_exit EXIT
+
+fail=0
+files=0
+
+for directory in $SCANNED; do
+  [ -d "$directory" ] || continue
+  while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    files=$((files + 1))
+    # Walk the file, tracking whether the struct being declared derives Debug
+    # and whether it holds a secret-shaped field.
+    awk -v secrets="$SECRET_FIELDS" -v path="$file" '
+      BEGIN {
+        n = split(secrets, list, ",")
+        for (i = 1; i <= n; i++) if (list[i] != "") secret[list[i]] = 1
+      }
+      /^#\[derive\(/ { derives = ($0 ~ /Debug/); next }
+      /^(pub )?struct / {
+        name = $0
+        sub(/^(pub )?struct /, "", name)
+        sub(/[ ({<].*$/, "", name)
+        current = name
+        current_derives = derives
+        derives = 0
+        next
+      }
+      # A field line inside the struct being tracked.
+      current != "" && /^ +(pub )?[a-z_]+:/ {
+        field = $0
+        sub(/^ +(pub )?/, "", field)
+        sub(/:.*$/, "", field)
+        if (current_derives && (field in secret)) {
+          printf "FAIL  %s: struct %s derives Debug and holds `%s`\n", path, current, field
+          bad = 1
+          current = ""
+        }
+        next
+      }
+      /^}/ { current = ""; derives = 0 }
+      END { exit bad ? 1 : 0 }
+    ' "$file" || fail=1
+  done <<FILES_EOF
+$(find "$directory" -name '*.rs' -type f)
+FILES_EOF
+done
+
+if [ "$files" -eq 0 ]; then
+  echo "check-owner-effect-value-free: scanned zero files" >&2
+  exit 1
+fi
+
+echo "ok    $files fixture source files scanned for derived Debug on secrets"
+if [ "$fail" -ne 0 ]; then
+  echo "check-owner-effect-value-free: FAILED" >&2
+  exit 1
+fi
+
+completed=1
+echo "check-owner-effect-value-free: OK"

--- a/scripts/test_changed.sh
+++ b/scripts/test_changed.sh
@@ -166,6 +166,10 @@ if [ "${GATE_SELFTEST_RUNNING:-0}" != "1" ]; then
   # file. Cheap to scan for, and the way it happens is someone pasting one in
   # while debugging and not taking it out.
   run_step "owner-effect-canaries" ./scripts/check-owner-effect-canaries.sh
+  # Each secret-bearing type has a hand-written Debug and a test for it. This
+  # is what keeps that true for the next one, which will otherwise reach for
+  # derive because every other struct in the file has it.
+  run_step "owner-effect-value-free" ./scripts/check-owner-effect-value-free.sh
 fi
 run_step "file-size" ./scripts/check-file-size.sh
 run_step "fmt" cargo fmt --all --check


### PR DESCRIPTION
Several types in this work carry key material: a launch key, a connection key, a session cookie and its CSRF partner. Each has a hand-written `Debug` that prints `<redacted>`, and each has a test proving it.

**That is the state today and it is not what keeps it true.** The next struct to hold a key will be written by someone who reaches for `#[derive(Debug)]` because every other struct in the file has one, and the first anyone hears of it is a key in a log.

So the rule is checked structurally rather than remembered: a struct in the fixture's own modules that holds a secret-shaped field must not derive `Debug`. It has to write one, where the choice about what to print is deliberate and visible in review.

## It is a lint, and says so

It cannot see a secret stored under a name it does not recognise, and the field list is deliberately short — a longer one invites the belief that it is exhaustive. It removes the failure that happens **by habit**, which is the one that actually happens.

## Verified twice

Adding `Debug` to the existing `SessionTokens`, and adding a new struct holding a `launch_key`. Both were named with their file, their struct, and the field that gave them away:

```
FAIL  crates/owner/src/session.rs: struct SessionTokens derives Debug and holds `cookie`
FAIL  crates/authority/src/broker/connections.rs: struct NewThing derives Debug and holds `launch_key`
```

The first version used a newline-separated list, which macOS's awk rejects. It **failed rather than passing** — which is what the EXIT-trap and the zero-files check exist for.