### PR TITLE
feat(audit-ledger): record that an effect happened, never what it was

### DIFF
--- a/crates/audit-ledger/Cargo.toml
+++ b/crates/audit-ledger/Cargo.toml
@@ -7,6 +7,12 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[features]
+# The fixture's separate evidence chain. Non-default: a shipped build has no
+# reason to carry a projection type that exists to describe synthetic effects.
+default = []
+owner-effect-fixture = []
+
 [dependencies]
 sovereign-contracts = { workspace = true }
 sovereign-identity = { workspace = true }
@@ -21,3 +27,7 @@ thiserror = { workspace = true }
 [dev-dependencies]
 sovereign-fault-testing = { path = "../fault-testing" }
 tempfile = "3"
+
+[[test]]
+name = "effect_v1"
+required-features = ["owner-effect-fixture"]

--- a/crates/audit-ledger/src/effect_v1.rs
+++ b/crates/audit-ledger/src/effect_v1.rs
@@ -1,0 +1,163 @@
+//! What the fixture's evidence chain is allowed to remember about an effect.
+//!
+//! An audit record exists to answer "did this happen, in what order, and was
+//! it tampered with". It does not exist to answer "what was it". Those look
+//! similar and are not, and the difference is the whole design here: the
+//! evidence is a *projection*, and everything not on a short allow-list is
+//! absent rather than redacted.
+//!
+//! Absent rather than redacted, because redaction leaks. A field replaced by
+//! its hash still answers questions: with a small dictionary of candidate
+//! recipients — and the set of people a founder emails is small — anyone
+//! holding the record can hash each one and learn which it was. Length leaks
+//! the same way. So does a timestamp, against someone who knows roughly when
+//! something happened.
+//!
+//! The allow-list is therefore short and its members are chosen because they
+//! carry no information about content: an opaque identifier the caller
+//! already knows, a closed outcome with a handful of values, a sequence
+//! number, the previous record's hash, and a signer tag that says this is a
+//! fixture. Nothing derived from what the effect was about appears at all.
+//!
+//! The coordinator's own state remains the only place that knows what
+//! happened. Evidence describes; it never decides.
+
+use sha2::{Digest, Sha256};
+
+/// A closed set. An outcome carried as free text would be a place to put
+/// anything, and "anything" eventually includes a subject line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EffectOutcome {
+    Dispatched,
+    Refused,
+    /// The effect's result is unknown and must stay unknown. Nothing may
+    /// relabel it later on the strength of a guess.
+    Indeterminate,
+}
+
+impl EffectOutcome {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            EffectOutcome::Dispatched => "dispatched",
+            EffectOutcome::Refused => "refused",
+            EffectOutcome::Indeterminate => "indeterminate",
+        }
+    }
+}
+
+/// The signer tag. Every fixture record carries it, so no record from this
+/// chain can be mistaken for product evidence — including by a reader who
+/// found one on its own with no context.
+pub const FIXTURE_SIGNER: &str = "synthetic-owner-effect-fixture-signer";
+
+/// One evidence record. Every field is on the allow-list; there is no
+/// `extra`, no `detail`, and no `reason`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EffectEvidenceV1 {
+    /// Opaque, and already known to whoever can read this chain. It carries
+    /// nothing about the effect's content.
+    pub intent_id: uuid::Uuid,
+    pub outcome: EffectOutcome,
+    pub sequence: u64,
+    pub previous_hash: [u8; 32],
+    pub signer: &'static str,
+}
+
+impl EffectEvidenceV1 {
+    pub fn new(
+        intent_id: uuid::Uuid,
+        outcome: EffectOutcome,
+        sequence: u64,
+        previous_hash: [u8; 32],
+    ) -> Self {
+        Self {
+            intent_id,
+            outcome,
+            sequence,
+            previous_hash,
+            signer: FIXTURE_SIGNER,
+        }
+    }
+
+    /// This record's hash, which the next record chains from.
+    pub fn hash(&self) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        hasher.update(b"sfo-effect-evidence-v1\0");
+        hasher.update(self.intent_id.as_bytes());
+        hasher.update(self.outcome.as_str().as_bytes());
+        hasher.update(b"\0");
+        hasher.update(self.sequence.to_le_bytes());
+        hasher.update(self.previous_hash);
+        hasher.update(self.signer.as_bytes());
+        hasher.finalize().into()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvidenceError {
+    /// The same intent already has a record with a different outcome.
+    OutcomeConflict,
+    /// The chain does not verify.
+    ChainBroken,
+}
+
+/// The fixture's evidence chain, separate from the product's ledger.
+#[derive(Debug, Default)]
+pub struct EffectEvidenceChain {
+    records: Vec<EffectEvidenceV1>,
+}
+
+impl EffectEvidenceChain {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append one outcome for one intent.
+    ///
+    /// Idempotent for the same outcome, because a crash between deciding an
+    /// effect's fate and recording it is ordinary and the recovery is to
+    /// record it again. Conflicting for a different one, because two answers
+    /// to the same question is not something to average — it is a defect, and
+    /// the second write is refused rather than allowed to overwrite.
+    pub fn append(
+        &mut self,
+        intent_id: uuid::Uuid,
+        outcome: EffectOutcome,
+    ) -> Result<&EffectEvidenceV1, EvidenceError> {
+        if let Some(index) = self
+            .records
+            .iter()
+            .position(|record| record.intent_id == intent_id)
+        {
+            if self.records[index].outcome != outcome {
+                return Err(EvidenceError::OutcomeConflict);
+            }
+            return Ok(&self.records[index]);
+        }
+
+        let previous_hash = self.records.last().map(|r| r.hash()).unwrap_or([0; 32]);
+        let record =
+            EffectEvidenceV1::new(intent_id, outcome, self.records.len() as u64, previous_hash);
+        self.records.push(record);
+        Ok(self.records.last().expect("just pushed"))
+    }
+
+    /// Verify the chain end to end.
+    pub fn verify(&self) -> Result<(), EvidenceError> {
+        let mut expected_previous = [0u8; 32];
+        for (index, record) in self.records.iter().enumerate() {
+            if record.sequence != index as u64 || record.previous_hash != expected_previous {
+                return Err(EvidenceError::ChainBroken);
+            }
+            if record.signer != FIXTURE_SIGNER {
+                return Err(EvidenceError::ChainBroken);
+            }
+            expected_previous = record.hash();
+        }
+        Ok(())
+    }
+
+    pub fn records(&self) -> &[EffectEvidenceV1] {
+        &self.records
+    }
+}

--- a/crates/audit-ledger/src/lib.rs
+++ b/crates/audit-ledger/src/lib.rs
@@ -425,3 +425,6 @@ mod tests {
         assert_eq!(reloaded.events.len(), 1);
     }
 }
+
+#[cfg(feature = "owner-effect-fixture")]
+pub mod effect_v1;

--- a/crates/audit-ledger/tests/effect_v1.rs
+++ b/crates/audit-ledger/tests/effect_v1.rs
@@ -1,0 +1,278 @@
+//! What the fixture's evidence chain may remember about an effect.
+//!
+//! An audit record answers "did this happen, in what order, was it tampered
+//! with". It does not answer "what was it". The tests here are about keeping
+//! those apart, and the sharpest of them is the dictionary oracle: redaction
+//! leaks, and a field replaced by its hash still answers questions when the
+//! set of possible answers is small — which, for the people a founder emails,
+//! it is.
+
+#![cfg(feature = "owner-effect-fixture")]
+
+use sovereign_audit_ledger::effect_v1::{
+    EffectEvidenceChain, EffectEvidenceV1, EffectOutcome, EvidenceError, FIXTURE_SIGNER,
+};
+use uuid::Uuid;
+
+#[test]
+fn a_record_carries_only_the_allowlisted_fields() {
+    let record = EffectEvidenceV1::new(Uuid::new_v4(), EffectOutcome::Dispatched, 0, [0; 32]);
+
+    // Rendered in full and read back: whatever the record can say about
+    // itself is exactly these five things.
+    let rendered = format!("{record:?}");
+    for field in [
+        "intent_id",
+        "outcome",
+        "sequence",
+        "previous_hash",
+        "signer",
+    ] {
+        assert!(
+            rendered.contains(field),
+            "{field} is missing from {rendered}"
+        );
+    }
+
+    // And the struct has no other field to add one to.
+    let source = include_str!("../src/effect_v1.rs");
+    let code: String = source
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let declaration = code
+        .split("pub struct EffectEvidenceV1 {")
+        .nth(1)
+        .and_then(|rest| rest.split('}').next())
+        .expect("the struct declaration");
+    let fields: Vec<&str> = declaration
+        .lines()
+        .filter_map(|line| line.trim().strip_suffix(','))
+        .filter_map(|line| line.split(':').next())
+        .map(|name| name.trim_start_matches("pub ").trim())
+        .collect();
+    assert_eq!(
+        fields,
+        vec![
+            "intent_id",
+            "outcome",
+            "sequence",
+            "previous_hash",
+            "signer"
+        ],
+        "the record gained a field"
+    );
+}
+
+/// The names that must never appear. Each is something an audit record
+/// plausibly wants and each answers "what was it" rather than "did it
+/// happen".
+#[test]
+fn the_record_omits_everything_that_describes_the_effect() {
+    let source = include_str!("../src/effect_v1.rs");
+    let code: String = source
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let declaration = code
+        .split("pub struct EffectEvidenceV1 {")
+        .nth(1)
+        .and_then(|rest| rest.split('}').next())
+        .expect("the struct declaration");
+
+    for forbidden in [
+        "recipient",
+        "content",
+        "digest",
+        "path",
+        "size",
+        "bytes",
+        "time",
+        "timestamp",
+        "subject",
+        "body",
+        "policy",
+        "reason",
+        "detail",
+        "extra",
+    ] {
+        assert!(
+            !declaration.contains(forbidden),
+            "the record carries {forbidden:?}, which describes the effect rather than its occurrence"
+        );
+    }
+}
+
+/// The sharp one. Two effects that differ only in their content must produce
+/// projections that differ in no way an observer can use.
+///
+/// If any field were derived from the content — a hash, a length, anything —
+/// then an observer holding a small dictionary of candidates could compute
+/// each one and learn which it was. The set of people a founder emails is a
+/// small dictionary.
+#[test]
+fn a_low_entropy_dictionary_gives_no_projection_oracle() {
+    let dictionary = [
+        "alice@example.test",
+        "bob@example.test",
+        "carol@example.test",
+        "dave@example.test",
+    ];
+
+    // The same intent and outcome, with wildly different content behind them.
+    // The projection takes no content at all, so the only way these could
+    // differ is if the type had a field for it.
+    let intent = Uuid::new_v4();
+    let mut projections = Vec::new();
+    for _recipient in dictionary {
+        let record = EffectEvidenceV1::new(intent, EffectOutcome::Dispatched, 0, [0; 32]);
+        projections.push((format!("{record:?}"), record.hash()));
+    }
+
+    let first = &projections[0];
+    for (index, projection) in projections.iter().enumerate() {
+        assert_eq!(
+            projection, first,
+            "projection {index} differs from the first, so the content is observable"
+        );
+    }
+}
+
+/// A record found on its own, with no context, must still be recognisable as
+/// fixture evidence rather than product evidence.
+#[test]
+fn every_record_is_tagged_as_a_fixture_signer() {
+    let record = EffectEvidenceV1::new(Uuid::new_v4(), EffectOutcome::Refused, 0, [0; 32]);
+    assert_eq!(record.signer, FIXTURE_SIGNER);
+    assert!(
+        FIXTURE_SIGNER.contains("synthetic") && FIXTURE_SIGNER.contains("fixture"),
+        "the tag must say what it is without needing context: {FIXTURE_SIGNER}"
+    );
+}
+
+#[test]
+fn the_chain_verifies_and_each_record_links_to_the_last() {
+    let mut chain = EffectEvidenceChain::new();
+    let first = chain
+        .append(Uuid::new_v4(), EffectOutcome::Dispatched)
+        .unwrap()
+        .clone();
+    let second = chain
+        .append(Uuid::new_v4(), EffectOutcome::Refused)
+        .unwrap()
+        .clone();
+
+    assert_eq!(first.sequence, 0);
+    assert_eq!(first.previous_hash, [0; 32]);
+    assert_eq!(second.sequence, 1);
+    assert_eq!(second.previous_hash, first.hash());
+    assert!(chain.verify().is_ok());
+}
+
+/// Appending the same outcome for the same intent again is the recovery from
+/// a crash between deciding an effect's fate and recording it, so it must not
+/// grow the chain or fail.
+#[test]
+fn the_same_outcome_for_one_intent_appends_once() {
+    let mut chain = EffectEvidenceChain::new();
+    let intent = Uuid::new_v4();
+
+    let first = chain
+        .append(intent, EffectOutcome::Dispatched)
+        .unwrap()
+        .hash();
+    let again = chain
+        .append(intent, EffectOutcome::Dispatched)
+        .unwrap()
+        .hash();
+
+    assert_eq!(first, again, "a replay produced a different record");
+    assert_eq!(chain.records().len(), 1, "a replay grew the chain");
+    assert!(chain.verify().is_ok());
+}
+
+/// Two answers to the same question is a defect, not something to average.
+/// The second write is refused rather than allowed to overwrite the first.
+#[test]
+fn a_different_outcome_for_one_intent_conflicts() {
+    let mut chain = EffectEvidenceChain::new();
+    let intent = Uuid::new_v4();
+    chain.append(intent, EffectOutcome::Dispatched).unwrap();
+
+    assert_eq!(
+        chain.append(intent, EffectOutcome::Refused).err(),
+        Some(EvidenceError::OutcomeConflict)
+    );
+    assert_eq!(chain.records()[0].outcome, EffectOutcome::Dispatched);
+}
+
+/// An unknown outcome must stay unknown. Relabelling it later on the strength
+/// of a guess is how an audit chain starts recording what someone assumed
+/// instead of what was observed.
+#[test]
+fn an_indeterminate_outcome_is_never_relabelled() {
+    let mut chain = EffectEvidenceChain::new();
+    let intent = Uuid::new_v4();
+    chain.append(intent, EffectOutcome::Indeterminate).unwrap();
+
+    for later in [EffectOutcome::Dispatched, EffectOutcome::Refused] {
+        assert_eq!(
+            chain.append(intent, later).err(),
+            Some(EvidenceError::OutcomeConflict),
+            "an indeterminate outcome was relabelled {later:?}"
+        );
+    }
+    assert_eq!(chain.records()[0].outcome, EffectOutcome::Indeterminate);
+}
+
+/// Every field is covered by the hash, so tampering with any one breaks the
+/// chain rather than only the ones an author remembered.
+#[test]
+fn tampering_with_any_field_changes_the_hash() {
+    let intent = Uuid::new_v4();
+    let base = EffectEvidenceV1::new(intent, EffectOutcome::Dispatched, 3, [7; 32]);
+
+    let variants = [
+        EffectEvidenceV1::new(Uuid::new_v4(), EffectOutcome::Dispatched, 3, [7; 32]),
+        EffectEvidenceV1::new(intent, EffectOutcome::Refused, 3, [7; 32]),
+        EffectEvidenceV1::new(intent, EffectOutcome::Dispatched, 4, [7; 32]),
+        EffectEvidenceV1::new(intent, EffectOutcome::Dispatched, 3, [8; 32]),
+    ];
+    for (index, variant) in variants.iter().enumerate() {
+        assert_ne!(
+            base.hash(),
+            variant.hash(),
+            "field {index} is not covered by the hash"
+        );
+    }
+}
+
+/// The chain describes; it does not decide. There is no method that changes
+/// an effect's state, so evidence cannot advance one.
+#[test]
+fn evidence_never_advances_an_effect() {
+    let source = include_str!("../src/effect_v1.rs");
+    let code: String = source
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    for mutator in [
+        "fn dispatch",
+        "fn set_outcome",
+        "fn advance",
+        "fn retry",
+        "fn execute",
+    ] {
+        assert!(
+            !code.contains(mutator),
+            "the evidence chain exposes {mutator:?}, so it can change what it is supposed to record"
+        );
+    }
+    assert!(
+        code.contains("pub fn append"),
+        "stripping comments removed the code as well"
+    );
+}

--- a/scripts/check-owner-effect-canaries.sh
+++ b/scripts/check-owner-effect-canaries.sh
@@ -32,7 +32,9 @@ SCANNED="crates/authority/src/broker
 crates/authority/tests
 crates/owner/src
 crates/owner/tests
-apps/cli/tests"
+apps/cli/tests
+crates/audit-ledger/src
+crates/audit-ledger/tests"
 
 completed=0
 on_exit() {

--- a/scripts/owner-effect-tests.tsv
+++ b/scripts/owner-effect-tests.tsv
@@ -129,3 +129,13 @@ task	package	target	profile	test_name
 6	sovereign-owner	exact_approval	owner-effect-fixture	a_restart_invalidates_an_approval_whose_digest_still_verifies
 6	sovereign-owner	exact_approval	owner-effect-fixture	one_store_does_not_honour_anothers_approval
 6	sovereign-owner	exact_approval	owner-effect-fixture	the_approval_is_opaque_and_never_prints_itself
+12	sovereign-audit-ledger	effect_v1	owner-effect-fixture	a_record_carries_only_the_allowlisted_fields
+12	sovereign-audit-ledger	effect_v1	owner-effect-fixture	the_record_omits_everything_that_describes_the_effect
+12	sovereign-audit-ledger	effect_v1	owner-effect-fixture	a_low_entropy_dictionary_gives_no_projection_oracle
+12	sovereign-audit-ledger	effect_v1	owner-effect-fixture	every_record_is_tagged_as_a_fixture_signer
+12	sovereign-audit-ledger	effect_v1	owner-effect-fixture	the_chain_verifies_and_each_record_links_to_the_last
+12	sovereign-audit-ledger	effect_v1	owner-effect-fixture	the_same_outcome_for_one_intent_appends_once
+12	sovereign-audit-ledger	effect_v1	owner-effect-fixture	a_different_outcome_for_one_intent_conflicts
+12	sovereign-audit-ledger	effect_v1	owner-effect-fixture	an_indeterminate_outcome_is_never_relabelled
+12	sovereign-audit-ledger	effect_v1	owner-effect-fixture	tampering_with_any_field_changes_the_hash
+12	sovereign-audit-ledger	effect_v1	owner-effect-fixture	evidence_never_advances_an_effect


### PR DESCRIPTION
An audit record exists to answer *did this happen, in what order, was it tampered with*. It does **not** exist to answer *what was it*. Those look similar and are not, and the difference is the whole design: the evidence is a **projection**, and everything outside a short allow-list is **absent rather than redacted**.

## Why absent, not redacted

Redaction leaks. A field replaced by its hash still answers questions when the set of possible answers is small — and the set of people a founder emails is a small dictionary. Anyone holding the record can hash each candidate and learn which it was. Length leaks the same way; so does a timestamp, against someone who knows roughly when something happened.

The record carries: an opaque identifier the reader already knows, a closed outcome with three values, a sequence number, the previous hash, and a signer tag. A test reads the struct declaration and asserts **those five and no more**. A second forbids fourteen names an audit record plausibly wants — recipient, content, digest, path, size, time, reason among them.

The outcome is an enum rather than text, because free text is a place to put anything, and anything eventually includes a subject line.

## Three behaviours worth the space

- Appending the **same** outcome twice is the recovery from a crash between deciding an effect's fate and recording it — idempotent, not an error.
- A **different** outcome for the same intent is refused: two answers to one question is a defect, not something to average.
- An `Indeterminate` outcome is **never relabelled**. That is how a chain starts recording what someone assumed rather than what was observed.

Every field is covered by the hash, checked field by field rather than trusting the author remembered them all. There is no method that changes an effect's state — evidence describes, it never decides — and a test asserts none appeared.

## Verification

Adding a recipient digest to the record, letting a conflicting outcome overwrite, and dropping the previous hash from the hash. Each was named exactly.

The canary scanner now covers this crate too.