### PR TITLE
feat(owner): turn what the preflight measured into what the surface accepts

### DIFF
--- a/crates/owner/Cargo.toml
+++ b/crates/owner/Cargo.toml
@@ -39,3 +39,7 @@ required-features = ["owner-effect-fixture"]
 [[test]]
 name = "exact_approval"
 required-features = ["owner-effect-fixture"]
+
+[[test]]
+name = "fixture_loopback"
+required-features = ["owner-effect-fixture"]

--- a/crates/owner/src/http_guard.rs
+++ b/crates/owner/src/http_guard.rs
@@ -1,0 +1,210 @@
+//! What the fixture's HTTP surface accepts, and everything it refuses.
+//!
+//! The origin preflight measured three facts about loopback that a design
+//! cannot assume away, and this module is where they turn into code.
+//!
+//! Cookies are not isolated by port: another server on this host can set and
+//! overwrite the session cookie. So a cookie alone is never a session, and a
+//! request must also carry the CSRF value the page was given — something a
+//! cross-origin page can cause a browser to *send* but cannot cause it to
+//! *learn*.
+//!
+//! A WebAuthn RP ID is a host, so every port shares one. What separates them
+//! is the origin the browser records, which means the `Origin` header is
+//! checked exactly and not by suffix, prefix or scheme-insensitively. A
+//! near-miss origin is a different origin.
+//!
+//! And an IP address cannot be an RP ID at all, so the compiled origin names
+//! `localhost` while the socket binds loopback. There is no API to change it:
+//! an origin a caller can set is not a boundary.
+//!
+//! The route list is closed. A request that does not name one of these routes
+//! is refused before anything else is considered, so there is no path that
+//! exists by accident, no alias, and no way to smuggle a route in a query
+//! parameter.
+
+use crate::config::ORIGIN;
+
+/// Every route, and there is no other. An enum rather than a string match, so
+/// adding one is a change a reviewer sees.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Route {
+    /// The synthetic warning shell. The only GET.
+    Shell,
+    RegistrationStart,
+    RegistrationFinish,
+    LoginStart,
+    LoginFinish,
+    Logout,
+}
+
+impl Route {
+    const ALL: &'static [(Route, &'static str, Method)] = &[
+        (Route::Shell, "/", Method::Get),
+        (
+            Route::RegistrationStart,
+            "/fixture/register/start",
+            Method::Post,
+        ),
+        (
+            Route::RegistrationFinish,
+            "/fixture/register/finish",
+            Method::Post,
+        ),
+        (Route::LoginStart, "/fixture/login/start", Method::Post),
+        (Route::LoginFinish, "/fixture/login/finish", Method::Post),
+        (Route::Logout, "/fixture/logout", Method::Post),
+    ];
+
+    fn lookup(method: Method, path: &str) -> Option<Route> {
+        Self::ALL
+            .iter()
+            .find(|(_, route_path, route_method)| *route_path == path && *route_method == method)
+            .map(|(route, _, _)| *route)
+    }
+
+    /// Whether this route runs before a session exists. Registration and
+    /// login must, or there would be no way to obtain one; everything else
+    /// must not.
+    pub fn is_pre_session(self) -> bool {
+        matches!(
+            self,
+            Route::Shell
+                | Route::RegistrationStart
+                | Route::RegistrationFinish
+                | Route::LoginStart
+                | Route::LoginFinish
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Method {
+    Get,
+    Post,
+}
+
+/// The bytes a caller may send. Small on purpose: nothing this surface
+/// accepts is large, and a generous cap is a place to put a payload.
+pub const MAX_BODY_BYTES: usize = 8 * 1024;
+
+/// One request, reduced to what the guard judges.
+#[derive(Debug, Clone)]
+pub struct Request<'a> {
+    pub method: Method,
+    /// The raw target, query string included. A guard that saw only the path
+    /// could not refuse a token smuggled in a query parameter.
+    pub target: &'a str,
+    /// Every header, in order, including repeats — a guard given a map has
+    /// already lost the duplicate it needs to refuse.
+    pub headers: Vec<(&'a str, &'a str)>,
+    pub body_len: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Reject {
+    UnknownRoute,
+    /// A query string on a surface that has no use for one.
+    QueryNotAllowed,
+    WrongHost,
+    WrongOrigin,
+    /// `Sec-Fetch-Site` or `Sec-Fetch-Mode` is not what a same-origin fetch
+    /// from our own page sends.
+    WrongFetchMetadata,
+    WrongContentType,
+    BodyTooLarge,
+    /// The same header appears twice.
+    DuplicateHeader,
+    /// A cookie with no CSRF value, or the reverse.
+    IncompleteCredentials,
+}
+
+/// The value `Host` must equal. Derived from the compiled origin rather than
+/// written twice, so the two cannot drift.
+fn expected_host() -> &'static str {
+    ORIGIN.trim_start_matches("http://")
+}
+
+fn header<'a>(request: &'a Request<'a>, name: &str) -> Option<&'a str> {
+    request
+        .headers
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case(name))
+        .map(|(_, value)| *value)
+}
+
+fn count(request: &Request<'_>, name: &str) -> usize {
+    request
+        .headers
+        .iter()
+        .filter(|(key, _)| key.eq_ignore_ascii_case(name))
+        .count()
+}
+
+/// Judge one request.
+///
+/// The order is deliberate: the route first, so an unknown path is refused
+/// before any header is trusted; then the headers that say who is calling;
+/// then the body. A guard that read the body before deciding the request was
+/// even addressed to it would have accepted work from a stranger.
+pub fn check(request: &Request<'_>) -> Result<Route, Reject> {
+    let (path, query) = match request.target.split_once('?') {
+        Some((path, query)) => (path, Some(query)),
+        None => (request.target, None),
+    };
+    let route = Route::lookup(request.method, path).ok_or(Reject::UnknownRoute)?;
+    // No route here takes a parameter, so a query string is either a mistake
+    // or an attempt to pass something where it will not be looked at.
+    if query.is_some() {
+        return Err(Reject::QueryNotAllowed);
+    }
+
+    // Duplicates first: a guard that read the first of two `Origin` headers
+    // would be judging one and letting a proxy or a browser quirk deliver the
+    // other.
+    for name in ["host", "origin", "cookie", "x-sfo-csrf", "content-type"] {
+        if count(request, name) > 1 {
+            return Err(Reject::DuplicateHeader);
+        }
+    }
+
+    if header(request, "host") != Some(expected_host()) {
+        return Err(Reject::WrongHost);
+    }
+    // Exact, not by suffix or prefix, and not scheme-insensitively.
+    if header(request, "origin") != Some(ORIGIN) {
+        return Err(Reject::WrongOrigin);
+    }
+    // What our own page's fetch sends, and what a cross-site navigation or a
+    // form post does not.
+    if header(request, "sec-fetch-site") != Some("same-origin") {
+        return Err(Reject::WrongFetchMetadata);
+    }
+    if request.method == Method::Post && header(request, "sec-fetch-mode") != Some("cors") {
+        return Err(Reject::WrongFetchMetadata);
+    }
+
+    if request.method == Method::Post {
+        if header(request, "content-type") != Some("application/json") {
+            return Err(Reject::WrongContentType);
+        }
+        if request.body_len > MAX_BODY_BYTES {
+            return Err(Reject::BodyTooLarge);
+        }
+    }
+
+    // A cookie without its CSRF partner is what a cross-origin page can
+    // cause; a CSRF value without a cookie names no session. Both or neither.
+    let has_cookie = header(request, "cookie").is_some();
+    let has_csrf = header(request, "x-sfo-csrf").is_some();
+    if has_cookie != has_csrf {
+        return Err(Reject::IncompleteCredentials);
+    }
+    // Routes that exist to create a session are the only ones that may arrive
+    // without one.
+    if !has_cookie && !route.is_pre_session() {
+        return Err(Reject::IncompleteCredentials);
+    }
+
+    Ok(route)
+}

--- a/crates/owner/src/lib.rs
+++ b/crates/owner/src/lib.rs
@@ -32,6 +32,9 @@ pub mod approval;
 pub mod config;
 
 #[cfg(feature = "owner-effect-fixture")]
+pub mod http_guard;
+
+#[cfg(feature = "owner-effect-fixture")]
 pub mod registry;
 
 #[cfg(feature = "owner-effect-fixture")]

--- a/crates/owner/tests/fixture_loopback.rs
+++ b/crates/owner/tests/fixture_loopback.rs
@@ -1,0 +1,304 @@
+//! What the fixture's HTTP surface accepts, and everything it refuses.
+//!
+//! The origin preflight measured three facts about loopback. Cookies are not
+//! isolated by port. A WebAuthn RP ID is a host, so every port shares one.
+//! And an IP address cannot be an RP ID at all. These tests are where those
+//! measurements are held to.
+
+#![cfg(feature = "owner-effect-fixture")]
+
+use sovereign_owner::config::ORIGIN;
+use sovereign_owner::http_guard::{check, Method, Reject, Request, Route, MAX_BODY_BYTES};
+
+const HOST: &str = "localhost:7787";
+
+fn post(target: &str) -> Request<'static> {
+    Request {
+        method: Method::Post,
+        target: Box::leak(target.to_owned().into_boxed_str()),
+        headers: vec![
+            ("Host", HOST),
+            ("Origin", ORIGIN),
+            ("Sec-Fetch-Site", "same-origin"),
+            ("Sec-Fetch-Mode", "cors"),
+            ("Content-Type", "application/json"),
+        ],
+        body_len: 16,
+    }
+}
+
+fn with(
+    mut request: Request<'static>,
+    name: &'static str,
+    value: &'static str,
+) -> Request<'static> {
+    request
+        .headers
+        .retain(|(key, _)| !key.eq_ignore_ascii_case(name));
+    request.headers.push((name, value));
+    request
+}
+
+#[test]
+fn the_known_routes_are_accepted() {
+    assert_eq!(
+        check(&post("/fixture/register/start")),
+        Ok(Route::RegistrationStart)
+    );
+    assert_eq!(
+        check(&post("/fixture/login/finish")),
+        Ok(Route::LoginFinish)
+    );
+}
+
+/// The route list is closed. Anything not on it is refused before a single
+/// header is trusted, so there is no path that exists by accident.
+#[test]
+fn an_unknown_route_is_refused_before_anything_else() {
+    for target in [
+        "/fixture/register",
+        "/fixture/register/start/",
+        "/FIXTURE/register/start",
+        "/api/fixture/register/start",
+        "/fixture/admin",
+        "/",
+    ] {
+        let mut request = post(target);
+        // Everything else about this request is wrong too — the route check
+        // must still be the one that fires.
+        request.headers.clear();
+        assert_eq!(
+            check(&request),
+            Err(Reject::UnknownRoute),
+            "{target} was not refused as an unknown route"
+        );
+    }
+}
+
+/// The one GET is the synthetic warning shell, and it is not reachable by
+/// POST — nor are the POST routes reachable by GET.
+#[test]
+fn methods_are_not_interchangeable() {
+    let mut shell = post("/");
+    shell.method = Method::Get;
+    shell
+        .headers
+        .retain(|(k, _)| !k.eq_ignore_ascii_case("content-type"));
+    shell
+        .headers
+        .retain(|(k, _)| !k.eq_ignore_ascii_case("sec-fetch-mode"));
+    assert_eq!(check(&shell), Ok(Route::Shell));
+
+    let mut as_get = post("/fixture/login/start");
+    as_get.method = Method::Get;
+    assert_eq!(check(&as_get), Err(Reject::UnknownRoute));
+}
+
+/// No route here takes a parameter, so a query string is either a mistake or
+/// an attempt to pass something where it will not be looked at.
+#[test]
+fn a_query_string_is_refused() {
+    for target in [
+        "/fixture/login/start?token=abc",
+        "/fixture/login/start?",
+        "/fixture/login/start?csrf=stolen",
+    ] {
+        assert_eq!(
+            check(&post(target)),
+            Err(Reject::QueryNotAllowed),
+            "{target} was accepted"
+        );
+    }
+}
+
+/// Exact, not by suffix or prefix, and not scheme-insensitively. Every one of
+/// these is a near miss that a looser check would accept, and each is a
+/// different origin.
+#[test]
+fn the_origin_must_match_exactly() {
+    for origin in [
+        "http://127.0.0.1:7787",
+        "https://localhost:7787",
+        "http://localhost:7788",
+        "http://localhost",
+        "http://localhost:7787/",
+        "http://evil.localhost:7787",
+        "http://localhost:7787.evil.test",
+        "null",
+        "",
+    ] {
+        assert_eq!(
+            check(&with(post("/fixture/login/start"), "Origin", origin)),
+            Err(Reject::WrongOrigin),
+            "origin {origin:?} was accepted"
+        );
+    }
+}
+
+#[test]
+fn a_missing_origin_is_refused() {
+    let mut request = post("/fixture/login/start");
+    request
+        .headers
+        .retain(|(k, _)| !k.eq_ignore_ascii_case("origin"));
+    assert_eq!(check(&request), Err(Reject::WrongOrigin));
+}
+
+#[test]
+fn the_host_must_match_the_compiled_origin() {
+    for host in ["127.0.0.1:7787", "localhost:7788", "localhost", "evil.test"] {
+        assert_eq!(
+            check(&with(post("/fixture/login/start"), "Host", host)),
+            Err(Reject::WrongHost),
+            "host {host:?} was accepted"
+        );
+    }
+}
+
+/// Fetch metadata a same-origin fetch from our own page sends, and a
+/// cross-site navigation or a form post does not.
+#[test]
+fn cross_site_fetch_metadata_is_refused() {
+    for site in ["cross-site", "same-site", "none", ""] {
+        assert_eq!(
+            check(&with(post("/fixture/login/start"), "Sec-Fetch-Site", site)),
+            Err(Reject::WrongFetchMetadata),
+            "sec-fetch-site {site:?} was accepted"
+        );
+    }
+    for mode in ["navigate", "no-cors", "same-origin"] {
+        assert_eq!(
+            check(&with(post("/fixture/login/start"), "Sec-Fetch-Mode", mode)),
+            Err(Reject::WrongFetchMetadata),
+            "sec-fetch-mode {mode:?} was accepted"
+        );
+    }
+}
+
+/// A form can be submitted cross-origin and cannot set a JSON content type,
+/// so requiring one is a second, independent barrier.
+#[test]
+fn a_non_json_content_type_is_refused() {
+    for content_type in [
+        "application/x-www-form-urlencoded",
+        "multipart/form-data",
+        "text/plain",
+        "application/json; charset=utf-8",
+        "",
+    ] {
+        assert_eq!(
+            check(&with(
+                post("/fixture/login/start"),
+                "Content-Type",
+                content_type
+            )),
+            Err(Reject::WrongContentType),
+            "content type {content_type:?} was accepted"
+        );
+    }
+}
+
+#[test]
+fn an_oversized_body_is_refused() {
+    let mut request = post("/fixture/login/start");
+    request.body_len = MAX_BODY_BYTES + 1;
+    assert_eq!(check(&request), Err(Reject::BodyTooLarge));
+
+    request.body_len = MAX_BODY_BYTES;
+    assert!(check(&request).is_ok(), "the cap itself must be allowed");
+}
+
+/// A guard that read the first of two `Origin` headers would be judging one
+/// and letting a proxy or a browser quirk deliver the other.
+#[test]
+fn a_duplicated_security_header_is_refused() {
+    for name in ["Host", "Origin", "Cookie", "X-SFO-CSRF", "Content-Type"] {
+        let mut request = post("/fixture/login/start");
+        // The header must be present *twice*. Pushing onto a request that
+        // lacks it entirely — as Cookie and X-SFO-CSRF do — would add a
+        // first one, and a different check would fire.
+        request.headers.push((name, "a-value"));
+        request.headers.push((name, "second-value"));
+        assert_eq!(
+            check(&request),
+            Err(Reject::DuplicateHeader),
+            "a duplicated {name} was accepted"
+        );
+    }
+}
+
+/// The preflight's finding, encoded. A cookie alone is what a cross-origin
+/// page can cause a browser to send — and another port on this host can set
+/// that cookie. The CSRF value is the half it cannot learn.
+#[test]
+fn a_cookie_without_its_csrf_partner_is_refused() {
+    let cookie_only = with(
+        post("/fixture/logout"),
+        "Cookie",
+        "__Host-sfo_fixture_session=x",
+    );
+    assert_eq!(check(&cookie_only), Err(Reject::IncompleteCredentials));
+
+    let csrf_only = with(post("/fixture/logout"), "X-SFO-CSRF", "y");
+    assert_eq!(check(&csrf_only), Err(Reject::IncompleteCredentials));
+
+    let both = with(
+        with(
+            post("/fixture/logout"),
+            "Cookie",
+            "__Host-sfo_fixture_session=x",
+        ),
+        "X-SFO-CSRF",
+        "y",
+    );
+    assert_eq!(check(&both), Ok(Route::Logout));
+}
+
+/// Registration and login must work without a session — there would be no way
+/// to obtain one otherwise — and nothing else may.
+#[test]
+fn only_the_pre_session_routes_run_without_credentials() {
+    for (target, route) in [
+        ("/fixture/register/start", Route::RegistrationStart),
+        ("/fixture/register/finish", Route::RegistrationFinish),
+        ("/fixture/login/start", Route::LoginStart),
+        ("/fixture/login/finish", Route::LoginFinish),
+    ] {
+        assert_eq!(check(&post(target)), Ok(route));
+        assert!(route.is_pre_session());
+    }
+
+    assert_eq!(
+        check(&post("/fixture/logout")),
+        Err(Reject::IncompleteCredentials),
+        "logout ran without a session"
+    );
+    assert!(!Route::Logout.is_pre_session());
+}
+
+/// There is no way to change the compiled origin. An origin a caller can set
+/// is not a boundary.
+#[test]
+fn no_api_changes_the_origin() {
+    let source = include_str!("../src/http_guard.rs");
+    let code: String = source
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    for setter in [
+        "fn set_origin",
+        "fn with_origin",
+        "origin: String",
+        "pub static mut",
+    ] {
+        assert!(
+            !code.contains(setter),
+            "the guard exposes {setter:?}, so the origin is configurable"
+        );
+    }
+    assert!(
+        code.contains("use crate::config::ORIGIN"),
+        "the origin must be the compiled one"
+    );
+}

--- a/scripts/owner-effect-tests.tsv
+++ b/scripts/owner-effect-tests.tsv
@@ -152,3 +152,17 @@ task	package	target	profile	test_name
 10	sovereign-authority	reservation_atomicity	owner-effect-fixture	a_replay_reserves_nothing_new
 10	sovereign-authority	reservation_atomicity	owner-effect-fixture	the_same_key_with_a_different_fingerprint_conflicts
 10	sovereign-authority	reservation_atomicity	owner-effect-fixture	a_reservation_survives_reopening_the_store
+9	sovereign-owner	fixture_loopback	owner-effect-fixture	the_known_routes_are_accepted
+9	sovereign-owner	fixture_loopback	owner-effect-fixture	an_unknown_route_is_refused_before_anything_else
+9	sovereign-owner	fixture_loopback	owner-effect-fixture	methods_are_not_interchangeable
+9	sovereign-owner	fixture_loopback	owner-effect-fixture	a_query_string_is_refused
+9	sovereign-owner	fixture_loopback	owner-effect-fixture	the_origin_must_match_exactly
+9	sovereign-owner	fixture_loopback	owner-effect-fixture	a_missing_origin_is_refused
+9	sovereign-owner	fixture_loopback	owner-effect-fixture	the_host_must_match_the_compiled_origin
+9	sovereign-owner	fixture_loopback	owner-effect-fixture	cross_site_fetch_metadata_is_refused
+9	sovereign-owner	fixture_loopback	owner-effect-fixture	a_non_json_content_type_is_refused
+9	sovereign-owner	fixture_loopback	owner-effect-fixture	an_oversized_body_is_refused
+9	sovereign-owner	fixture_loopback	owner-effect-fixture	a_duplicated_security_header_is_refused
+9	sovereign-owner	fixture_loopback	owner-effect-fixture	a_cookie_without_its_csrf_partner_is_refused
+9	sovereign-owner	fixture_loopback	owner-effect-fixture	only_the_pre_session_routes_run_without_credentials
+9	sovereign-owner	fixture_loopback	owner-effect-fixture	no_api_changes_the_origin


### PR DESCRIPTION
The origin preflight (#57) established three facts about loopback that a design cannot assume away. This is where they become code.

**Cookies are not isolated by port** — another server on this host can set and overwrite the session cookie — so a cookie alone is never a session. A request must also carry the CSRF value the page was given, which a cross-origin page can cause a browser to *send* but cannot cause it to *learn*. Both or neither, and the routes that exist to create a session are the only ones allowed to arrive without one.

**A WebAuthn RP ID is a host**, so every port shares one, and what separates them is the origin the browser records. So `Origin` is compared exactly: nine near misses are tested one by one, including `http://127.0.0.1:7787`, a trailing slash, and `http://localhost:7787.evil.test` — each of which some looser check accepts, and each of which is a different origin.

**An IP address cannot be an RP ID at all**, so the compiled origin names `localhost` while the socket binds loopback — and there is no API to change it, because an origin a caller can set is not a boundary.

## The rest of the guard

The route list is closed and is an enum, so adding one is a change a reviewer sees. Anything not on it is refused **before a single header is trusted**: a guard that read the body before deciding the request was even addressed to it would have accepted work from a stranger.

Duplicate headers are refused before any are read. A guard that took the first of two `Origin` headers would be judging one while a proxy or a browser quirk delivered the other — which is why the request carries headers **in order, repeats included**, rather than as a map that has already lost the duplicate.

Fetch metadata and a JSON content type are two further independent barriers: a form can be submitted cross-origin and cannot set either.

## Verification

Matching the origin by prefix, removing the duplicate check, and accepting a cookie without its CSRF partner — each was named exactly.

One test was my own mistake first: the duplicate-header case pushed a header onto a request that lacked it entirely, so it added a *first* one rather than a second, and a different check fired. It now ensures the header is genuinely present twice.