### PR TITLE
docs(security): publish what the fixture demonstrates, and gate what it claims

### DIFF
--- a/docs/security/synthetic-owner-exact-effect-fixture-qualification.md
+++ b/docs/security/synthetic-owner-exact-effect-fixture-qualification.md
@@ -1,0 +1,98 @@
+# Synthetic owner / exact-effect fixture — evidence and limitations
+
+**Status:** Fixture qualification. Nothing here enables a product workspace.
+**Contract:** [RFC 0006](../../rfcs/0006-synthetic-owner-session-exact-effect-fixture.md)
+**Gate:** `scripts/check-owner-effect-documentation.sh`
+
+## What this document is for
+
+To record what the fixture demonstrates and, more carefully, what it does not
+— in one place, so that neither has to be reconstructed later from commit
+messages by someone deciding whether to rely on it.
+
+There is no status field here, and no transition. A document that could be
+edited to say "qualified" would eventually be edited to say it.
+
+## The honest boundary
+
+**This fixture is not owner admission.** A hostile process running under the
+same account as the founder can win the empty-registry enrolment, and nothing
+in the fixture can tell that process from the founder. Every mechanism below
+holds *given* an established credential; none of them establishes who
+established it.
+
+Three specific things that might look like they close that gap and do not:
+
+- **The hidden subcommand is not a barrier.** `__owner-effect-broker` is
+  absent from a default build, which keeps it out of the product. It is
+  present in a fixture build, where any local process can invoke it. Obscurity
+  is not admission.
+- **The bootstrap key is connection authentication, not provenance.** It
+  proves the process on the other end of the pipe holds the key the parent
+  generated. A same-account caller can supply its own syntactically valid
+  frame and become the parent, which is deliberately indistinguishable and is
+  tested as unqualified fixture control.
+- **Same-user-handle credential replacement is a denial of service that is
+  accepted, not mitigated.** The preflight observed a second port replacing a
+  resident credential rather than adding alongside it. On real hardware that
+  is something a local process can inflict on the owner. The fixture has no
+  owner to lock out, so it is recorded as a residual.
+
+## What is demonstrated
+
+Each row is a property with tests behind it, all registered in
+`scripts/owner-effect-tests.tsv`.
+
+| Property | Where |
+| --- | --- |
+| Nothing is bound, locked or opened before a supervisor authenticates | `broker_kill_matrix` — the process is killed between each pair of steps |
+| One absolute monotonic deadline bounds the whole unowned window | `broker_listener` |
+| The supervisor is authenticated by MAC over the published nonce, verified in constant time | `broker_supervisor` — all 256 single-bit tag changes |
+| Sole writable ownership is a real lock the kernel releases on death, not a claim in a file | `broker_process_lock` |
+| The store is unreachable without the lock, by construction | `broker_store` |
+| Credentials are minted by the broker; callers choose no key, id or expiry | `broker_connections` |
+| A root is classified by the broker itself and cannot be aimed at product state | `fixture_root_lifecycle`, `broker_bootstrap_frame` |
+| A session is not an approval; approval binds five fields and dies with a restart | `exact_approval` |
+| Evidence records that an effect happened, never what it was | `effect_v1` — including a dictionary-oracle test |
+| Everything an effect needs is reserved in one transaction or not at all | `reservation_atomicity` |
+| The HTTP surface accepts exactly one origin and a closed route list | `fixture_loopback` |
+| The composed message is deterministic and unreadable from outside the crate | `exact_fixture_prepare` |
+
+## What is measured rather than assumed
+
+The origin preflight
+([matrix](owner-auth-mechanism-matrix.md)) established three facts with a real
+browser rather than from the specification:
+
+- cookies are not isolated by port — a second port set and overwrote the
+  `__Host-` session cookie;
+- a page on another port obtained a **user-verified** assertion over the same
+  credential, because an RP ID is a host;
+- an IP address cannot be a WebAuthn RP ID at all, which is why the fixture is
+  reached as `http://localhost:7787` while the socket binds loopback.
+
+The real-authenticator matrix is **empty**. No attended run against real
+hardware has been performed, so the mechanism is unqualified on every
+platform.
+
+## What is not demonstrated
+
+- **Owner admission**, as above.
+- **The WebAuthn adapter.** The ceremony's logic is implemented and tested —
+  the registry takes user-verification, the credential id and the returned
+  handle as inputs — but the adapter that produces those from a browser
+  response is not written. It requires `webauthn-rs`, whose pin resolves 116
+  packages including a binding to the system OpenSSL, and that is an audit
+  decision rather than a coding step.
+- **Product effects.** No product route, command, or workspace is reachable
+  from any of this, and the corpus is a compile-time constant.
+- **Encryption of the fixture store.** Redb is ACID and crash-safe. It is not
+  encrypted and not authenticated, so even synthetic plaintext persistence
+  generalises to nothing about founder data.
+
+## The conjunctive gates that remain
+
+RFC 0006 lists these as gates that must **all** be complete before product
+use, not alternatives: Program 1B1 clean-machine recovery qualification,
+Program 1C1 identity and role-key custody, Program 1D `ActiveV2`, and a
+protected-payload review. None is addressed here.

--- a/scripts/check-owner-effect-documentation.sh
+++ b/scripts/check-owner-effect-documentation.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# The documents must not claim more than the fixture demonstrates.
+#
+# Code gates catch code. This catches the other way the boundary erodes:
+# somebody summarises the work in a sentence that is nearly right, the
+# sentence gets quoted, and six months later a decision rests on it.
+#
+# Two halves, and both are needed. Forbidding overstatement alone would pass a
+# document that simply stopped mentioning the limit; requiring the limit alone
+# would pass one that stated it and then contradicted itself.
+#
+# The forbidden phrases are affirmative constructions that cannot appear in an
+# honest sentence. "is not owner admission" is fine and required; "is owner
+# admission" is not. That is why the patterns are this specific rather than a
+# ban on the words themselves — a ban on the words would make the honest
+# sentence unwritable, which is how a check ends up training people to say
+# less.
+#
+# Portability: bash 3.2 (stock macOS).
+set -euo pipefail
+
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 3 ] ||
+  { [ "${BASH_VERSINFO[0]}" -eq 3 ] && [ "${BASH_VERSINFO[1]}" -lt 2 ]; }; then
+  echo "unsupported bash: need 3.2 or newer, got ${BASH_VERSION:-non-bash shell}" >&2
+  exit 3
+fi
+
+QUALIFICATION="docs/security/synthetic-owner-exact-effect-fixture-qualification.md"
+MATRIX="docs/security/owner-auth-mechanism-matrix.md"
+RFC="rfcs/0006-synthetic-owner-session-exact-effect-fixture.md"
+
+completed=0
+on_exit() {
+  status=$?
+  if [ "$completed" -eq 0 ] && [ "$status" -eq 0 ]; then
+    echo "check-owner-effect-documentation: INCOMPLETE — exited before finishing" >&2
+    exit 1
+  fi
+}
+trap on_exit EXIT
+
+fail=0
+checked=0
+
+# Prose wraps, so a phrase that reads as one sentence is several lines in the
+# file. Every scan runs against the document with newlines collapsed to
+# spaces, or a required phrase would fail purely because of where it wrapped.
+normalised() { tr '\n' ' ' < "$1" | tr -s ' '; }
+
+scan() { # <file> <needle> -> 0 present, 1 absent, aborts on scanner error
+  if normalised "$1" | grep -Fqi -- "$2"; then
+    return 0
+  fi
+  status=$?
+  if [ "$status" -ge 2 ]; then
+    echo "check-owner-effect-documentation: scanner error on '$2'" >&2
+    exit 2
+  fi
+  return 1
+}
+
+# An honest sentence can contain an affirmative phrase — "no row here is owner
+# admission" is exactly the sentence this gate wants to see, and it contains
+# "is owner admission". Grep cannot read, so the rule is: the phrase is only a
+# failure in a sentence with no negator in it.
+#
+# This is a heuristic and is stated as one. It would miss "this is owner
+# admission, and nothing is not". It catches the way overstatement is actually
+# written, which is plainly and without qualification.
+claims_affirmatively() { # <file> <needle>
+  normalised "$1" |
+    tr '.' '\n' |
+    grep -Fi -- "$2" |
+    grep -qvEi 'not|never|no |cannot|nothing|neither'
+}
+
+require() { # <file> <needle>
+  checked=$((checked + 1))
+  if scan "$1" "$2"; then
+    echo "ok    $1 states: $2"
+  else
+    echo "FAIL  $1 must state: $2"
+    fail=1
+  fi
+}
+
+forbid_all() { # <needle> — no document anywhere may claim this affirmatively
+  checked=$((checked + 1))
+  found=""
+  for file in "$QUALIFICATION" "$MATRIX" "$RFC" README.md THREAT_MODEL.md ROADMAP.md; do
+    [ -f "$file" ] || continue
+    if claims_affirmatively "$file" "$1"; then
+      found="$found $file"
+    fi
+  done
+  if [ -n "$found" ]; then
+    echo "FAIL  claims '$1':$found"
+    fail=1
+  else
+    echo "ok    nothing claims: $1"
+  fi
+}
+
+for file in "$QUALIFICATION" "$MATRIX" "$RFC"; do
+  if [ ! -f "$file" ]; then
+    echo "check-owner-effect-documentation: missing $file; nothing was verified" >&2
+    exit 1
+  fi
+done
+
+# --- the limit must be stated, not merely not-contradicted -----------------
+echo "== the honest boundary is stated"
+require "$QUALIFICATION" "is not owner admission"
+require "$QUALIFICATION" "can win the empty-registry enrolment"
+require "$QUALIFICATION" "Obscurity is not admission"
+require "$QUALIFICATION" "connection authentication, not provenance"
+require "$QUALIFICATION" "accepted, not mitigated"
+require "$QUALIFICATION" "real-authenticator matrix is **empty**"
+require "$QUALIFICATION" "not encrypted and not authenticated"
+# The matrix's own words. Written to match the document rather than the
+# document rewritten to match the check: a gate that dictates phrasing makes
+# every document read like the gate.
+require "$MATRIX" "the mechanism is unqualified"
+require "$MATRIX" "Nothing may cite this document as evidence"
+
+# --- and no document may claim otherwise -----------------------------------
+echo "== no document overstates"
+forbid_all "is owner admission"
+forbid_all "provides owner admission"
+forbid_all "achieves owner admission"
+forbid_all "hostile native bootstrap is defeated"
+forbid_all "hostile-native bootstrap is defeated"
+forbid_all "prevents a same-account process"
+forbid_all "the mechanism is qualified"
+forbid_all "ready for product use"
+forbid_all "production ready"
+
+# --- and there is no status a later edit can flip --------------------------
+echo "== no activation transition"
+checked=$((checked + 1))
+if grep -Eqi '^\*\*?status:?\*\*?[[:space:]]*(qualified|active|enabled|production)' "$QUALIFICATION"; then
+  echo "FAIL  $QUALIFICATION carries a status that can be flipped to enable product use"
+  fail=1
+else
+  echo "ok    no flippable status field"
+fi
+
+echo
+if [ "$checked" -lt 18 ]; then
+  echo "check-owner-effect-documentation: only $checked checks ran" >&2
+  exit 1
+fi
+if [ "$fail" -ne 0 ]; then
+  echo "check-owner-effect-documentation: FAILED" >&2
+  exit 1
+fi
+
+completed=1
+echo "check-owner-effect-documentation: OK — $checked checks"

--- a/scripts/test_changed.sh
+++ b/scripts/test_changed.sh
@@ -175,6 +175,10 @@ if [ "${GATE_SELFTEST_RUNNING:-0}" != "1" ]; then
   # all of it in the release binary, and nothing about a normal day would show
   # it. This checks the artefact.
   run_step "owner-effect-boundary" ./scripts/check-owner-effect-boundary.sh
+  # Code gates catch code. This catches the other way the boundary erodes:
+  # a sentence that is nearly right gets quoted, and later a decision rests
+  # on it.
+  run_step "owner-effect-documentation" ./scripts/check-owner-effect-documentation.sh
 fi
 run_step "file-size" ./scripts/check-file-size.sh
 run_step "fmt" cargo fmt --all --check


### PR DESCRIPTION
The qualification document records what the fixture shows and, more carefully, **what it does not** — in one place, so neither has to be reconstructed later from commit messages by someone deciding whether to rely on it. It has **no status field and no transition**, because a document that could be edited to say "qualified" would eventually be edited to say it.

It leads with the limit rather than burying it, and names three things that look like they close the gap and do not:

- the hidden subcommand keeps the broker out of the product and is invocable by any local process in a fixture build — **obscurity is not admission**;
- the bootstrap key proves possession of what the parent generated, not *who* the parent is — **connection authentication, not provenance**;
- same-user-handle credential replacement is a denial of service a local process can inflict, **accepted as a residual rather than mitigated**.

## The gate is the other half

Code gates catch code. This catches the way a boundary actually erodes: somebody summarises the work in a sentence that is nearly right, the sentence gets quoted, and six months later a decision rests on it.

Both halves are needed. Forbidding overstatement alone would pass a document that simply **stopped mentioning** the limit; requiring the limit alone would pass one that stated it and then contradicted itself.

## Two problems writing it

**Prose wraps.** A phrase that reads as one sentence is several lines in the file, and a fixed-string scan misses it. Every scan now runs against the document with newlines collapsed.

**An honest sentence contains the affirmative phrase.** "no row here is owner admission" is exactly what this gate wants to see — and it contains "is owner admission". The gate now splits on sentences and only fails on one with no negator in it. That is a heuristic and says so: it would miss a deliberately contorted claim, and it catches the way overstatement is actually written, which is plainly and without qualification.

One check was rewritten to match the matrix's **own words**, rather than the matrix rewritten to match the check. A gate that dictates phrasing makes every document read like the gate.

Verified three ways: adding an overstatement, removing the limit, and adding a flippable status. Each was named.