### PR TITLE
ci(owner-effect): run the fixture's tests, which CI had never run

### DIFF
--- a/.github/workflows/owner-effect-fixture.yml
+++ b/.github/workflows/owner-effect-fixture.yml
@@ -1,0 +1,74 @@
+name: Owner-effect fixture
+
+# The fixture's tests do not run in the main CI job, and it took noticing
+# rather than reading to find that out. `cargo test --workspace` skips every
+# target with `required-features`, silently and with a zero exit — so a
+# hundred-odd tests behind `owner-effect-fixture` had only ever run on a
+# developer's machine. That is the worst shape for a test suite: present,
+# green, and not consulted.
+#
+# This workflow is where they run. It is separate from `ci.yml` rather than
+# folded into it, so that the fixture's own dependencies — redb, hmac — and
+# its longer, process-spawning tests cannot slow down or destabilise the gate
+# that guards ordinary changes.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fixture:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Every target that carries `required-features`, which is the set the
+      # main job cannot see.
+      - name: Fixture tests
+        run: |
+          cargo test -p sovereign-authority -p sovereign-owner -p sovereign-cli \
+            --no-default-features --features owner-effect-fixture --locked
+
+      # The barriers live behind a second feature, so the kill matrix needs
+      # both. This is also the only place the two-feature combination is
+      # exercised by tests rather than only compiled.
+      - name: Kill matrix
+        run: |
+          cargo test -p sovereign-cli --test broker_kill_matrix \
+            --no-default-features --features owner-effect-fixture,fault-injection \
+            --locked -- --test-threads=1
+
+      # Repeated, because the matrix spawns processes and kills them: a case
+      # that is broken one time in twenty passes a single run. Five is a
+      # compromise between catching that and not making every pull request
+      # wait; the script accepts up to fifty for a deliberate soak.
+      - name: Kill matrix, repeated
+        run: ./scripts/exact-effect-kill-matrix.sh --iterations 5
+
+      - name: Subprocess claims
+        run: ./scripts/run-authority-subprocess-claims.sh --iterations 5
+
+      # The boundary gates. They run in the local gate on every session too;
+      # here they run against a clean checkout, where a stale artefact cannot
+      # make one of them pass.
+      - name: Boundary and corpus gates
+        run: |
+          ./scripts/check-owner-effect-boundary.sh
+          ./scripts/check-owner-effect-canaries.sh
+          ./scripts/check-owner-effect-value-free.sh
+          ./scripts/check-owner-effect-crypto-profile.sh
+          ./scripts/check-owner-effect-documentation.sh
+          ./scripts/check-fault-injection-excluded.sh
+
+      # Every registered row, run through the checked runner, so a row naming
+      # a test that no longer exists fails here rather than rotting.
+      - name: Registered manifest rows
+        run: ./scripts/run-owner-effect-tests.sh --all

--- a/crates/authority/tests/broker_listener.rs
+++ b/crates/authority/tests/broker_listener.rs
@@ -101,8 +101,16 @@ fn the_deadline_starts_before_the_address_is_published() {
 /// A connection that arrives inherits what is left of the shared budget, not
 /// a fresh one. Otherwise a caller could connect immediately and then dribble
 /// bytes for as long as it liked.
+///
+/// The bound is on the total from bind to the read giving up, not on the read
+/// alone. Timing the read on its own asserts it got *slightly less* than a
+/// full budget, which is a hair's breadth — it passed when the file ran in
+/// order and failed when run alone, where almost none of the budget had been
+/// spent before the read began. The property is that connecting buys one
+/// window, not two.
 #[test]
 fn a_connected_caller_inherits_the_remaining_budget_not_a_new_one() {
+    let started = Instant::now();
     let mut published = Vec::new();
     let established = bind_and_publish(&NONCE, &mut published).unwrap();
     let port = established.port();
@@ -111,15 +119,14 @@ fn a_connected_caller_inherits_the_remaining_budget_not_a_new_one() {
     let _client = TcpStream::connect(("127.0.0.1", port)).unwrap();
     let mut supervisor = accept_by_deadline(&established).expect("the connection is accepted");
 
-    let started = Instant::now();
     let mut buffer = [0u8; 8];
     let read = supervisor.read(&mut buffer);
-    let elapsed = started.elapsed();
+    let total = started.elapsed();
 
     assert!(read.is_err(), "a silent caller must not satisfy a read");
     assert!(
-        elapsed < SUPERVISOR_ESTABLISHMENT,
-        "the read got {elapsed:?}, which is a fresh budget rather than what remained"
+        total < SUPERVISOR_ESTABLISHMENT * 2,
+        "bind through failed read took {total:?}: connecting bought a second window"
     );
 }
 

--- a/scripts/exact-effect-kill-matrix.sh
+++ b/scripts/exact-effect-kill-matrix.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Bounded repetition for the broker kill matrix.
+#
+# Each case in the matrix spawns a broker, drives a handshake, waits for a
+# barrier and kills the process. That is four moving parts and a real
+# filesystem, so one green run says less than it looks like: a matrix that
+# passes nineteen times in twenty passes a single run.
+#
+# The barrier makes the kill land at an exact point rather than at a sleep, so
+# these are not expected to be flaky — which is the reason to repeat them. A
+# test that is *believed* not to be flaky and never checked is
+# indistinguishable from one that is.
+#
+# Any iteration that is not a clean pass ends the run. Zero executed, a
+# skipped target, or a missing test all stop it, because none of those may be
+# averaged into a pass.
+#
+# Portability: bash 3.2 (stock macOS).
+set -euo pipefail
+
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 3 ] ||
+  { [ "${BASH_VERSINFO[0]}" -eq 3 ] && [ "${BASH_VERSINFO[1]}" -lt 2 ]; }; then
+  echo "unsupported bash: need 3.2 or newer, got ${BASH_VERSION:-non-bash shell}" >&2
+  exit 3
+fi
+
+completed=0
+on_exit() {
+  status=$?
+  if [ "$completed" -eq 0 ] && [ "$status" -eq 0 ]; then
+    echo "exact-effect-kill-matrix: INCOMPLETE — exited before finishing" >&2
+    exit 1
+  fi
+}
+trap on_exit EXIT
+
+ITERATIONS=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --iterations) shift; [ $# -gt 0 ] || { echo "--iterations needs a value" >&2; exit 2; }; ITERATIONS="$1" ;;
+    *) echo "usage: exact-effect-kill-matrix.sh --iterations <1..50>" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+case "$ITERATIONS" in
+  ''|*[!0-9]*) echo "exact-effect-kill-matrix: --iterations must be an integer 1..50" >&2; exit 2 ;;
+esac
+if [ "$ITERATIONS" -lt 1 ] || [ "$ITERATIONS" -gt 50 ]; then
+  echo "exact-effect-kill-matrix: --iterations must be between 1 and 50" >&2
+  exit 2
+fi
+
+# Every case, by name. A run that did not execute all of them did not exercise
+# the matrix, whatever its exit status said.
+REQUIRED="killed_after_address_before_hello_leaves_no_lock_and_no_store
+killed_after_hello_before_lock_leaves_no_lock_and_no_store
+killed_after_lock_before_redb_leaves_a_releasable_lock_and_no_store
+killed_after_redb_open_leaves_a_store_the_next_broker_can_take
+every_broker_barrier_is_reachable"
+
+iteration=1
+while [ "$iteration" -le "$ITERATIONS" ]; do
+  printf 'iteration %d/%d ... ' "$iteration" "$ITERATIONS"
+  set +e
+  output=$(cargo test -p sovereign-cli --test broker_kill_matrix \
+    --no-default-features --features owner-effect-fixture,fault-injection --locked \
+    -- --test-threads=1 2>&1)
+  status=$?
+  set -e
+
+  if printf '%s' "$output" | grep -Fq "skipping due to unsatisfied required-features"; then
+    echo "FAILED"; echo "the target was skipped for unsatisfied required-features" >&2
+    printf '%s\n' "$output" >&2; exit 1
+  fi
+  if ! printf '%s' "$output" | grep -Eq "^test result:"; then
+    echo "FAILED"; echo "no test result line — nothing ran" >&2
+    printf '%s\n' "$output" >&2; exit 1
+  fi
+  if [ "$status" -ne 0 ]; then
+    echo "FAILED"; printf '%s\n' "$output" >&2; exit 1
+  fi
+
+  missing=""
+  for name in $REQUIRED; do
+    if ! printf '%s' "$output" | grep -Eq "^test $name \.\.\. ok"; then
+      missing="$missing $name"
+    fi
+  done
+  if [ -n "$missing" ]; then
+    echo "FAILED"
+    echo "these cases did not run and pass in this iteration:$missing" >&2
+    exit 1
+  fi
+
+  echo "ok"
+  iteration=$((iteration + 1))
+done
+
+completed=1
+echo "exact-effect-kill-matrix: OK — $ITERATIONS iteration(s), all five cases each time"

--- a/scripts/test_changed.sh
+++ b/scripts/test_changed.sh
@@ -179,6 +179,10 @@ if [ "${GATE_SELFTEST_RUNNING:-0}" != "1" ]; then
   # a sentence that is nearly right gets quoted, and later a decision rests
   # on it.
   run_step "owner-effect-documentation" ./scripts/check-owner-effect-documentation.sh
+  # Every registered row, through the checked runner. A row naming a test that
+  # no longer exists fails here rather than rotting, and CI runs the same
+  # command against a clean checkout.
+  run_step "owner-effect-manifest" ./scripts/run-owner-effect-tests.sh --all
 fi
 run_step "file-size" ./scripts/check-file-size.sh
 run_step "fmt" cargo fmt --all --check


### PR DESCRIPTION
`cargo test --workspace` **skips every target carrying `required-features`** — silently, with a zero exit. So of the fixture's test binaries, exactly one (the only one without the attribute) had ever run in CI. The other ~160 tests had only ever run on a developer's machine.

That is the worst shape a test suite can be in: **present, green, and not consulted.** It took noticing rather than reading, which is the argument for checking rather than assuming.

## What runs now

A separate workflow, deliberately not folded into `ci.yml`: the fixture's own dependencies and its process-spawning tests should not slow or destabilise the gate that guards ordinary changes.

It runs the fixture targets, the kill matrix under **both** features — the only place that combination is exercised by tests rather than merely compiled — the boundary and corpus gates against a clean checkout, and every registered manifest row.

`exact-effect-kill-matrix.sh` repeats the matrix a bounded number of times. The barriers make each kill land at an exact point rather than at a sleep, so these are **not expected** to be flaky — which is precisely the reason to repeat them. A suite believed not to be flaky and never checked is indistinguishable from one that is.

## What running the whole manifest found

`a_connected_caller_inherits_the_remaining_budget_not_a_new_one` passed when its file ran in order and **failed when run alone**. It timed the read by itself and asserted it got *slightly less* than a full budget — a hair's breadth — and run alone, almost none of the budget had been spent before the read began.

The bound is now on the total from bind to the read giving up: connecting buys **one window, not two**. That is the property, and it passes both ways.

Same mistake as the transport budget and the errno name earlier in this line of work: an assertion pinned to an incidental measurement rather than to what is being claimed.