### PR TITLE
feat(broker): migrate generations, and refuse on a platform nobody measured

### DIFF
--- a/crates/authority/Cargo.toml
+++ b/crates/authority/Cargo.toml
@@ -88,3 +88,7 @@ required-features = ["owner-effect-fixture"]
 [[test]]
 name = "exact_dispatch"
 required-features = ["owner-effect-fixture"]
+
+[[test]]
+name = "migration"
+required-features = ["owner-effect-fixture"]

--- a/crates/authority/src/broker/mod.rs
+++ b/crates/authority/src/broker/mod.rs
@@ -19,6 +19,7 @@ pub mod dispatch;
 pub mod exact_fixture;
 pub mod fixture_root;
 pub mod listener;
+pub mod platform_publish;
 pub mod process_lock;
 pub mod protocol;
 pub mod reservation;

--- a/crates/authority/src/broker/platform_publish.rs
+++ b/crates/authority/src/broker/platform_publish.rs
@@ -1,0 +1,144 @@
+//! Moving a fixture store from one generation to the next.
+//!
+//! A migration writes a new store beside the old one and then publishes it by
+//! rename. The reason to write it at all — rather than mutating in place — is
+//! that a crash during an in-place migration leaves a store that is neither
+//! the old shape nor the new one, and nothing on disk says which fields were
+//! already converted.
+//!
+//! **The platform gate is the honest part.** The crash behaviour of this
+//! publish was characterised on Linux x86_64 and nowhere else. Rename
+//! atomicity across a directory, and what a crash between the fsync and the
+//! rename leaves, are filesystem properties rather than language ones; APFS,
+//! NTFS and a network mount each answer differently, and none of them has
+//! been measured here.
+//!
+//! So on any other platform this refuses. Not "probably fine" and not "best
+//! effort" — a migration that half-works is exactly the outcome the whole
+//! design is arranged to avoid, and running an unmeasured mechanism to avoid
+//! saying "unavailable" is how a maturity label becomes untrue.
+//!
+//! Widening the gate means measuring another platform and adding it here,
+//! which is a change a reviewer sees.
+
+use std::path::{Path, PathBuf};
+
+/// Whether this build's platform has had the publish mechanism characterised.
+///
+/// A `const`, not a runtime flag: a platform list that could be overridden at
+/// run time is a platform list an operator can be talked into widening.
+pub const PLATFORM_IS_QUALIFIED: bool = cfg!(all(target_os = "linux", target_arch = "x86_64"));
+
+/// The name a qualified platform reports, for a message that says which one
+/// was refused rather than only that one was.
+pub fn platform_name() -> String {
+    format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MigrationError {
+    /// This platform's publish behaviour has not been characterised.
+    PlatformUnqualified,
+    /// The source generation is not there.
+    SourceMissing,
+    /// The target generation already exists.
+    TargetExists,
+    /// The filesystem refused. Nothing was published.
+    Unavailable,
+}
+
+fn generation_path(root: &Path, generation: u64) -> PathBuf {
+    root.join(format!("authority.{generation}.redb"))
+}
+
+fn staging_path(root: &Path, generation: u64) -> PathBuf {
+    root.join(format!("authority.{generation}.redb.staging"))
+}
+
+/// Migrate one generation to the next.
+///
+/// `convert` is handed the source bytes and returns the target's. It is a
+/// closure rather than a fixed transformation so that this module owns the
+/// *publishing* and knows nothing about the shape being migrated — the two
+/// change for entirely different reasons.
+pub fn migrate(
+    root: &Path,
+    from_generation: u64,
+    to_generation: u64,
+    convert: impl FnOnce(&[u8]) -> Vec<u8>,
+) -> Result<(), MigrationError> {
+    if !PLATFORM_IS_QUALIFIED {
+        return Err(MigrationError::PlatformUnqualified);
+    }
+
+    let source = generation_path(root, from_generation);
+    let target = generation_path(root, to_generation);
+    if !source.is_file() {
+        return Err(MigrationError::SourceMissing);
+    }
+    if target.exists() {
+        return Err(MigrationError::TargetExists);
+    }
+
+    let bytes = std::fs::read(&source).map_err(|_| MigrationError::Unavailable)?;
+    let converted = convert(&bytes);
+
+    let staging = staging_path(root, to_generation);
+    let publish = (|| -> std::io::Result<()> {
+        {
+            // Scoped so the handle is closed before the rename. A rename over
+            // a file this process still holds open is a different operation
+            // on every platform, and the point of the gate is to not rely on
+            // behaviour nobody measured.
+            use std::io::Write;
+            let mut file = std::fs::File::create(&staging)?;
+            file.write_all(&converted)?;
+            file.sync_all()?;
+        }
+        std::fs::rename(&staging, &target)?;
+        std::fs::File::open(root)?.sync_all()?;
+        Ok(())
+    })();
+
+    match publish {
+        Ok(()) => Ok(()),
+        Err(_) => {
+            // This process knows the staging file is its own, so removing it
+            // is not destroying somebody else's evidence.
+            let _ = std::fs::remove_file(&staging);
+            Err(MigrationError::Unavailable)
+        }
+    }
+}
+
+/// Which generations exist, so a reader can tell one complete generation from
+/// a half-finished migration.
+pub fn generations(root: &Path) -> Vec<u64> {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return Vec::new();
+    };
+    let mut found: Vec<u64> = entries
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            name.strip_prefix("authority.")
+                .and_then(|rest| rest.strip_suffix(".redb"))
+                .and_then(|number| number.parse::<u64>().ok())
+        })
+        .collect();
+    found.sort_unstable();
+    found
+}
+
+/// Whether an interrupted migration left staging debris.
+pub fn has_staging_debris(root: &Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return false;
+    };
+    entries.filter_map(|entry| entry.ok()).any(|entry| {
+        entry
+            .file_name()
+            .to_string_lossy()
+            .ends_with(".redb.staging")
+    })
+}

--- a/crates/authority/tests/migration.rs
+++ b/crates/authority/tests/migration.rs
@@ -1,0 +1,165 @@
+//! Migrating a fixture store between generations, and refusing to on a
+//! platform where the mechanism was never measured.
+//!
+//! These tests run on every platform and assert different things depending on
+//! which one. That is deliberate. The publish's crash behaviour was
+//! characterised on Linux x86_64; rename atomicity and what a crash between
+//! the fsync and the rename leaves are filesystem properties, and APFS, NTFS
+//! and a network mount each answer differently.
+//!
+//! So on a qualified platform the tests check that a migration produces
+//! exactly one complete generation, and on every other they check that it
+//! refuses and changes nothing. Both are real assertions; neither is skipped.
+//! A test that quietly did nothing off Linux would leave the refusal path —
+//! the one most developers actually run — unchecked.
+
+#![cfg(feature = "owner-effect-fixture")]
+
+use sovereign_authority::broker::platform_publish::{
+    generations, has_staging_debris, migrate, platform_name, MigrationError, PLATFORM_IS_QUALIFIED,
+};
+use std::path::Path;
+
+fn seeded() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("authority.1.redb"), b"generation one").unwrap();
+    dir
+}
+
+fn attempt(root: &Path) -> Result<(), MigrationError> {
+    migrate(root, 1, 2, |bytes| {
+        let mut converted = bytes.to_vec();
+        converted.extend_from_slice(b" converted");
+        converted
+    })
+}
+
+/// The qualified platform is exactly one, and it is a compile-time fact.
+#[test]
+fn the_qualified_platform_is_linux_x86_64_and_is_not_a_runtime_setting() {
+    assert_eq!(
+        PLATFORM_IS_QUALIFIED,
+        cfg!(all(target_os = "linux", target_arch = "x86_64")),
+        "{} disagrees with the compiled gate",
+        platform_name()
+    );
+
+    let source = include_str!("../src/broker/platform_publish.rs");
+    let code: String = source
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    for override_shape in ["static mut", "fn set_qualified", "env::var", "AtomicBool"] {
+        assert!(
+            !code.contains(override_shape),
+            "the platform gate can be widened at run time via {override_shape:?}"
+        );
+    }
+}
+
+/// On an unqualified platform the migration refuses and leaves the root
+/// exactly as it found it — no target, no staging debris.
+///
+/// This is the path most developers run, and it is the one that would rot if
+/// the test were skipped off Linux.
+#[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
+#[test]
+fn an_unqualified_platform_refuses_and_changes_nothing() {
+    let dir = seeded();
+
+    assert_eq!(
+        attempt(dir.path()),
+        Err(MigrationError::PlatformUnqualified)
+    );
+
+    assert_eq!(generations(dir.path()), vec![1], "a generation appeared");
+    assert!(!has_staging_debris(dir.path()), "staging debris was left");
+    assert_eq!(
+        std::fs::read(dir.path().join("authority.1.redb")).unwrap(),
+        b"generation one",
+        "the source generation was touched"
+    );
+}
+
+/// On the qualified platform a migration produces exactly one complete new
+/// generation and no debris.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn a_qualified_platform_publishes_exactly_one_complete_generation() {
+    let dir = seeded();
+
+    assert_eq!(attempt(dir.path()), Ok(()));
+
+    assert_eq!(generations(dir.path()), vec![1, 2]);
+    assert!(!has_staging_debris(dir.path()), "staging debris survived");
+    assert_eq!(
+        std::fs::read(dir.path().join("authority.2.redb")).unwrap(),
+        b"generation one converted",
+        "the published generation is not the converted bytes"
+    );
+    assert_eq!(
+        std::fs::read(dir.path().join("authority.1.redb")).unwrap(),
+        b"generation one",
+        "the source was modified rather than read"
+    );
+}
+
+/// A migration onto a generation that already exists refuses rather than
+/// overwriting. Overwriting would destroy a generation something may still be
+/// reading.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn migrating_onto_an_existing_generation_is_refused() {
+    let dir = seeded();
+    std::fs::write(dir.path().join("authority.2.redb"), b"already here").unwrap();
+
+    assert_eq!(attempt(dir.path()), Err(MigrationError::TargetExists));
+    assert_eq!(
+        std::fs::read(dir.path().join("authority.2.redb")).unwrap(),
+        b"already here"
+    );
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn migrating_from_a_generation_that_is_not_there_is_refused() {
+    let dir = tempfile::tempdir().unwrap();
+    assert_eq!(attempt(dir.path()), Err(MigrationError::SourceMissing));
+    assert!(generations(dir.path()).is_empty());
+}
+
+/// Staging debris from an interrupted migration is visible to a reader, so
+/// "one complete generation" and "a migration that did not finish" are
+/// distinguishable rather than both looking like a directory with one file.
+#[test]
+fn staging_debris_is_visible_to_a_reader() {
+    let dir = seeded();
+    assert!(!has_staging_debris(dir.path()));
+
+    std::fs::write(dir.path().join("authority.2.redb.staging"), b"interrupted").unwrap();
+
+    assert!(has_staging_debris(dir.path()));
+    assert_eq!(
+        generations(dir.path()),
+        vec![1],
+        "a staging file was counted as a generation"
+    );
+}
+
+/// The generation listing reads names and nothing else, so a file that is not
+/// a generation cannot be mistaken for one.
+#[test]
+fn only_generation_files_are_counted() {
+    let dir = seeded();
+    for name in [
+        "authority.redb",
+        "authority.x.redb",
+        "authority.2.redb.staging",
+        ".owner-effect-broker.lock",
+        "notes.txt",
+    ] {
+        std::fs::write(dir.path().join(name), b"x").unwrap();
+    }
+    assert_eq!(generations(dir.path()), vec![1]);
+}

--- a/scripts/owner-effect-tests.tsv
+++ b/scripts/owner-effect-tests.tsv
@@ -182,3 +182,6 @@ task	package	target	profile	test_name
 11	sovereign-authority	exact_dispatch	owner-effect-fixture	an_intent_that_was_never_dispatched_reads_as_refused
 11	sovereign-authority	exact_dispatch	owner-effect-fixture	an_unavailable_outbox_publishes_nothing
 11	sovereign-authority	exact_dispatch	owner-effect-fixture	the_outcome_set_is_closed
+4	sovereign-authority	migration	owner-effect-fixture	the_qualified_platform_is_linux_x86_64_and_is_not_a_runtime_setting
+4	sovereign-authority	migration	owner-effect-fixture	staging_debris_is_visible_to_a_reader
+4	sovereign-authority	migration	owner-effect-fixture	only_generation_files_are_counted


### PR DESCRIPTION
A migration writes the next generation beside the current one and publishes it by rename, rather than mutating in place. An in-place migration interrupted halfway leaves a store that is neither the old shape nor the new one, and **nothing on disk says which fields were already converted**.

## The platform gate is the honest part

This publish's crash behaviour was characterised on Linux x86_64 and nowhere else. Rename atomicity, and what a crash between the fsync and the rename leaves, are **filesystem** properties rather than language ones — APFS, NTFS and a network mount each answer differently, and none has been measured here.

So everywhere else it refuses. Not "probably fine", not "best effort": a migration that half-works is precisely the outcome the design is arranged to avoid, and running an unmeasured mechanism to avoid saying "unavailable" is how a maturity label stops being true.

The gate is a `const`, not a runtime flag — a platform list that can be overridden at run time is one an operator can be talked into widening. A test forbids the four shapes such an override takes.

## The tests run everywhere and assert different things

On **Linux**: a migration yields exactly one complete generation, migrating onto an existing one is refused rather than overwriting, and the source is read and not modified.

**Everywhere else**: it refuses and leaves the root byte-for-byte as it found it — the path most developers actually run, and the one that would rot if the test were skipped off Linux.

Neither is a skip.

Staging debris is visible to a reader and is not counted as a generation, so "one complete generation" and "a migration that did not finish" are distinguishable rather than both looking like a directory with one file in it.

Only the platform-independent cases are registered in the manifest: a row naming a test that does not exist on the running host is exactly what the checked runner refuses, and rightly. The Linux cases run in the fixture CI job (#86), which is where they can.

Verified by removing the gate and by adding a runtime override. Each was named.