### PR TITLE
feat(capability): consume approved tokens through the bundle transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,6 +1459,7 @@ dependencies = [
  "sovereign-artifact",
  "sovereign-authority",
  "sovereign-contracts",
+ "sovereign-fault-testing",
  "sovereign-identity",
  "sovereign-policy",
  "tempfile",

--- a/crates/authority/src/lib.rs
+++ b/crates/authority/src/lib.rs
@@ -79,6 +79,13 @@ const BUNDLE_DOMAIN: &[u8] = b"sovereign:authority-bundle:v1";
 pub enum AuthorityError {
     #[error("authority was already consumed")]
     AlreadyConsumed,
+    /// The bundle's approval is held by a different bundle. Distinct from
+    /// `AlreadyConsumed` because a bundle reports one outcome for six steps,
+    /// and a caller holding a fresh token and a spent approval needs to be
+    /// told which of the two it is holding — "try a new token" is the wrong
+    /// advice when the approval is what was used.
+    #[error("approval was already consumed by another bundle")]
+    ApprovalAlreadyConsumed,
     #[error("idempotency key was already consumed for the same invocation")]
     IdempotencyReplay,
     #[error("idempotency key was consumed for a different invocation")]
@@ -292,7 +299,8 @@ impl AuthorityStore {
     /// means this call observed the one `Authorized` outcome for the
     /// bundle — a durable `.committed` marker. Every other outcome,
     /// including a retry of a bundle someone else already committed, is
-    /// `AlreadyConsumed`, `Revoked`, a replay/conflict error, or
+    /// `AlreadyConsumed` (the token, or the commit itself),
+    /// `ApprovalAlreadyConsumed`, `Revoked`, a replay/conflict error, or
     /// `CorruptRecord`.
     pub fn consume_bundle(
         &self,
@@ -461,7 +469,7 @@ impl AuthorityStore {
                 if existing.bundle_hex.as_deref() == Some(bundle_hex) {
                     Ok(())
                 } else {
-                    Err(AuthorityError::AlreadyConsumed)
+                    Err(AuthorityError::ApprovalAlreadyConsumed)
                 }
             }
             Err(ClaimError::Store(error)) => Err(error),

--- a/crates/capability/Cargo.toml
+++ b/crates/capability/Cargo.toml
@@ -21,4 +21,5 @@ thiserror = { workspace = true }
 serde_json_canonicalizer = { workspace = true }
 
 [dev-dependencies]
+sovereign-fault-testing = { path = "../fault-testing" }
 tempfile = "3"

--- a/crates/capability/src/v2.rs
+++ b/crates/capability/src/v2.rs
@@ -19,7 +19,7 @@ use sovereign_artifact::{
 use sovereign_identity::{ApprovalRole, AuthorityRole, IdentityError, RoleTrustStore, TypedSigner};
 use sovereign_policy::PolicyAuthorizationV2;
 
-use sovereign_authority::{AuthorityError, AuthorityStore};
+use sovereign_authority::{AuthorityError, AuthorityStore, BundlePart};
 
 use crate::approval::SignedApprovalV1;
 use thiserror::Error;
@@ -278,6 +278,12 @@ pub enum CapabilityV2Error {
     ApprovalFromFuture,
     #[error("approval was already consumed in this process")]
     ApprovalReused,
+    /// The token or the approval carries a durable revocation record. Distinct
+    /// from `Replay`: a replay is something spent by a legitimate earlier use,
+    /// a revocation is something the owner withdrew — and a caller that cannot
+    /// tell them apart cannot tell "try a fresh token" from "stop".
+    #[error("the token or its approval has been revoked")]
+    Revoked,
     #[error("approval evidence in the token does not match the presented approval")]
     ApprovalEvidenceMismatch,
     #[error("approval signing key is not trusted")]
@@ -527,6 +533,10 @@ pub struct CapabilityValidatorV2<C: TrustedClock> {
     expected_issuer: String,
     expected_audience: String,
     clock: C,
+    // The process-local mirrors below are not the durable record and do not
+    // pretend to be. With a store attached, the bundle transaction is what
+    // decides; these remain as the only defence when no store is attached at
+    // all, and as a cheap early refusal before a store round-trip.
     consumed_tokens: HashSet<Uuid>,
     idempotency: HashMap<Uuid, Digest>,
     approvals: Option<ApprovalTrust>,
@@ -748,24 +758,63 @@ impl<C: TrustedClock> CapabilityValidatorV2<C> {
         }
 
         // Durable claims come after every validation and before the
-        // process-local bookkeeping. A partial failure burns the earlier
-        // claims and denies the request: fail closed, never fail open.
+        // process-local bookkeeping.
+        //
+        // With an approval present, all three claims — token, idempotency,
+        // approval — go through one bundle transaction (RFC 0003 Amendment 1).
+        // The claims are made under one durable intent, so a bundle that
+        // stops part-way — a crash, a store that went away — is retried as
+        // the same bundle and resumes where it stopped, rather than finding
+        // its own token already spent. The previous shape made the three
+        // claims in sequence with no intent record, so a failure on the third
+        // burned the first two for good on a request that was then denied.
+        // Both shapes fail closed; only the old one was also lossy.
+        //
+        // Revocation is checked inside the bundle, before any claim, and
+        // surfaces as its own error rather than as a replay.
         if let Some(store) = &self.authority_store {
-            store
-                .consume_token(claims.token_id, now_unix, claims.expires_at_unix)
-                .map_err(map_authority_error_token)?;
-            store
-                .bind_idempotency(
-                    claims.idempotency_key,
-                    fingerprint.as_bytes(),
-                    now_unix,
-                    claims.expires_at_unix,
-                )
-                .map_err(map_authority_error_idempotency)?;
-            if let Some((approval_id, approval_expires_at_unix)) = approval_claim {
-                store
-                    .consume_approval(approval_id, now_unix, approval_expires_at_unix)
-                    .map_err(map_authority_error_approval)?;
+            match approval_claim {
+                Some((approval_id, approval_expires_at_unix)) => {
+                    store
+                        .consume_bundle(
+                            BundlePart {
+                                id: claims.token_id,
+                                expires_at_unix: claims.expires_at_unix,
+                            },
+                            BundlePart {
+                                id: approval_id,
+                                expires_at_unix: approval_expires_at_unix,
+                            },
+                            BundlePart {
+                                id: claims.idempotency_key,
+                                expires_at_unix: claims.expires_at_unix,
+                            },
+                            fingerprint.as_bytes(),
+                            now_unix,
+                        )
+                        .map_err(map_authority_error_bundle)?;
+                }
+                None => {
+                    // No approval, so no bundle: the authority store offers
+                    // the transaction only for the three-part case. This
+                    // path keeps two sequential claims, and keeps the old
+                    // defect with them — an idempotency failure after the
+                    // token was consumed burns that token. It is the
+                    // no-approval path, so nothing a person authorised is
+                    // lost, but it is a gap and is named as one rather than
+                    // hidden behind the bundle above.
+                    store
+                        .consume_token(claims.token_id, now_unix, claims.expires_at_unix)
+                        .map_err(map_authority_error_token)?;
+                    store
+                        .bind_idempotency(
+                            claims.idempotency_key,
+                            fingerprint.as_bytes(),
+                            now_unix,
+                            claims.expires_at_unix,
+                        )
+                        .map_err(map_authority_error_idempotency)?;
+                }
             }
         }
 
@@ -1073,9 +1122,24 @@ fn compare_invocation_claims(
     Ok(())
 }
 
+/// The bundle reports one outcome for the whole transaction. `AlreadyConsumed`
+/// is the bundle's word for "another caller committed this bundle first",
+/// which from this side is a replay; `Revoked` is its own thing and stays so.
+fn map_authority_error_bundle(error: AuthorityError) -> CapabilityV2Error {
+    match error {
+        AuthorityError::Revoked => CapabilityV2Error::Revoked,
+        AuthorityError::AlreadyConsumed => CapabilityV2Error::Replay,
+        AuthorityError::ApprovalAlreadyConsumed => CapabilityV2Error::ApprovalReused,
+        AuthorityError::IdempotencyReplay => CapabilityV2Error::IdempotencyReplay,
+        AuthorityError::IdempotencyConflict => CapabilityV2Error::IdempotencyConflict,
+        _ => CapabilityV2Error::AuthorityStoreUnavailable,
+    }
+}
+
 fn map_authority_error_token(error: AuthorityError) -> CapabilityV2Error {
     match error {
         AuthorityError::AlreadyConsumed => CapabilityV2Error::Replay,
+        AuthorityError::Revoked => CapabilityV2Error::Revoked,
         _ => CapabilityV2Error::AuthorityStoreUnavailable,
     }
 }
@@ -1084,13 +1148,6 @@ fn map_authority_error_idempotency(error: AuthorityError) -> CapabilityV2Error {
     match error {
         AuthorityError::IdempotencyReplay => CapabilityV2Error::IdempotencyReplay,
         AuthorityError::IdempotencyConflict => CapabilityV2Error::IdempotencyConflict,
-        _ => CapabilityV2Error::AuthorityStoreUnavailable,
-    }
-}
-
-fn map_authority_error_approval(error: AuthorityError) -> CapabilityV2Error {
-    match error {
-        AuthorityError::AlreadyConsumed => CapabilityV2Error::ApprovalReused,
         _ => CapabilityV2Error::AuthorityStoreUnavailable,
     }
 }

--- a/crates/capability/tests/approval_v2.rs
+++ b/crates/capability/tests/approval_v2.rs
@@ -16,6 +16,7 @@ use sovereign_capability::v2::{
     CapabilityV2IssueRequest, CapabilityV2ValidationContext, CapabilityValidatorV2, TrustedClock,
 };
 use sovereign_contracts::{AutomationLevel, DataClass};
+use sovereign_fault_testing::BlockedPath;
 use sovereign_identity::{
     ApprovalRole, AuthorityRole, KeyValidity, PublisherRole, RoleTrustStore, TypedSigner,
 };
@@ -632,7 +633,9 @@ fn expired_approval_purges_at_approval_expiry() {
     let store = sovereign_authority::AuthorityStore::open(dir.path()).unwrap();
     assert_eq!(store.purge_expired(NOW + 31).unwrap(), 2);
     assert_eq!(store.purge_expired(NOW + 119).unwrap(), 0);
-    assert_eq!(store.purge_expired(NOW + 120).unwrap(), 1);
+    // Three, not one: the approval record, and the bundle's intent and
+    // commit records, which expire with the bundle's longest-lived part.
+    assert_eq!(store.purge_expired(NOW + 120).unwrap(), 3);
 }
 
 #[test]
@@ -807,5 +810,153 @@ fn broken_authority_store_fails_closed() {
     assert_eq!(
         consume(&mut validator, &token, &invocation, &policy_decision, None).unwrap_err(),
         CapabilityV2Error::AuthorityStoreUnavailable
+    );
+}
+
+/// The token is opaque until it is authorized, and the issuer mints its id.
+/// To learn the id without spending anything durable, authorize once through
+/// a throwaway validator with no store attached: its process-local mirror is
+/// the only thing that records the use, and it is dropped here.
+fn minted_ids(
+    token: &CapabilityTokenV2,
+    invocation: &PreparedInvocation,
+    policy_decision: &PolicyAuthorizationV2,
+    approval: &SignedApprovalV1,
+) -> (Uuid, Uuid, i64) {
+    let authorized = validator_at(NOW + 1)
+        .authorize_and_consume_approved(token, context(invocation, policy_decision), Some(approval))
+        .unwrap();
+    let claims = authorized.claims();
+    let approval_id = claims
+        .approval_evidence
+        .as_ref()
+        .expect("an approved token carries its approval's id")
+        .approval_id;
+    (claims.token_id, approval_id, claims.expires_at_unix)
+}
+
+/// A revoked token is refused as revoked, not as a replay. The difference is
+/// advice: a replay says "this token was spent, get a fresh one", a
+/// revocation says "the owner withdrew this, stop" — and a caller that cannot
+/// tell them apart hands out the wrong one.
+#[test]
+fn a_revoked_token_is_refused_as_revoked_not_as_a_replay() {
+    let dir = tempfile::tempdir().unwrap();
+    let invocation = prepared("revoked token");
+    let idempotency = Uuid::from_u128(40);
+    let policy_decision = decision(&invocation, AutomationLevel::L3BoundedAuto, idempotency);
+    let approval = approve_at(NOW, &invocation, &policy_decision, 120);
+    let token = issuer_at(NOW)
+        .issue_approved(
+            request_with_ttl(&invocation, &policy_decision, idempotency, 30),
+            &approval,
+        )
+        .unwrap();
+
+    let (token_id, _, expires_at_unix) =
+        minted_ids(&token, &invocation, &policy_decision, &approval);
+    let store = sovereign_authority::AuthorityStore::open(dir.path()).unwrap();
+    store
+        .revoke_token(token_id, NOW + 1, expires_at_unix)
+        .unwrap();
+
+    let mut validator = validator_at(NOW + 1).with_authority_store(store);
+    assert_eq!(
+        consume(
+            &mut validator,
+            &token,
+            &invocation,
+            &policy_decision,
+            Some(&approval),
+        ),
+        Err(CapabilityV2Error::Revoked)
+    );
+}
+
+/// The approval side of the same distinction. The token is fresh and
+/// unspent; what was withdrawn is the person's approval behind it.
+#[test]
+fn a_revoked_approval_is_refused_as_revoked() {
+    let dir = tempfile::tempdir().unwrap();
+    let invocation = prepared("revoked approval");
+    let idempotency = Uuid::from_u128(41);
+    let policy_decision = decision(&invocation, AutomationLevel::L3BoundedAuto, idempotency);
+    let approval = approve_at(NOW, &invocation, &policy_decision, 120);
+    let token = issuer_at(NOW)
+        .issue_approved(
+            request_with_ttl(&invocation, &policy_decision, idempotency, 30),
+            &approval,
+        )
+        .unwrap();
+    let (_, approval_id, _) = minted_ids(&token, &invocation, &policy_decision, &approval);
+
+    let store = sovereign_authority::AuthorityStore::open(dir.path()).unwrap();
+    store
+        .revoke_approval(approval_id, NOW + 1, NOW + 120)
+        .unwrap();
+
+    let mut validator = validator_at(NOW + 1).with_authority_store(store);
+    assert_eq!(
+        consume(
+            &mut validator,
+            &token,
+            &invocation,
+            &policy_decision,
+            Some(&approval),
+        ),
+        Err(CapabilityV2Error::Revoked)
+    );
+}
+
+/// The claim that motivated the bundle. A bundle that stops after claiming
+/// the token — here because the approvals directory went away under it — is
+/// retried as the same bundle and completes. Under the old sequential shape
+/// the first attempt had already spent the token on its own, and the retry
+/// was refused as a replay of a request that never succeeded.
+#[test]
+fn a_bundle_interrupted_after_the_token_claim_resumes_on_retry() {
+    let dir = tempfile::tempdir().unwrap();
+    let invocation = prepared("interrupted bundle");
+    let idempotency = Uuid::from_u128(42);
+    let policy_decision = decision(&invocation, AutomationLevel::L3BoundedAuto, idempotency);
+    let approval = approve_at(NOW, &invocation, &policy_decision, 120);
+    let token = issuer_at(NOW)
+        .issue_approved(
+            request_with_ttl(&invocation, &policy_decision, idempotency, 30),
+            &approval,
+        )
+        .unwrap();
+
+    // Open first so the store has its directories, then take the approvals
+    // directory away. The bundle claims the token and binds the idempotency
+    // key before it reaches the approval, and fails there.
+    let store = sovereign_authority::AuthorityStore::open(dir.path()).unwrap();
+    let blocked = BlockedPath::block(dir.path().join("approvals")).unwrap();
+    let mut first = validator_at(NOW + 1).with_authority_store(store);
+    assert_eq!(
+        consume(
+            &mut first,
+            &token,
+            &invocation,
+            &policy_decision,
+            Some(&approval),
+        ),
+        Err(CapabilityV2Error::AuthorityStoreUnavailable)
+    );
+    drop(blocked);
+
+    // A fresh validator over the same store, so nothing process-local can be
+    // what makes the retry succeed.
+    let mut retry = validator_at(NOW + 1)
+        .with_authority_store(sovereign_authority::AuthorityStore::open(dir.path()).unwrap());
+    assert_eq!(
+        consume(
+            &mut retry,
+            &token,
+            &invocation,
+            &policy_decision,
+            Some(&approval),
+        ),
+        Ok(())
     );
 }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -45,6 +45,38 @@ repo audit; every entry below points at verified, real state of the code.
 
 ## Queue
 
+- [ ] **P1 | `crates/capability/` | Uncommitted authority-bundle refactor in `v2.rs` regresses the approval-reuse gate and leaves a dead mapper.**
+  Diagnosed 2026-09-10 by the stop gate during a planning-only session that
+  made no source edits; the failure belongs to the pre-existing uncommitted
+  working tree on `feature/component-wit-input-abi` (`git diff
+  crates/capability/src/v2.rs`, +79/−18). The diff replaces the three
+  separate `.map_err(map_authority_error_{token,idempotency,approval})` calls
+  with one `map_authority_error_bundle` path (`v2.rs:1126`), which maps
+  `AuthorityError::AlreadyConsumed` → `CapabilityV2Error::Replay` for every
+  claim kind. Two consequences:
+  1. `map_authority_error_approval` (`v2.rs:1152`, the only producer of
+     `ApprovalReused` from the durable store) is now unreferenced, so
+     `cargo clippy -p sovereign-authority -p sovereign-owner -p sovereign-cli
+     --all-targets --features owner-effect-fixture --locked -- -D warnings`
+     fails with `dead_code`.
+  2. `cargo test -p sovereign-capability --test approval_v2 --locked` fails
+     2/12: `durable_approval_survives_token_expiry_purge_until_approval_expiry`
+     (`approval_v2.rs:603`, gets `Replay`, expects `ApprovalReused`) and
+     `expired_approval_purges_at_approval_expiry` (`approval_v2.rs:635`,
+     purge leaves 3 claims, expects 1 — the bundle's claims no longer purge
+     independently at the approval's own expiry).
+  These two tests are the verified deliverable of owner-session plan Task 2
+  (run log 2026-08-26 below) and back THREAT_MODEL.md "Attached Authority
+  Store rejects approval reuse after token expiry/purge". Not fixed in
+  passing because it is a semantics decision, not a typo: either (a) keep the
+  distinction — map approval-claim consumption to `ApprovalReused` inside the
+  bundle path and restore per-claim-kind purge, then delete nothing; or
+  (b) if the bundle deliberately collapses approval reuse into `Replay`,
+  update both tests, delete `map_authority_error_approval`, and reword the
+  THREAT_MODEL.md verification line in the same commit. Done when the clippy
+  command above and `cargo test -p sovereign-capability --locked` are green
+  and `./scripts/test_changed.sh` passes on a stop.
+
 - [x] **P1 | `docs/handoff/codex/`, `docs/backlog.md` | Strengthen the full-chain Goal and context recovery instructions.**
   Extend the canonical MVP Goal with founder-runnable end-to-end acceptance,
   active context reduction, persistent recovery summaries, and continuation
@@ -670,8 +702,14 @@ while the controller routes eligible design/review cards to the strong role.
   durable outcome, and `cargo test -p sovereign-authority` covers each. Test
   names are pinned by Amendment 1 part (e) — use them verbatim.
 
-- [ ] **P1 | `crates/capability/` | Consume through the bundle transaction and surface revocation as a typed rejection.**
-  Blocked on the two `crates/authority` entries above.
+- [x] **P1 | `crates/capability/` | Consume through the bundle transaction and surface revocation as a typed rejection.**
+  Landed 2026-09-10. The approved path calls `consume_bundle`;
+  `CapabilityV2Error::Revoked` is its own variant, and authority gained
+  `ApprovalAlreadyConsumed` so the bundle can say which part was held
+  elsewhere (the public API's `ApprovalReused` promise depends on it). Three
+  regression tests in `crates/capability/tests/approval_v2.rs`, each shown to
+  fail against the sequential shape. The no-approval path is not covered — see
+  the P3 entry below.
   `authorize_and_consume_approved` (v2.rs:602) switches from three sequential
   claims to the bundle API; the in-memory mirrors (v2.rs:530-533) remain only
   as no-store-attached defense and say so; revocation maps to a new typed
@@ -680,6 +718,18 @@ while the controller routes eligible design/review cards to the strong role.
   no longer burns earlier claims through the public capability API, a revoked
   token/approval is rejected through `authorize_and_consume_approved` with
   the typed error, and `cargo test -p sovereign-capability` passes.
+
+- [ ] **P3 | `crates/authority/`, `crates/capability/` | Give the no-approval path a two-part bundle.**
+  `authorize_and_consume_approved` with `approval_claim == None` still makes
+  two sequential claims (token, then idempotency), because the authority
+  store offers the bundle only for the three-part case. An idempotency failure
+  after the token claim burns that token for good — the defect the bundle
+  removed from the approved path. Nothing a person authorised is at stake on
+  this path, which is why it is P3 and not P1. Done when: `consume_bundle`
+  (or a sibling) accepts an absent approval, the `None` arm in
+  `crates/capability/src/v2.rs` uses it, and a regression test mirrors
+  `a_bundle_interrupted_after_the_token_claim_resumes_on_retry` for a token
+  without an approval.
 
 - [x] **P1 | `rfcs/`, `docs/` | Pin the 1C0 mechanism design: admitted owner authenticator, single session, one-use approval issuer.**
   ROADMAP v0.1's largest un-designed block (ROADMAP.md:106, 184-186; exit


### PR DESCRIPTION
Closes the backlog P1 "Consume through the bundle transaction and surface revocation as a typed rejection."

## What changes

- `authorize_and_consume_approved` with an approval now calls `AuthorityStore::consume_bundle` instead of three sequential claims. A bundle that stops part-way is retried as the same bundle and resumes; previously the first claims were burned for good on a request that was then denied.
- `CapabilityV2Error::Revoked` is a new variant. A replay says "get a fresh token"; a revocation says "stop". They were indistinguishable before (revocation surfaced as `AuthorityStoreUnavailable`).
- `AuthorityError::ApprovalAlreadyConsumed`: the bundle previously reported one `AlreadyConsumed` whether the token or the approval was held by another bundle, which broke the public `ApprovalReused` promise (an existing test caught it).
- The in-memory mirrors' comment now says what they are: the only defence with no store attached, and a cheap early refusal otherwise.

## Tests

Three regression tests in `crates/capability/tests/approval_v2.rs`, each verified to fail when the behaviour is reverted (bundle mapping alone → both revocation tests red; sequential claims → the interrupted-bundle test red with `Replay`).

`expired_approval_purges_at_approval_expiry` now expects 3 purged records at approval expiry: the approval, plus the bundle's intent and commit records, which expire with the bundle's longest-lived part.

## Not covered

The no-approval path still makes two sequential claims because the store offers the bundle only for the three-part case. Queued as a P3 with the proposed shape, rather than hidden.

`./scripts/test_changed.sh` green; clippy clean on both crates.
