### PR TITLE
fix(cli): two defects from the MVP walkthrough — backup verification and the Security page's admission anchor

### DIFF
--- a/apps/cli/src/ui.rs
+++ b/apps/cli/src/ui.rs
@@ -602,16 +602,17 @@ fn integrity_json(root: &Path) -> serde_json::Value {
     }
 }
 
-/// List admission records from the on-disk store, verifying each record
-/// against the demo admission trust anchor. A record that fails verification
-/// is still listed — flagged unverified — because showing a tampered record
-/// as "absent" would hide evidence from the owner.
+/// List admission records from the on-disk store, verifying each against
+/// the keys that sign them: the owner's admission key for what the send path
+/// admitted, the demo key for what `sovereign demo` admitted. A record that
+/// fails both is still listed — flagged unverified — because showing a
+/// tampered record as "absent" would hide evidence from the owner.
 fn admitted_plugins_json(root: &Path) -> Vec<serde_json::Value> {
     let admissions_dir = root.join("artifacts").join("admissions");
     let Ok(entries) = std::fs::read_dir(&admissions_dir) else {
         return Vec::new();
     };
-    let trust = demo_admission_trust();
+    let trust = workspace::admission_trust(root);
     let now_unix = chrono::Utc::now().timestamp();
 
     let mut plugins = Vec::new();
@@ -632,12 +633,13 @@ fn admitted_plugins_json(root: &Path) -> Vec<serde_json::Value> {
         let Some(record) = record else {
             continue;
         };
-        match trust
-            .verify(&record, demo::ADMISSION_ISSUER, now_unix)
-            .ok()
+        let verified = [workspace::OWNER_ADMISSION_ISSUER, demo::ADMISSION_ISSUER]
+            .iter()
+            .find_map(|issuer| trust.verify(&record, issuer, now_unix).ok())
             .and_then(|verified| {
                 serde_json::from_slice::<AdmissionRecordClaimsV1>(verified.payload()).ok()
-            }) {
+            });
+        match verified {
             Some(claims) => plugins.push(serde_json::json!({
                 "verified": true,
                 "admission_id": claims.admission_id,
@@ -652,25 +654,11 @@ fn admitted_plugins_json(root: &Path) -> Vec<serde_json::Value> {
             None => plugins.push(serde_json::json!({
                 "verified": false,
                 "manifest_digest": &name[..12],
-                "error": "admission record failed verification against the demo trust anchor",
+                "error": "admission record failed verification against the owner and demo admission anchors",
             })),
         }
     }
     plugins
-}
-
-fn demo_admission_trust() -> RoleTrustStore<AdmissionRole> {
-    let now_unix = chrono::Utc::now().timestamp();
-    let mut trust = RoleTrustStore::<AdmissionRole>::new();
-    if let Ok(signer) = TypedSigner::<AdmissionRole>::from_secret_bytes(
-        demo::ADMISSION_ISSUER,
-        demo::DEMO_ADMISSION_SECRET,
-    ) {
-        if let Ok(validity) = KeyValidity::new(now_unix - 60, now_unix + 3_600) {
-            let _ = trust.trust_signer(&signer, validity);
-        }
-    }
-    trust
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/cli/src/ui.rs
+++ b/apps/cli/src/ui.rs
@@ -58,6 +58,12 @@ const UI_FAVICON: &str = include_str!("../assets/favicon.svg");
 const JS_TYPE: &str = "application/javascript; charset=utf-8";
 
 const MAX_REQUEST_BODY_BYTES: usize = 64 * 1024;
+/// The one body the app itself asks a person to post back is an export
+/// bundle — "verify a backup file" — and a workspace with a handful of
+/// documents and a hundred audit events is already past the general cap.
+/// That route takes a larger body; larger is still bounded, for the same
+/// reason the general cap exists.
+const MAX_VERIFY_EXPORT_BODY_BYTES: usize = 32 * 1024 * 1024;
 
 /// Marker line printed once the server is listening, carrying the address it
 /// actually bound. A supervising process (the desktop shell) reads this from
@@ -205,10 +211,12 @@ fn route(request: &mut tiny_http::Request, port: u16, root: &Path) -> UiResponse
             Ok(body) => json_response(&workspace_assist(&body, root)),
             Err(error) => bad_request(&error),
         },
-        (Method::Post, "/api/verify-export") => match read_json_body(request) {
-            Ok(body) => json_response(&verify_export_json(&body)),
-            Err(error) => bad_request(&error),
-        },
+        (Method::Post, "/api/verify-export") => {
+            match read_json_body_capped(request, MAX_VERIFY_EXPORT_BODY_BYTES) {
+                Ok(body) => json_response(&verify_export_json(&body)),
+                Err(error) => bad_request(&error),
+            }
+        }
         (Method::Post, path)
             if path.starts_with("/api/workspace/") || path.starts_with("/api/privacy/") =>
         {
@@ -243,6 +251,13 @@ fn host_allowed(request: &tiny_http::Request, port: u16) -> bool {
 /// CSRF defense: cross-origin pages cannot send that content type without a
 /// CORS preflight, which this server never approves.
 fn read_json_body(request: &mut tiny_http::Request) -> Result<serde_json::Value, String> {
+    read_json_body_capped(request, MAX_REQUEST_BODY_BYTES)
+}
+
+fn read_json_body_capped(
+    request: &mut tiny_http::Request,
+    cap: usize,
+) -> Result<serde_json::Value, String> {
     let is_json = request
         .headers()
         .iter()
@@ -259,10 +274,10 @@ fn read_json_body(request: &mut tiny_http::Request) -> Result<serde_json::Value,
         return Err("Content-Type must be application/json".into());
     }
     let mut body = Vec::new();
-    std::io::Read::take(request.as_reader(), (MAX_REQUEST_BODY_BYTES + 1) as u64)
+    std::io::Read::take(request.as_reader(), (cap + 1) as u64)
         .read_to_end(&mut body)
         .map_err(|error| error.to_string())?;
-    if body.len() > MAX_REQUEST_BODY_BYTES {
+    if body.len() > cap {
         return Err("request body too large".into());
     }
     if body.is_empty() {

--- a/apps/cli/src/workspace/kernel_exec.rs
+++ b/apps/cli/src/workspace/kernel_exec.rs
@@ -345,6 +345,44 @@ impl Store {
     }
 }
 
+/// Every key that may have signed an admission record on this installation:
+/// the owner's admission key, minted into the vault the first time a
+/// document is sent (`owner_secret` above), and the demo command's fixed key
+/// for records `sovereign demo` wrote. A reader verifies against
+/// `OWNER_ADMISSION_ISSUER` first and `demo::ADMISSION_ISSUER` second.
+///
+/// Read-only on purpose. A page that lists records must not mint the key
+/// that signs them, so a vault that does not exist yet contributes no owner
+/// anchor rather than being created here.
+pub(crate) fn admission_trust(root: &std::path::Path) -> RoleTrustStore<AdmissionRole> {
+    let now_unix = now();
+    let mut trust = RoleTrustStore::<AdmissionRole>::new();
+    let Ok(validity) = KeyValidity::new(now_unix - 60, now_unix + 3_600) else {
+        return trust;
+    };
+    let vault_root = root.join("vault");
+    if vault_root.join("vault.key").exists() {
+        let owner_secret = Vault::init(&vault_root)
+            .and_then(|vault| vault.get("owner_admission_key"))
+            .ok()
+            .and_then(|bytes| <[u8; 32]>::try_from(bytes).ok());
+        if let Some(secret) = owner_secret {
+            if let Ok(signer) =
+                TypedSigner::<AdmissionRole>::from_secret_bytes(OWNER_ADMISSION_ISSUER, secret)
+            {
+                let _ = trust.trust_signer(&signer, validity);
+            }
+        }
+    }
+    if let Ok(signer) = TypedSigner::<AdmissionRole>::from_secret_bytes(
+        crate::demo::ADMISSION_ISSUER,
+        crate::demo::DEMO_ADMISSION_SECRET,
+    ) {
+        let _ = trust.trust_signer(&signer, validity);
+    }
+    trust
+}
+
 /// Stage 2 — exactness: bind this document's canonical input and resource
 /// grant into a prepared invocation of the admitted tool.
 fn prepare_delivery_invocation(

--- a/apps/cli/src/workspace/mod.rs
+++ b/apps/cli/src/workspace/mod.rs
@@ -65,6 +65,7 @@ pub use compliance_pack::packs;
 pub use crew_roles::role_cards;
 pub use crew_types::*;
 pub use erp_types::*;
+pub(crate) use kernel_exec::admission_trust;
 pub use model_config::{provider_status, MODEL_CONFIG_FILE};
 pub use privacy_ops::{transforms_json, StoredPreset};
 pub use types::*;
@@ -103,7 +104,7 @@ const BUILTIN_PUBLISHER_SECRET: [u8; 32] = *b"sovereign-builtin-publisher-01!!";
 const BUILTIN_PUBLISHER_ISSUER: &str = "builtin.sovereign-founder-os";
 const RUNTIME_AUTHORITY_ISSUER: &str = "workspace-runtime.local";
 const OWNER_APPROVAL_ISSUER: &str = "founder-owner.local";
-const OWNER_ADMISSION_ISSUER: &str = "founder-device.workspace";
+pub(crate) const OWNER_ADMISSION_ISSUER: &str = "founder-device.workspace";
 const WORKSPACE_AUDIENCE: &str = "sovereign-runtime";
 const APPROVAL_TTL_SECONDS: i64 = 300;
 

--- a/apps/cli/tests/support/ui_server.rs
+++ b/apps/cli/tests/support/ui_server.rs
@@ -141,8 +141,42 @@ fn parse(raw: &[u8]) -> Response {
         httparse::Status::Complete(offset) => offset,
         httparse::Status::Partial => panic!("incomplete HTTP response"),
     };
+    // tiny_http switches to chunked transfer for bodies past its threshold
+    // (an export bundle is one), and a chunk-size line is not JSON.
+    let chunked = response.headers.iter().any(|header| {
+        header.name.eq_ignore_ascii_case("transfer-encoding")
+            && std::str::from_utf8(header.value)
+                .map(|value| value.to_ascii_lowercase().contains("chunked"))
+                .unwrap_or(false)
+    });
+    let body = if chunked {
+        dechunk(&raw[body_at..])
+    } else {
+        raw[body_at..].to_vec()
+    };
     Response {
         status: response.code.expect("status code"),
-        body: raw[body_at..].to_vec(),
+        body,
+    }
+}
+
+/// Decode a chunked transfer body: hex size line, that many bytes, CRLF,
+/// repeated until a zero-size chunk.
+fn dechunk(mut raw: &[u8]) -> Vec<u8> {
+    let mut body = Vec::new();
+    loop {
+        let line_end = raw
+            .windows(2)
+            .position(|pair| pair == b"\r\n")
+            .expect("chunk size line");
+        let size_text = std::str::from_utf8(&raw[..line_end]).expect("chunk size is text");
+        let size = usize::from_str_radix(size_text.split(';').next().unwrap_or("").trim(), 16)
+            .expect("chunk size is hex");
+        raw = &raw[line_end + 2..];
+        if size == 0 {
+            return body;
+        }
+        body.extend_from_slice(&raw[..size]);
+        raw = &raw[size + 2..];
     }
 }

--- a/apps/cli/tests/support/ui_server.rs
+++ b/apps/cli/tests/support/ui_server.rs
@@ -61,8 +61,21 @@ impl UiServer {
         }
     }
 
+    /// Every test binary compiles this file on its own, so a helper one of
+    /// them does not call is dead code there: this one builds a wrong `Host`
+    /// in the boundary tests and nowhere else.
+    #[allow(dead_code)]
     pub fn port(&self) -> u16 {
         self.port
+    }
+
+    /// A GET with the app's own `Host`, no body, no credential.
+    pub fn get(&self, path: &str) -> Response {
+        let headers = vec![
+            ("Host".to_string(), format!("127.0.0.1:{}", self.port)),
+            ("Connection".to_string(), "close".to_string()),
+        ];
+        self.exchange("GET", path, &headers, &[])
     }
 
     /// A POST the app's own frontend could have sent: correct `Host`, correct
@@ -179,4 +192,46 @@ fn dechunk(mut raw: &[u8]) -> Vec<u8> {
         body.extend_from_slice(&raw[..size]);
         raw = &raw[size + 2..];
     }
+}
+
+/// Drive the shipped flow up to a pending approval and return its id.
+pub fn pending_approval(server: &UiServer) -> String {
+    let venture = server.post(
+        "/api/workspace/venture",
+        &serde_json::json!({ "name": "Boundary Co", "service": "Pinning the HTTP surface" }),
+    );
+    assert_eq!(venture.status, 200, "venture: {:?}", venture.json());
+
+    let customer = server.post(
+        "/api/workspace/customer",
+        &serde_json::json!({ "name": "A Customer", "email": "", "notes": "" }),
+    );
+    let state = customer.json();
+    assert_eq!(state["ok"], true, "customer: {state}");
+    let customer_id = state["workspace"]["customers"][0]["id"]
+        .as_str()
+        .expect("customer id")
+        .to_owned();
+
+    let offer = server.post(
+        "/api/workspace/offer",
+        &serde_json::json!({ "customer_id": customer_id }),
+    );
+    let state = offer.json();
+    assert_eq!(state["ok"], true, "offer: {state}");
+    let document_id = state["workspace"]["documents"][0]["id"]
+        .as_str()
+        .expect("document id")
+        .to_owned();
+
+    let requested = server.post(
+        "/api/workspace/request-send",
+        &serde_json::json!({ "document_id": document_id }),
+    );
+    let state = requested.json();
+    assert_eq!(state["ok"], true, "request-send: {state}");
+    state["workspace"]["approvals"][0]["id"]
+        .as_str()
+        .expect("approval id")
+        .to_owned()
 }

--- a/apps/cli/tests/ui_admissions.rs
+++ b/apps/cli/tests/ui_admissions.rs
@@ -1,0 +1,36 @@
+//! What the Security page says about the admission records the product
+//! itself wrote.
+
+#[path = "support/ui_server.rs"]
+mod ui_server;
+
+use serde_json::json;
+use ui_server::{pending_approval, UiServer};
+
+/// The send path admits the built-in delivery tool under the owner's
+/// admission key. The Security page verified every record against the demo
+/// command's key instead, so the one record every installation has showed
+/// as "failed verification" — on a fresh install, with nothing wrong.
+#[test]
+fn a_record_the_send_path_wrote_verifies_on_the_security_page() {
+    let server = UiServer::start();
+    let approval_id = pending_approval(&server);
+    let decided = server
+        .post(
+            "/api/workspace/decide",
+            &json!({ "approval_id": approval_id, "approve": true }),
+        )
+        .json();
+    assert_eq!(decided["ok"], true, "{decided}");
+
+    let state = server.get("/api/state").json();
+    let plugins = state["plugins"].as_array().expect("plugins array");
+    assert_eq!(
+        plugins.len(),
+        1,
+        "one admitted tool after one send: {state}"
+    );
+    let plugin = &plugins[0];
+    assert_eq!(plugin["verified"], true, "{plugin}");
+    assert_eq!(plugin["issuer"], "founder-device.workspace", "{plugin}");
+}

--- a/apps/cli/tests/ui_http_boundary.rs
+++ b/apps/cli/tests/ui_http_boundary.rs
@@ -152,3 +152,49 @@ fn a_body_over_the_cap_is_refused() {
     let state = response.json();
     assert_eq!(state["ok"], false, "{state}");
 }
+
+/// The export bundle is the one body the app itself asks a person to post
+/// back — "verify a backup file" — and a workspace with a few dozen records
+/// is already past the general cap. Before this test, every real backup was
+/// refused by the very route that exists to check it.
+#[test]
+fn an_export_past_the_general_cap_still_verifies() {
+    let server = UiServer::start();
+    let venture = server
+        .post(
+            "/api/workspace/venture",
+            &json!({ "name": "Cap Test Pte Ltd", "service": "backups" }),
+        )
+        .json();
+    assert_eq!(venture["ok"], true, "{venture}");
+    let notes = "n".repeat(2048);
+    for index in 0..48 {
+        let added = server
+            .post(
+                "/api/workspace/customer",
+                &json!({ "name": format!("Customer {index}"), "email": "", "notes": notes }),
+            )
+            .json();
+        assert_eq!(added["ok"], true, "{added}");
+    }
+
+    let get_headers = vec![
+        ("Host".to_string(), format!("127.0.0.1:{}", server.port())),
+        ("Connection".to_string(), "close".to_string()),
+    ];
+    let bundle = server
+        .exchange("GET", "/api/export", &get_headers, &[])
+        .json();
+    let size = serde_json::to_vec(&bundle).expect("serialize bundle").len();
+    assert!(
+        size > 64 * 1024,
+        "the export is {size} bytes, under the general cap, so this test proves nothing"
+    );
+
+    let verdict = server
+        .post("/api/verify-export", &json!({ "bundle": bundle }))
+        .json();
+    assert_eq!(verdict["ok"], true, "{verdict}");
+    assert_eq!(verdict["report"]["audit_chain_verified"], true, "{verdict}");
+    assert_eq!(verdict["report"]["customers"], 48, "{verdict}");
+}

--- a/apps/cli/tests/ui_http_boundary.rs
+++ b/apps/cli/tests/ui_http_boundary.rs
@@ -8,49 +8,7 @@
 mod ui_server;
 
 use serde_json::json;
-use ui_server::UiServer;
-
-/// Drive the shipped flow up to a pending approval and return its id.
-fn pending_approval(server: &UiServer) -> String {
-    let venture = server.post(
-        "/api/workspace/venture",
-        &json!({ "name": "Boundary Co", "service": "Pinning the HTTP surface" }),
-    );
-    assert_eq!(venture.status, 200, "venture: {:?}", venture.json());
-
-    let customer = server.post(
-        "/api/workspace/customer",
-        &json!({ "name": "A Customer", "email": "", "notes": "" }),
-    );
-    let state = customer.json();
-    assert_eq!(state["ok"], true, "customer: {state}");
-    let customer_id = state["workspace"]["customers"][0]["id"]
-        .as_str()
-        .expect("customer id")
-        .to_owned();
-
-    let offer = server.post(
-        "/api/workspace/offer",
-        &json!({ "customer_id": customer_id }),
-    );
-    let state = offer.json();
-    assert_eq!(state["ok"], true, "offer: {state}");
-    let document_id = state["workspace"]["documents"][0]["id"]
-        .as_str()
-        .expect("document id")
-        .to_owned();
-
-    let requested = server.post(
-        "/api/workspace/request-send",
-        &json!({ "document_id": document_id }),
-    );
-    let state = requested.json();
-    assert_eq!(state["ok"], true, "request-send: {state}");
-    state["workspace"]["approvals"][0]["id"]
-        .as_str()
-        .expect("approval id")
-        .to_owned()
-}
+use ui_server::{pending_approval, UiServer};
 
 /// A POST that carries no credential of any kind approves a real send, and
 /// the backend signs it as the owner's decision.
@@ -178,13 +136,7 @@ fn an_export_past_the_general_cap_still_verifies() {
         assert_eq!(added["ok"], true, "{added}");
     }
 
-    let get_headers = vec![
-        ("Host".to_string(), format!("127.0.0.1:{}", server.port())),
-        ("Connection".to_string(), "close".to_string()),
-    ];
-    let bundle = server
-        .exchange("GET", "/api/export", &get_headers, &[])
-        .json();
+    let bundle = server.get("/api/export").json();
     let size = serde_json::to_vec(&bundle).expect("serialize bundle").len();
     assert!(
         size > 64 * 1024,

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1510,6 +1510,11 @@ Entries here follow the queue rules above; `lane:codex` does not apply.
 - [x] **P1 | `apps/cli/assets/`, `apps/cli/src/ui_mvp.rs` | Seven-tab bilingual MVP pages.** Landed 2026-09-10; verified by hand in the in-app browser.
 
 - [ ] **P1 | `docs/`, `apps/cli/` | Live verification with a real Ollama model and the five-consultant usability protocol.**
+  2026-09-10: the half that needs no model ran — every route and page on a
+  fresh workspace, report at
+  `docs/handoff/reports/2026-09-10-mvp-walkthrough-without-a-model.md`, two
+  defects fixed in #91. The model half is blocked on Ollama being
+  installed on the founder's machine; nothing about model quality is known.
   Run every role against a real local model (`ollama serve`, a pulled model,
   `model.json` enabled) and record which proposals validated, which fell back
   to the template, and why; then run the five-consultant usability protocol
@@ -1524,6 +1529,35 @@ Entries here follow the queue rules above; `lane:codex` does not apply.
   size rules, JSON error envelopes, and that a malformed `RunSubject` or
   profile is a 200 `{ok:false}` with a message, never a panic. Done when
   `cargo test -p sovereign-cli` covers each route once.
+  The route sequence to convert is written out at the end of the walkthrough
+  report above; `tests/support/ui_server.rs` already has `get`, `post` and
+  `pending_approval` for it.
+- [ ] **P2 | `apps/cli/src/workspace/` | A rejected or revoked document has a way back to draft.**
+  `decide(reject)` sets a document `rejected`; `revoke_delivery` sets it
+  `revoked`; `update_document` and `request_send` both require `draft`. So a
+  founder who rejects a send to fix a line, or revokes one, can only start a
+  new document and lose the revision thread. Candidate rule: editing a
+  rejected or revoked document produces a new draft revision, with the
+  rejection or revocation kept in the audit chain. Done when: the rule is
+  chosen and written into the `DocumentStatus` doc comment, `update_document`
+  implements it, and a test walks draft → rejected → edited → sent.
+- [ ] **P3 | `apps/cli/src/workspace/crew_roles.rs`, `apps/cli/assets/team.js` | Role cards' reads / delivers / cannot lines get Chinese variants.**
+  `RoleCard` carries `title_en/zh` and `description_en/zh` but a single
+  English `reads`, `delivers`, `cannot`; the Chinese Team page shows three
+  English lines per card. Done when: the three fields have `_en/_zh` pairs
+  and `team.js` picks by language, with a test that no card's `_zh` is empty.
+- [ ] **P3 | `apps/cli/src/ui.rs`, `apps/cli/src/workspace/compliance.rs` | Venture-level disclosures name the company, not `(unknown)`.**
+  A company compliance check records a disclosure with `customer_id:
+  Uuid::nil()` and an audit resource of `customer:00000000-…`; the Security
+  page renders the customer as `(unknown)`. Done when: a venture-level
+  disclosure carries a venture subject (or `None`) and renders as the
+  company, and the audit resource says `venture:profile`.
+- [ ] **P3 | `apps/cli/assets/` | Two copy/layout nits from the walkthrough.**
+  Compliance page: the history box says "no checks yet" (`cp_no_reports`)
+  when exactly one report exists, because the list excludes the report shown
+  above it — say "no earlier checks". Documents page: a long title pushes the
+  second action button onto its own line. Done when both are gone in `zh`
+  and `en`.
 - [ ] **P2 | `apps/cli/src/workspace/` | Export/verify-export learns the new entities.**
   `verify_export` counts only customers/documents/approvals; extend the
   report (and the UI) to projects, tasks, follow-ups, payments, employees,

--- a/docs/handoff/reports/2026-09-10-mvp-walkthrough-without-a-model.md
+++ b/docs/handoff/reports/2026-09-10-mvp-walkthrough-without-a-model.md
@@ -1,0 +1,138 @@
+# MVP walkthrough without a model — every route, every page, two defects fixed
+
+- **Outcome:** the founder MVP driven end to end by script and by browser on a fresh workspace and on the demo workspace; two defects fixed in `#91`; four product findings queued; the live-model half of the backlog item still blocked
+- **Base:** `02508dd` (main at the start of the session)
+- **Backlog item:** "Live verification with a real Ollama model and the five-consultant usability protocol" — the half of it that needs no model
+- **Machine:** the founder's Mac, macOS 26.5 arm64, `target/debug/sovereign ui` on ports 7791 (demo data) and 7793 (fresh `HOME`)
+
+## The one thing to read first
+
+**Ollama is not installed on this machine**, so the part of the backlog item
+that names a real model — which prompts validated per role, which fell back to
+the template, and why — did not run and is not reported here. Installing
+software while the founder was asleep was not mine to do. Every proposal in
+this walkthrough was produced by the built-in template drafter, and the app
+says so on every one of them (`模板 · 产出方: local-drafter`, `model_backed:
+false`). Nothing below is evidence about model quality.
+
+What did run is everything else: 60 API steps through every workspace route
+on a fresh installation, a DOM-level survey of all eight pages, full-page
+screenshots of each, and the business flow from an empty company to a paid
+invoice with a compliance check on the way.
+
+## What was found
+
+Two defects that a reviewer would have hit within minutes, both fixed in
+`#91` with tests that were shown to fail against the previous code:
+
+**Backup verification refused every real backup.** The Company page's
+"verify a backup file" posts the exported bundle to `/api/verify-export`,
+which read it under the general 64 KiB request cap. A workspace with one
+customer, three documents and ninety audit events exports at 118 KB. So the
+route that exists to check a backup refused any backup worth checking. It now
+reads up to 32 MiB — bounded, for the same reason the general cap exists — and
+`an_export_past_the_general_cap_still_verifies` proves the round trip at a
+size above 64 KiB.
+
+**The Security page marked the product's own admission records as failing
+verification.** The send path admits the built-in delivery tool under the
+owner's admission key (`founder-device.workspace`, minted into the vault).
+The page verified every record against the *demo command's* key
+(`founder-device.local`). So on a fresh install, after the first send, the one
+admitted tool showed `admission record failed verification against the demo
+trust anchor` — with nothing wrong. The page now verifies against the keys
+that actually sign, owner first and demo second, from one function
+(`workspace::admission_trust`) that the send path's key derivation shares.
+`a_record_the_send_path_wrote_verifies_on_the_security_page` pins it.
+
+Four product findings, queued in `docs/backlog.md` rather than fixed, because
+each is a rule for the founder to set:
+
+1. **A rejected or revoked document is a dead end.** Reject a send request and
+   the document becomes `rejected`; revoke an approved-but-undelivered one and
+   it becomes `revoked`. Neither can be edited (`update_document` requires a
+   draft) or resubmitted (`request_send` requires a draft). The only way on is
+   a new document, which loses the revision thread. P2.
+2. **Role cards are half-translated.** Each card's title and description have
+   `en`/`zh` variants; its *reads / delivers / cannot* lines exist only in
+   English, so the Chinese Team page shows three English lines per card. P3.
+3. **Venture-level model disclosures show `(unknown)` as the customer**, and
+   their audit resource is `customer:00000000-…`. A company-level compliance
+   check has no customer; it should say so. P3.
+4. **Two copy/layout nits**: the compliance page's history box says "no checks
+   yet" when exactly one report exists (the list deliberately excludes the
+   report shown above it); on the Documents page a long title pushes the
+   second action button onto its own line. P3.
+
+Two things that looked like findings and were not: English proposal titles on
+the demo workspace came from my own earlier API scripts, which passed no
+`lang` — the frontend's `api()` helper injects it on every call; and
+"proposal_writer" as an employee name on the Customers page was the name I gave
+at hire time, rendered as `title · name`.
+
+## What held
+
+Everything else in the walk behaved, and behaved precisely. The steps that
+"failed" beyond the defects above were all the API refusing something it
+should refuse, with a message that said exactly why:
+
+- `only an approved, undelivered document can be confirmed delivered` — on a
+  second confirm.
+- `customer_id is required` — on a timeline without one.
+- `unknown purpose draft_offer` — the purposes are `draft_discovery_summary`,
+  `draft_proposal`, `review_draft`.
+- `unknown variant Lead, expected lead or customer`.
+
+The security gauntlet passed 11/11 on the fresh workspace. The audit chain
+verified with 90 events at the end of the walk and 0 integrity findings.
+Receivables went from `500000 open` to `0 paid` on one recorded payment. The
+company compliance check produced 10 findings and the invoice check 3, each
+carrying its source, its "who to ask", and the facts it read. Privacy presets
+switched both ways and the projection preview answered. Model status reported
+`local-drafter · healthy · real_model: false`, which is the truth.
+
+Visually, all eight pages rendered without overflow, `undefined`, `NaN` or
+missing strings, in light and dark, in Chinese; screenshots were sent to the
+founder.
+
+## What still needs a person
+
+- **Install Ollama, pull a model, enable `model.json`**, then re-run the role
+  runs from the walk with `lang` set both ways and record pass/fall-back per
+  role. That is the other half of the backlog item, and it is the founder's
+  machine.
+- **Decide the document rule** in finding 1: "editing a rejected or revoked
+  document produces a new draft revision" is the obvious candidate; the
+  rejection stays in the audit chain either way.
+- **The five-consultant usability protocol** wants five people, not one
+  script.
+
+## The walk, for whoever runs it next
+
+Sixty steps against `http://127.0.0.1:7793` with `Host: 127.0.0.1:7793` and
+`Content-Type: application/json`, in this order — each `POST` unless marked:
+
+`workspace/venture` → `workspace/profile` (SG, SGD, UEN, FYE 12) →
+`workspace/customer` → `customer/update` (discovery notes, stage `lead`) →
+`workspace/roles` → `employee/hire` × 6 → `employee/status` paused then hired
+→ `employee/run` analyst → `decision` approve → `employee/run`
+proposal_writer → `decision` approve → `document/update` (amount 5000) →
+`request-send` → `decide` reject → `request-send` again (**stuck**) → new
+`workspace/offer` → `request-send` → `decide` approve → `revoke` →
+`request-send` again (**stuck**) → new offer → `request-send` → `decide`
+approve → `confirm-delivery` → `offer/accepted` → `employee/run`
+delivery_planner → `decision` approve (1 project, 6 tasks) → `task` add →
+`task/done` × 7 → `project/status` done → `employee/run` invoice_clerk →
+`decision` approve → `request-send` invoice → `decide` approve →
+`employee/run` quality_checker → `decision` approve → `receivables` →
+`payment` → `receivables` → `follow-up` → `follow-up/done` →
+`compliance/check` company (zh) → `compliance/check` invoice → `compliance/rules`
+("GST") → `employee/run` compliance_checker → `decision` approve →
+`work-suggestions` → `timeline` → `GET command-center` → `assist` →
+`privacy/state` → `privacy/preset` local_only → `privacy/preview`
+draft_proposal → `privacy/preset` auto_protect → `GET model/status` →
+`GET export` → `verify-export` (**was refused**) → `gauntlet` → `GET state`.
+
+The P2 backlog item "HTTP-layer tests for the MVP routes" is the place this
+sequence belongs, as Rust tests over the existing `tests/support/ui_server.rs`
+harness; two of its steps are already there as of `#91`.


### PR DESCRIPTION
Two defects found by driving the founder MVP end to end on a fresh workspace (report and queued findings follow in a docs commit on this branch).

## 1. Backup verification refused every real backup

The Company page's "verify a backup file" posts the exported bundle to `/api/verify-export`, which read it under the general 64 KiB request cap. A workspace with one customer, three documents and ninety audit events exports at 118 KB. The route now reads up to 32 MiB — still bounded — through the same take-then-measure path; every other route keeps the general cap.

The test harness learns chunked-transfer decoding (tiny_http chunks bodies past its threshold; an export is one). `an_export_past_the_general_cap_still_verifies` builds a workspace whose export exceeds 64 KiB, asserts that it does, and round-trips it. It fails with `ok: false` on the previous cap.

## 2. The Security page marked the product's own admission records as failing verification

The send path admits the delivery tool under the owner's admission key (`founder-device.workspace`); the page verified against the demo command's key (`founder-device.local`). On a fresh install, after the first send, the one admitted tool showed as failed.

`workspace::admission_trust` is now the one place that knows which keys may sign an admission record (owner when the vault holds it, demo always), shared by the page; read-only, so a GET never mints a key. `a_record_the_send_path_wrote_verifies_on_the_security_page` drives a real send and reads `/api/state`; it fails when the owner anchor is withheld.

## Also

`tests/support/ui_server.rs` gains `get` and the shared `pending_approval` flow driver; `port` stays with an explicit dead-code allowance because only the boundary binary calls it.

`./scripts/test_changed.sh` green on the final tree; `cargo clippy -p sovereign-cli --all-targets -- -D warnings` clean.
