### PR TITLE
test(transport): name the failing step and retry a loopback EINVAL before any byte is sent

### DIFF
--- a/crates/consultant-playground/tests/support/transport.rs
+++ b/crates/consultant-playground/tests/support/transport.rs
@@ -14,13 +14,39 @@ pub struct Response {
 }
 
 pub fn connect(port: u16) -> io::Result<TcpStream> {
-    let stream = TcpStream::connect_timeout(
-        &std::net::SocketAddr::from(([127, 0, 0, 1], port)),
-        Duration::from_secs(2),
-    )?;
-    stream.set_read_timeout(Some(Duration::from_secs(8)))?;
-    stream.set_write_timeout(Some(Duration::from_secs(2)))?;
+    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+    // A loopback connect that returns EINVAL is a host quirk: seen on macOS
+    // 26.5 only under the full gate, never standalone (docs/backlog.md,
+    // "transport EINVAL"). Nothing has been sent yet, so trying again cannot
+    // duplicate a request; an error after the write is never retried.
+    let mut attempt = 0;
+    let stream = loop {
+        match TcpStream::connect_timeout(&addr, Duration::from_secs(2)) {
+            Ok(stream) => break stream,
+            Err(error) if error.raw_os_error() == Some(22) && attempt < 3 => {
+                attempt += 1;
+                eprintln!(
+                    "transport: connect to {addr} returned EINVAL (attempt {attempt}), retrying"
+                );
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Err(error) => return Err(step("connect", error)),
+        }
+    };
+    stream
+        .set_read_timeout(Some(Duration::from_secs(8)))
+        .map_err(|error| step("set_read_timeout", error))?;
+    stream
+        .set_write_timeout(Some(Duration::from_secs(2)))
+        .map_err(|error| step("set_write_timeout", error))?;
     Ok(stream)
+}
+
+/// Name the step an error came from. An intermittent failure under the gate
+/// otherwise says only which errno, and errno 22 has five possible sources
+/// in one request.
+fn step(name: &str, error: io::Error) -> io::Error {
+    io::Error::new(error.kind(), format!("{name}: {error}"))
 }
 
 pub fn raw_request(port: u16, method: &str, target: &str, headers: &str, body: &[u8]) -> Vec<u8> {
@@ -32,7 +58,9 @@ pub fn raw_request(port: u16, method: &str, target: &str, headers: &str, body: &
 
 pub fn request(port: u16, bytes: &[u8]) -> io::Result<Response> {
     let mut stream = connect(port)?;
-    stream.write_all(bytes)?;
+    stream
+        .write_all(bytes)
+        .map_err(|error| step("write", error))?;
     // A server that has already answered and closed leaves nothing to shut
     // down. Linux reports that as ENOTCONN; macOS lets the call succeed. The
     // difference says nothing about the server, and the response it sent is
@@ -41,9 +69,9 @@ pub fn request(port: u16, bytes: &[u8]) -> io::Result<Response> {
     match stream.shutdown(Shutdown::Write) {
         Ok(()) => {}
         Err(error) if peer_is_gone(&error) => {}
-        Err(error) => return Err(error),
+        Err(error) => return Err(step("shutdown", error)),
     }
-    read_response(&mut stream)
+    read_response(&mut stream).map_err(|error| step("read", error))
 }
 
 /// Whether an error means the connection is gone, under any of the names the
@@ -64,7 +92,9 @@ pub fn read_response(stream: &mut TcpStream) -> io::Result<Response> {
     let mut buf = [0; 4096];
     // Whole-second socket waits avoid the fractional-timeout EINVAL observed
     // on the test host. The absolute deadline bounds all retries to <9 seconds.
-    stream.set_read_timeout(Some(Duration::from_secs(1)))?;
+    stream
+        .set_read_timeout(Some(Duration::from_secs(1)))
+        .map_err(|error| step("set_read_timeout(1s)", error))?;
     loop {
         if Instant::now() >= deadline {
             return Err(io::ErrorKind::TimedOut.into());

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1532,6 +1532,21 @@ Entries here follow the queue rules above; `lane:codex` does not apply.
   The route sequence to convert is written out at the end of the walkthrough
   report above; `tests/support/ui_server.rs` already has `get`, `post` and
   `pending_approval` for it.
+- [ ] **P3 | `crates/consultant-playground/tests/support/transport.rs` | Transport EINVAL under the full gate on the macOS test host.**
+  `two_cli_roots_have_identical_complete_transcripts_and_no_writes`
+  (`apps/cli/tests/playground_isolation.rs:93`) failed twice on 2026-09-10
+  under the Stop-hook gate with `Os { code: 22, InvalidInput }` from
+  `transport::request`, at the 7th and the 17th exchange of the first root —
+  a server that had just answered. It passed 8/8 standalone and in three
+  background gate runs the same hour, and it touches nothing the day's
+  changes touched. The helper already avoids fractional socket timeouts for
+  a related EINVAL seen on this host; every timeout is whole-second now, so
+  the remaining sources are `connect_timeout`'s poll, `shutdown`, or a
+  `setsockopt` quirk in macOS 26.5. Mitigation in place: `request` names the
+  failing step in its error, and `connect` retries EINVAL up to three times
+  before any byte is sent (never after). Done when: the next occurrence
+  names its step and either the retry absorbs it or the step gets a targeted
+  fix; if it never recurs in a month, close as absorbed.
 - [ ] **P2 | `apps/cli/src/workspace/` | A rejected or revoked document has a way back to draft.**
   `decide(reject)` sets a document `rejected`; `revoke_delivery` sets it
   `revoked`; `update_document` and `request_send` both require `draft`. So a


### PR DESCRIPTION
An intermittent `Os { code: 22, InvalidInput }` from `transport::request` failed `two_cli_roots_have_identical_complete_transcripts_and_no_writes` twice under the local gate on 2026-09-10, mid-conversation with a server that had just answered; the same test passed 8/8 standalone and in three other gate runs that hour, and touches nothing that day's changes touched.

- `request` now names the failing step in its error (connect / set_read_timeout / write / shutdown / read), so the next occurrence says which syscall rather than only which errno.
- `connect` retries EINVAL up to three times, 100 ms apart. Nothing has been sent at that point, so a retry cannot duplicate a request; errors after the write are never retried.
- The evidence and the remaining suspects are recorded as a P3 in `docs/backlog.md`.

All three consumers of the helper pass (`server_transport` 32, `playground_isolation` 23, `business_demo_http` 8); `./scripts/test_changed.sh` green; clippy clean on both crates.
