### PR TITLE
fix(workspace): stop the crew prompts and parser from discarding valid model answers

### DIFF
--- a/apps/cli/src/workspace/crew_roles.rs
+++ b/apps/cli/src/workspace/crew_roles.rs
@@ -328,7 +328,13 @@ pub(super) fn prompt_for(input: &RoleInput) -> String {
             r#"{"title":string,"body":string,"amount":string,"due_in_days":integer}"#
         }
         RoleId::QualityChecker => {
-            r#"{"findings":[{"kind":"gap"|"contradiction"|"placeholder"|"risk","detail":string}]}"#
+            // `"kind":"gap"|"contradiction"|…` reads to a model as a list of
+            // bare values rather than one field with four allowed words, and
+            // it copied that shape back: four of six validation failures
+            // measured against qwen2.5:7b were `{"placeholder","detail":…}`
+            // with the key name dropped. The allowed words moved into the
+            // task text, where they cannot be mistaken for syntax.
+            r#"{"findings":[{"kind":string,"detail":string}]}"#
         }
         RoleId::ComplianceChecker => r#"{"summary":string}"#,
     };
@@ -336,8 +342,8 @@ pub(super) fn prompt_for(input: &RoleInput) -> String {
         RoleId::Analyst => "You are the Requirements Analyst for a one-person consulting company. From the customer facts below, extract concrete problems, constraints, the stated budget (or \"not stated\"), open questions to ask the customer, and assumptions you are making. Never present a guess as a confirmed fact; put guesses under assumptions.",
         RoleId::ProposalWriter => "You are the Proposal Writer for a one-person consulting company. Draft a proposal for this customer: title, a body with sections Context, Scope, Deliverables, Timeline, Investment, Assumptions, Next step; an amount as a decimal string in the company currency if the facts support one, otherwise null. Do not promise anything the facts do not support.",
         RoleId::DeliveryPlanner => "You are the Delivery Planner for a one-person consulting company. Turn the offer into a project name, 4–8 dated tasks (due_in_days counted from today, 1–120) and 2–5 acceptance criteria that can be checked. Do not change the agreed scope.",
-        RoleId::InvoiceClerk => "You are the Invoice Clerk for a one-person consulting company. Draft an invoice for the finished project: title, body listing what was delivered, the amount as a decimal string (use the offer amount or the project budget; never invent one), and due_in_days (typically 30). If the company is GST registered, say that GST applies per the local rules; do not compute tax.",
-        RoleId::QualityChecker => "You are the Quality Checker for a one-person consulting company. Read the draft and list findings: gaps (missing scope, timeline, price, recipient), contradictions, placeholders left in the text, and risks. Be specific and quote the passage. Return an empty list only if you found nothing.",
+        RoleId::InvoiceClerk => "You are the Invoice Clerk for a one-person consulting company. Draft an invoice for the finished project: title, body listing what was delivered, the amount as a decimal string of digits with at most one decimal point and no thousands separators, currency symbol or spaces (use the offer amount or the project budget; never invent one), and due_in_days (typically 30). If the company is GST registered, say that GST applies per the local rules; do not compute tax.",
+        RoleId::QualityChecker => "You are the Quality Checker for a one-person consulting company. Read the draft and list findings: gaps (missing scope, timeline, price, recipient), contradictions, placeholders left in the text, and risks. Every finding needs both fields, and its \"kind\" must be exactly one of these four words: gap, contradiction, placeholder, risk. Be specific and quote the passage. Return an empty list only if you found nothing.",
         RoleId::ComplianceChecker => "Summarise the compliance findings in plain language for the founder.",
     };
     format!(
@@ -416,16 +422,28 @@ struct ReviewFindingOut {
 /// around it) and validate it into the exact change the founder will see.
 /// Any violation returns `None`: the deterministic draft is used instead and
 /// the decision says so.
+/// The first complete JSON value at or after the first `{`, ignoring whatever
+/// follows it.
+///
+/// Spanning the first `{` to the *last* `}` looks equivalent and is not: a
+/// model that answers once and then repeats itself inside a code fence — two
+/// valid objects, measured against qwen2.5:7b — produces a span holding both,
+/// which is not valid JSON, and the whole answer was discarded for it. Taking
+/// the first value changes only which text reaches the checks below; every
+/// field is still validated, and the founder still approves the proposal.
+fn first_json_value<T: serde::de::DeserializeOwned>(json: &str) -> Option<T> {
+    serde_json::Deserializer::from_str(json)
+        .into_iter::<T>()
+        .next()?
+        .ok()
+}
+
 pub(super) fn parse_model_change(input: &RoleInput, text: &str) -> Option<ProposedChange> {
     let start = text.find('{')?;
-    let end = text.rfind('}')?;
-    if end <= start {
-        return None;
-    }
-    let json = &text[start..=end];
+    let json = &text[start..];
     match input.role {
         RoleId::Analyst => {
-            let out: AnalystOut = serde_json::from_str(json).ok()?;
+            let out: AnalystOut = first_json_value(json)?;
             let customer = input.customer.as_ref()?;
             Some(ProposedChange::DiscoverySummary {
                 customer_id: customer.id,
@@ -437,7 +455,7 @@ pub(super) fn parse_model_change(input: &RoleInput, text: &str) -> Option<Propos
             })
         }
         RoleId::ProposalWriter => {
-            let out: ProposalOut = serde_json::from_str(json).ok()?;
+            let out: ProposalOut = first_json_value(json)?;
             let customer = input.customer.as_ref()?;
             let amount_cents = match out.amount.as_deref().map(str::trim) {
                 None | Some("") | Some("null") => None,
@@ -452,7 +470,7 @@ pub(super) fn parse_model_change(input: &RoleInput, text: &str) -> Option<Propos
             })
         }
         RoleId::DeliveryPlanner => {
-            let out: PlanOut = serde_json::from_str(json).ok()?;
+            let out: PlanOut = first_json_value(json)?;
             let customer = input.customer.as_ref()?;
             if out.tasks.is_empty() || out.tasks.len() > MAX_LIST_ITEMS {
                 return None;
@@ -477,7 +495,7 @@ pub(super) fn parse_model_change(input: &RoleInput, text: &str) -> Option<Propos
             })
         }
         RoleId::InvoiceClerk => {
-            let out: InvoiceOut = serde_json::from_str(json).ok()?;
+            let out: InvoiceOut = first_json_value(json)?;
             let customer = input.customer.as_ref()?;
             let project = input.project.as_ref()?;
             let amount_cents = parse_amount_cents(out.amount.trim()).ok()?;
@@ -494,7 +512,7 @@ pub(super) fn parse_model_change(input: &RoleInput, text: &str) -> Option<Propos
             })
         }
         RoleId::QualityChecker => {
-            let out: ReviewOut = serde_json::from_str(json).ok()?;
+            let out: ReviewOut = first_json_value(json)?;
             let document = input.document.as_ref()?;
             if out.findings.len() > MAX_LIST_ITEMS {
                 return None;

--- a/apps/cli/src/workspace/crew_tests.rs
+++ b/apps/cli/src/workspace/crew_tests.rs
@@ -1,4 +1,4 @@
-use super::crew_roles::{build_input, parse_model_change};
+use super::crew_roles::{build_input, parse_model_change, prompt_for};
 use super::test_support::fake_ollama;
 use super::*;
 use sovereign_audit_ledger::AuditLedger;
@@ -621,4 +621,96 @@ fn a_real_model_answer_is_validated_and_marked_model_backed() {
     assert!(!decision.model_backed);
     assert_eq!(decision.provider_id, "ollama:test-model");
     assert!(decision.summary.contains("failed validation"));
+}
+
+/// The schema a prompt shows is itself an instruction, and a model copies its
+/// shape. Writing the allowed values as `"kind":"gap"|"contradiction"|…` read
+/// as a list of bare values: against qwen2.5:7b, four of six measured
+/// validation failures came back as `{"placeholder","detail":…}` with the key
+/// name dropped, and the whole finding list was refused for it.
+///
+/// So the enum belongs in the task text, and the schema shows one field of
+/// one type. This test pins that split — the shape that misled the model must
+/// not come back, and the four words must still be stated somewhere.
+#[test]
+fn the_quality_checker_prompt_states_its_enum_in_prose_not_in_the_schema() {
+    let (_dir, store) = store();
+    store.set_venture("Acme", "Service").unwrap();
+    let workspace = store.add_customer("Acme Ltd", "", "notes").unwrap();
+    let customer_id = workspace.customers[0].id;
+    let workspace = store
+        .create_document(DocumentKind::Offer, customer_id, None, "en")
+        .unwrap();
+    let document_id = workspace.documents[0].id;
+    let input = build_input(
+        &workspace,
+        RoleId::QualityChecker,
+        RunSubject {
+            customer_id: None,
+            document_id: Some(document_id),
+            project_id: None,
+        },
+        "en",
+    )
+    .unwrap();
+    let prompt = prompt_for(&input);
+
+    assert!(
+        prompt.contains(r#"{"findings":[{"kind":string,"detail":string}]}"#),
+        "the schema no longer shows one typed field per key: {prompt}"
+    );
+    assert!(
+        !prompt.contains(r#""kind":"gap""#),
+        "the alternation that misled the model is back in the schema"
+    );
+    for word in ["gap", "contradiction", "placeholder", "risk"] {
+        assert!(prompt.contains(word), "the prompt stopped naming {word}");
+    }
+
+    // And the parser still refuses the malformed shape, whatever the prompt
+    // says — a prompt is a request, not a guarantee.
+    assert!(parse_model_change(&input, r#"{"findings":[{"placeholder","detail":"x"}]}"#).is_none());
+}
+
+/// A model that answers, then repeats the same answer inside a code fence.
+/// Measured against qwen2.5:7b; the two objects are byte-identical and both
+/// valid, and spanning the first `{` to the last `}` produced a string that
+/// is neither. The answer was thrown away and the template used instead.
+#[test]
+fn an_answer_repeated_after_itself_is_still_read() {
+    let (_dir, store) = store();
+    store.set_venture("Acme", "Service").unwrap();
+    let workspace = store.add_customer("Acme Ltd", "", "notes").unwrap();
+    let customer_id = workspace.customers[0].id;
+    let workspace = store
+        .create_document(DocumentKind::Offer, customer_id, None, "en")
+        .unwrap();
+    let document_id = workspace.documents[0].id;
+    let input = build_input(
+        &workspace,
+        RoleId::QualityChecker,
+        RunSubject {
+            customer_id: None,
+            document_id: Some(document_id),
+            project_id: None,
+        },
+        "en",
+    )
+    .unwrap();
+
+    let once = r#"{"findings":[{"kind":"gap","detail":"no timeline"}]}"#;
+    let twice = format!("{once}```json\n{once}\n```");
+    let parsed = parse_model_change(&input, &twice).expect("the repeated answer was discarded");
+    match parsed {
+        ProposedChange::ReviewFindings { findings, .. } => {
+            assert_eq!(findings.len(), 1, "{findings:?}");
+            assert_eq!(findings[0].kind, "gap");
+        }
+        other => panic!("wrong change: {other:?}"),
+    }
+
+    // Reading only the first value must not soften any check: a first value
+    // that fails validation is still refused, whatever follows it.
+    let bad_then_good = format!(r#"{{"findings":[{{"kind":"not-a-kind","detail":"x"}}]}}{once}"#);
+    assert!(parse_model_change(&input, &bad_then_good).is_none());
 }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1509,19 +1509,28 @@ Entries here follow the queue rules above; `lane:codex` does not apply.
 - [x] **P1 | `apps/cli/src/workspace/` | Singapore demo rule pack, keyword retrieval, deterministic compliance checks, reports.** Landed 2026-09-10 (`compliance*`).
 - [x] **P1 | `apps/cli/assets/`, `apps/cli/src/ui_mvp.rs` | Seven-tab bilingual MVP pages.** Landed 2026-09-10; verified by hand in the in-app browser.
 
-- [ ] **P1 | `docs/`, `apps/cli/` | Live verification with a real Ollama model and the five-consultant usability protocol.**
-  2026-09-10: the half that needs no model ran — every route and page on a
-  fresh workspace, report at
-  `docs/handoff/reports/2026-09-10-mvp-walkthrough-without-a-model.md`, two
-  defects fixed in #91. The model half is blocked on Ollama being
-  installed on the founder's machine; nothing about model quality is known.
-  Run every role against a real local model (`ollama serve`, a pulled model,
-  `model.json` enabled) and record which proposals validated, which fell back
-  to the template, and why; then run the five-consultant usability protocol
-  from the superseded playground plan (Task 8) on the MVP. Done when: a
-  report under `docs/handoff/reports/` records model, prompts' pass/fail per
-  role, and the usability observations, with follow-up entries queued for
-  every failure.
+- [ ] **P1 | `docs/` | The five-consultant usability protocol on the MVP.**
+  The model half of this item is done and reported
+  (`docs/handoff/reports/2026-09-11-live-model-verification.md`, 2026-09-11):
+  `qwen2.5:7b` through Ollama, every role five times per language against
+  fixed facts, 27/30 → 30/30 (en) and 27/30 → 29/30 (zh) after one transport
+  fix (#94) and two prompt/parsing fixes. What remains needs five people, not
+  a script: run the five-consultant usability protocol from the superseded
+  playground plan (Task 8) on the MVP and record the observations, with
+  follow-up entries queued for every failure.
+
+- [ ] **P2 | `crates/model/`, `apps/cli/src/workspace/` | Say why a model answer was not used.**
+  A silent fallback is only honest if someone can see it. The proposal card
+  says `model_backed: false` without a reason, and the disclosure record lists
+  skipped providers without one — `SkipReason.reason` exists in
+  `crates/model` and the workspace disclosure drops it. A founder cannot tell
+  "the model was wrong this time" from "the model has never once worked",
+  which is exactly what the chunked-transfer defect (#94) hid behind for its
+  whole life. Done when: the disclosure carries each skip's reason, a rejected
+  model answer carries a category (not the text — evidence records occurrence,
+  not content), both surface in the UI, and a test covers a skipped provider
+  and a rejected answer.
+
 - [ ] **P2 | `apps/cli/src/` | HTTP-layer tests for the MVP routes.**
   Extend the loopback HTTP boundary (HO-002) to cover `/api/workspace/profile`,
   `customer/update`, `document/update`, `project`, `task`, `follow-up`,

--- a/docs/handoff/reports/2026-09-11-live-model-verification.md
+++ b/docs/handoff/reports/2026-09-11-live-model-verification.md
@@ -1,0 +1,128 @@
+# Live verification against a real local model
+
+- **Outcome:** the configured model never produced a word until today; one
+  transport defect and two prompt/parsing defects fixed, each measured before
+  and after
+- **Model:** `qwen2.5:7b` via Ollama 0.33.3 on the founder's Mac (18 GB, arm64)
+- **Base:** `b0ada96` · **Merged on the way:** #94 (chunked transfer)
+- **Backlog item:** "Live verification with a real Ollama model and the
+  five-consultant usability protocol" — the model half; the five-consultant
+  protocol still needs five people and is not addressed here
+
+## The one thing to read first
+
+**Before today, a correctly configured local model on this machine produced
+nothing, and the product said everything was fine.** The Security page showed
+the provider `healthy`, the model status page showed `real_model: true`, and
+every AI-employee proposal came back from the template drafter. The only
+honest signal was one field on each disclosure record —
+`failover_from: ["ollama:qwen2.5:7b"]` — and nothing surfaced it.
+
+The cause was one line in `crates/model/src/ollama.rs`: the HTTP response
+parser refused `Transfer-Encoding: chunked`. Ollama sets a content length only
+when the whole body fits its write buffer, so the health probe (a short
+`GET /api/tags`) got a content length and passed, while every real answer came
+back chunked and failed. A provider that is reachable, healthy, and never
+usable is worse than one that is down, because the fallback is silent by
+design and nothing distinguished the two. Fixed in #94.
+
+## What was measured
+
+All numbers below: one fixed workspace — a company profile, one customer with
+discovery notes, an accepted offer, a finished project, an invoice — with each
+role re-run five times against **identical facts**, so the only variable is the
+model. Runs were not approved, so the state never moved between trials.
+
+| Role | en before | en after | zh before | zh after | median |
+| --- | --- | --- | --- | --- | --- |
+| Requirements Analyst | 5/5 | 5/5 | 5/5 | 5/5 | 6–8 s |
+| Proposal Writer | 5/5 | 5/5 | 5/5 | 5/5 | 15–18 s |
+| Delivery Planner | 5/5 | 5/5 | 5/5 | 5/5 | 6–9 s |
+| Invoice Clerk | 4/5 | 5/5 | 5/5 | 5/5 | 1.5–3 s |
+| Quality Checker | 4/5 | 5/5 | **2/5** | 4/5 | 4–9 s |
+| Compliance Checker | 4/5 | 5/5 | 5/5 | 5/5 | 7–10 s |
+| **Total** | **27/30** | **30/30** | **27/30** | **29/30** | |
+
+"Validated" means the model's own output survived the typed struct, the field
+guards, and the role's checks, and became the proposal. Anything else falls
+back to the deterministic template and says so on the card.
+
+## The six failures, by cause
+
+Every failing response was captured verbatim through a loopback logging proxy
+in front of Ollama, so these are transcripts, not inferences.
+
+**1. The schema taught the model to answer wrongly — four of six.** The
+Quality Checker's schema line read
+`{"findings":[{"kind":"gap"|"contradiction"|"placeholder"|"risk","detail":string}]}`.
+A model reads that alternation as a list of bare values, and copied the shape
+back: `{"placeholder","detail":"…"}`, with the key name dropped. One malformed
+finding voids the whole list. The four allowed words moved into the task text,
+where they cannot be mistaken for syntax, and the schema now shows one typed
+field per key. zh went 2/5 → 4/5 on this alone.
+
+**2. The same answer, twice — two of the remaining.** After fix 1, a new shape
+surfaced: the model answered, then repeated the byte-identical object inside a
+```` ```json ```` fence. Both objects are valid; the extraction spanned from
+the first `{` to the *last* `}`, which is not. The parser now reads the first
+complete JSON value and ignores what follows. This changes only which text
+reaches the checks — every field is still validated, and the founder still
+approves every proposal.
+
+**3. An amount with thousands separators — one.** `"amount":"4.000.000"` for a
+5,000.00 offer. `parse_amount_cents` refused it, correctly: had it been
+accepted by a looser parser it would have been an invoice off by three orders
+of magnitude. The prompt now states the exact format (digits, at most one
+decimal point, no separators, no currency symbol). Not observed again.
+
+**4. Raw newlines inside a JSON string — one.** The Compliance Checker's
+summary contained literal line breaks inside the quoted value, which is not
+valid JSON. Refused, template used. Nothing to fix here: the model was wrong
+and the guard did its job.
+
+**5. A truncated answer — one, still present.** One Chinese Quality Checker
+response ended after the findings array with no closing brace. An incomplete
+answer must be refused. This is the failure mode that remains at 1/5 for that
+one role in Chinese, and it is the correct behaviour.
+
+Causes 4 and 5 are the model being wrong and the system refusing it. Causes 1,
+2 and 3 were the product being wrong about how it asked.
+
+## What this says about the design
+
+The guard held in every case. Six times the model produced something the
+system could not verify, and six times a founder got a template draft labelled
+"not a model's" rather than a plausible-looking invoice with a wrong number.
+That is the property the whole crew design exists for, and it is now observed
+rather than assumed.
+
+The weakness it exposes is a different one: **a silent fallback is only honest
+if someone can see it.** `model_backed: false` appears on the proposal card,
+but the reason does not, and the disclosure record lists which providers were
+skipped without saying why — `SkipReason.reason` exists in `crates/model` and
+the workspace disclosure drops it on the floor. A founder who configures a
+model and gets template output has no way to tell "the model was wrong this
+time" from "the model has never once worked". That is the same gap the
+chunked-transfer defect hid behind, and it is queued as a P2.
+
+## What is still not verified
+
+- **The five-consultant usability protocol.** It needs five people.
+- **Model quality**, as opposed to model *validity*. Nothing here says whether
+  a proposal is any good — only that its shape was checked before a founder
+  was shown it. The summaries read plausibly; that is not a measurement.
+- **Any model other than `qwen2.5:7b`**, and any machine other than this one.
+  Both prompt defects are the kind that a different model would hit at a
+  different rate.
+
+## Reproducing this
+
+`ollama serve`, then a fresh `HOME` whose
+`Library/Application Support/sovereign-founder-os/model.json` is
+`{"version":1,"ollama":{"enabled":true,"base_url":"http://127.0.0.1:11434","model":"qwen2.5:7b"}}`,
+then `sovereign ui --no-open --port <port>`. Drive it over the loopback API
+with `Host: 127.0.0.1:<port>`; the route sequence is in
+`docs/handoff/reports/2026-09-10-mvp-walkthrough-without-a-model.md`. To read
+what the model actually returned, put a logging proxy on another loopback port
+and point `base_url` at it — the provider accepts any `127.0.0.1` port, and
+without that the failing responses are unrecoverable.


### PR DESCRIPTION
The model half of the backlog item "Live verification with a real Ollama model". Full report: `docs/handoff/reports/2026-09-11-live-model-verification.md`.

## How this was measured

One fixed workspace — company profile, a customer with discovery notes, an accepted offer, a finished project, an invoice — with each of the six roles re-run five times per language against **identical facts**. Runs were not approved, so state never moved between trials. Failing responses were captured verbatim through a loopback logging proxy in front of Ollama, so the causes below are transcripts, not inferences.

| | en before | en after | zh before | zh after |
| --- | --- | --- | --- | --- |
| validated | 27/30 | **30/30** | 27/30 | **29/30** |

## Three defects, all ours

**The schema taught the model to answer wrongly (4 of 6 failures).** `"kind":"gap"|"contradiction"|"placeholder"|"risk"` reads as a list of bare values; the model copied that shape back as `{"placeholder","detail":"…"}` with the key name dropped, and one malformed finding voids the whole list. The four words move into the task text; the schema shows one typed field per key. zh Quality Checker went 2/5 → 4/5 on this alone.

**The same answer twice (2 more, surfaced after the first fix).** The model answers, then repeats the byte-identical object inside a ```` ```json ```` fence. Both objects are valid; the first-`{`-to-last-`}` span is not. The parser now reads the first complete JSON value. Every field is still validated and the founder still approves every proposal — this only changes which text reaches the checks.

**An amount with thousands separators (1).** `"amount":"4.000.000"` for a 5,000.00 offer. `parse_amount_cents` refused it, correctly — a looser parser would have produced an invoice off by three orders of magnitude — so the fix is in the prompt, which now states the exact format.

The other two failures were the model being wrong and the guard doing its job: literal newlines inside a JSON string, and a truncated answer. Both must stay refused; the truncated one is the remaining 1/30.

## Tests

- `the_quality_checker_prompt_states_its_enum_in_prose_not_in_the_schema` — pins the split and that the misleading shape cannot come back.
- `an_answer_repeated_after_itself_is_still_read` — the observed duplicate answer, plus a case proving a first value that fails validation is still refused.

Both were sabotaged to confirm they bite; the first sabotage attempt did not, because the extraction span is not what fixes the duplicate — the value reader is — so it was redone against the reader.

`./scripts/test_changed.sh` green; clippy clean.
