### PR TITLE
feat(workspace): reconcile decisions, payments and compliance reports against the chain

### DIFF
--- a/apps/cli/src/workspace/reporting.rs
+++ b/apps/cli/src/workspace/reporting.rs
@@ -2,6 +2,7 @@ use super::erp_ops::receivable_rows;
 use super::types::document_status_label;
 use super::util::{now, storage};
 use super::*;
+use std::collections::BTreeMap;
 use uuid::Uuid;
 
 use sovereign_audit_ledger::AuditLedger;
@@ -252,6 +253,82 @@ impl Store {
             }
         }
 
+        // Counting, not existence, for the two kinds whose signed event names
+        // a subject rather than the record itself: two payments against one
+        // invoice share the invoice as their resource, and so do two
+        // compliance checks of the same subject. Asking only whether *an*
+        // event exists would let the second one hide behind the first one's
+        // evidence.
+        let count = |action: &str, resource: &str| {
+            events
+                .iter()
+                .filter(|event| event.action == action && event.resource == resource)
+                .count()
+        };
+
+        // An approved decision is how an AI employee's proposal becomes a
+        // change to the founder's own records. One sitting in state with
+        // nothing signed behind it is a change nobody agreed to.
+        for decision in &workspace.decisions {
+            if decision.status != DecisionStatus::Approved {
+                continue;
+            }
+            let resource = format!("decision:{}", decision.id);
+            if !has("decision.approved", &resource) {
+                findings.push(IntegrityFinding {
+                    severity: "critical",
+                    resource,
+                    detail: format!(
+                        "decision \"{}\" is approved with no signed decision.approved event",
+                        decision.title
+                    ),
+                });
+            }
+        }
+
+        let mut payments_per_invoice: BTreeMap<Uuid, usize> = BTreeMap::new();
+        for payment in &workspace.payments {
+            *payments_per_invoice.entry(payment.invoice_id).or_default() += 1;
+        }
+        for (invoice_id, recorded) in payments_per_invoice {
+            let resource = format!("document:{invoice_id}");
+            let signed = count("payment.record", &resource);
+            if signed < recorded {
+                findings.push(IntegrityFinding {
+                    severity: "critical",
+                    resource,
+                    detail: format!(
+                        "{recorded} payment(s) are recorded against this invoice with only \
+                         {signed} signed payment.record event(s)"
+                    ),
+                });
+            }
+        }
+
+        // Compliance reports, per subject, and one-way on purpose: the store
+        // drops the oldest report once it holds `MAX_COMPLIANCE_REPORTS`
+        // while its event stays on the chain, so more events than reports is
+        // history rather than a fault. Fewer is missing evidence.
+        let mut reports_per_subject: BTreeMap<String, usize> = BTreeMap::new();
+        for report in &workspace.compliance_reports {
+            *reports_per_subject
+                .entry(compliance_resource(&report.subject))
+                .or_default() += 1;
+        }
+        for (resource, stored) in reports_per_subject {
+            let signed = count("compliance.checked", &resource);
+            if signed < stored {
+                findings.push(IntegrityFinding {
+                    severity: "critical",
+                    resource,
+                    detail: format!(
+                        "{stored} compliance report(s) are stored for this subject with only \
+                         {signed} signed compliance.checked event(s)"
+                    ),
+                });
+            }
+        }
+
         // The reverse direction: signed events whose state never landed.
         // Commits are audit-first — every event of an operation in one chain
         // write, then the state write — so only the *tail* of the chain can
@@ -289,6 +366,33 @@ impl Store {
                         ),
                         "effect.revoked" => document_status != Some(DocumentStatus::Revoked),
                         "delivery.confirmed" => document_status != Some(DocumentStatus::Delivered),
+                        "decision.approved" => subject_id.is_some_and(|id| {
+                            !workspace.decisions.iter().any(|decision| {
+                                decision.id == id && decision.status == DecisionStatus::Approved
+                            })
+                        }),
+                        "payment.record" => subject_id.is_some_and(|id| {
+                            workspace
+                                .payments
+                                .iter()
+                                .filter(|payment| payment.invoice_id == id)
+                                .count()
+                                < count("payment.record", &event.resource)
+                        }),
+                        // Only meaningful below the trim cap: at the cap the
+                        // two counts diverge for a legitimate reason and this
+                        // would misfire on every check from then on.
+                        "compliance.checked" => {
+                            workspace.compliance_reports.len() < MAX_COMPLIANCE_REPORTS
+                                && workspace
+                                    .compliance_reports
+                                    .iter()
+                                    .filter(|report| {
+                                        compliance_resource(&report.subject) == event.resource
+                                    })
+                                    .count()
+                                    < count("compliance.checked", &event.resource)
+                        }
                         _ => false,
                     }
                 });
@@ -459,4 +563,15 @@ fn format_money(cents: u64) -> String {
         grouped.push(ch);
     }
     format!("{grouped}.{:02}", cents % 100)
+}
+
+/// A compliance report records its subject as `venture` or `document:<id>`;
+/// the signed event names the same subject as `venture:profile` or
+/// `document:<id>`. One function, so the two readings cannot drift apart.
+fn compliance_resource(subject: &str) -> String {
+    if subject == "venture" {
+        "venture:profile".to_owned()
+    } else {
+        subject.to_owned()
+    }
 }

--- a/apps/cli/src/workspace/tests.rs
+++ b/apps/cli/src/workspace/tests.rs
@@ -786,6 +786,125 @@ fn command_center_guidance_reports_pending_and_all_clear() {
     assert_eq!(kinds, vec!["all_clear"]);
 }
 
+/// One hand-edited-vault scenario: the record forged into state, the signed
+/// event whose absence must be reported, and how to forge it.
+struct ForgedRecord {
+    what: &'static str,
+    missing_event: &'static str,
+    forge: fn(&mut Workspace),
+}
+
+/// The three kinds of record the MVP added after the self-audit was written:
+/// an approved decision, a payment, and a compliance report. Each is state
+/// that either records money, changes the founder's records on an employee's
+/// say-so, or makes a compliance claim — so each must have signed evidence,
+/// and a vault edited to add one without its event must fail closed.
+#[test]
+fn integrity_check_covers_decisions_payments_and_compliance_reports() {
+    let (_dir, store) = store();
+    store.set_venture("Acme", "Landing pages").unwrap();
+    let workspace = store.add_customer("Dr. Tan", "", "expo").unwrap();
+    let customer_id = workspace.customers[0].id;
+    let workspace = store
+        .create_document(DocumentKind::Invoice, customer_id, Some(250_000), "en")
+        .unwrap();
+    let invoice_id = workspace.documents[0].id;
+    let workspace = store.request_send(invoice_id).unwrap();
+    store.decide(workspace.approvals[0].id, true).unwrap();
+    store
+        .record_payment(invoice_id, 250_000, 1_700_000_000, "bank transfer")
+        .unwrap();
+    let workspace = store.hire_employee(RoleId::Analyst, "Analyst").unwrap();
+    let employee_id = workspace.employees[0].id;
+    let decision = store
+        .run_employee(
+            employee_id,
+            RunSubject {
+                customer_id: Some(customer_id),
+                document_id: None,
+                project_id: None,
+            },
+            "en",
+        )
+        .unwrap();
+    store.decide_proposal(decision.id, true).unwrap();
+    store
+        .run_compliance_check(ComplianceSubject { document_id: None }, "en")
+        .unwrap();
+
+    // Built only through the audited API, all three reconcile.
+    let clean_state = store.load().unwrap();
+    let clean = store.integrity_check().unwrap();
+    assert!(clean.ok, "{:?}", clean.findings);
+    assert!(clean.findings.is_empty(), "{:?}", clean.findings);
+
+    // Each tamper is the shape a hand-edited vault produces: a record that
+    // exists in state with nothing signed behind it.
+    let cases = [
+        ForgedRecord {
+            what: "an approved decision",
+            missing_event: "decision.approved",
+            forge: |workspace| {
+                let mut forged = workspace.decisions[0].clone();
+                forged.id = Uuid::new_v4();
+                forged.title = "Forged decision".into();
+                forged.status = DecisionStatus::Approved;
+                workspace.decisions.push(forged);
+            },
+        },
+        ForgedRecord {
+            what: "a second payment",
+            missing_event: "payment.record",
+            forge: |workspace| {
+                let mut forged = workspace.payments[0].clone();
+                forged.id = Uuid::new_v4();
+                workspace.payments.push(forged);
+            },
+        },
+        ForgedRecord {
+            what: "a second compliance report",
+            missing_event: "compliance.checked",
+            forge: |workspace| {
+                let mut forged = workspace.compliance_reports[0].clone();
+                forged.id = Uuid::new_v4();
+                workspace.compliance_reports.push(forged);
+            },
+        },
+    ];
+
+    for ForgedRecord {
+        what,
+        missing_event: event_name,
+        forge,
+    } in cases
+    {
+        let mut tampered = clean_state.clone();
+        forge(&mut tampered);
+        store.save(&tampered).unwrap();
+
+        let report = store.integrity_check().unwrap();
+        assert!(!report.ok, "{what} passed the self-audit");
+        assert!(
+            report.chain_verified,
+            "{what}: the chain itself is untouched"
+        );
+        assert!(
+            report.findings.iter().any(
+                |finding| finding.severity == "critical" && finding.detail.contains(event_name)
+            ),
+            "{what}: expected a finding naming {event_name}, got {:?}",
+            report.findings
+        );
+
+        // Back to clean, so each case is judged on its own.
+        store.save(&clean_state).unwrap();
+        assert!(
+            store.integrity_check().unwrap().ok,
+            "{what}: restore failed"
+        );
+    }
+}
+
 #[test]
 fn verify_export_accepts_genuine_bundle_and_rejects_tampering() {
     let (_dir, store) = store();

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1614,12 +1614,21 @@ Entries here follow the queue rules above; `lane:codex` does not apply.
   does not create fails the test, which walks the serialised report instead
   of naming fields.
 
-- [ ] **P2 | `apps/cli/src/workspace/reporting.rs` | Integrity self-audit covers the MVP events.**
-  Reconcile approved decisions (`decision.approved` must exist for every
-  approved decision), payments (`payment.record`), and compliance reports
-  (`compliance.checked`) against the chain, in both directions. Done when
-  `integrity_check` fails closed on a vault edited to add an approved
-  decision without its event.
+- [x] **P2 | `apps/cli/src/workspace/reporting.rs` | Integrity self-audit covers the MVP events.**
+  Landed 2026-09-11. Approved decisions (`decision.approved`), payments
+  (`payment.record`) and compliance reports (`compliance.checked`) reconcile
+  against the chain in both directions.
+  Payments and compliance reports are reconciled **by count, not existence**:
+  their signed event names the subject (the invoice, the venture) rather than
+  the record, so two payments against one invoice share a resource and the
+  second would otherwise hide behind the first one's evidence. The compliance
+  direction is one-way below the trim cap, because the store drops the oldest
+  report at `MAX_COMPLIANCE_REPORTS` while its event stays.
+  `integrity_check_covers_decisions_payments_and_compliance_reports` forges
+  each of the three in a saved vault and asserts a critical finding naming
+  the missing event, restoring to clean between cases so each is judged on
+  its own.
+
 - [ ] **P2 | `apps/cli/src/workspace/compliance_pack.rs` | Professional review pass over the Singapore pack.**
   Each rule's summary and check must be confirmed against its cited source
   by a person; rules that cannot be confirmed are demoted to `demo_rule` or


### PR DESCRIPTION
Closes the P2 "Integrity self-audit covers the MVP events". Pairs with #99: that one says what a bundle *holds*, this one says whether it happened.

## The gap

The self-audit was written before the MVP had AI employees, payments or compliance checks. An approved decision, a recorded payment and a stored compliance report could each sit in a hand-edited vault with nothing signed behind them, and `integrity_check` still reported `ok`.

## What is reconciled now

- **Approved decisions** → `decision.approved`. This is how an employee's proposal becomes a change to the founder's own records; one with no signed event is a change nobody agreed to.
- **Payments** → `payment.record`, **by count**.
- **Compliance reports** → `compliance.checked`, **by count**, one-way.

## Why counting rather than existence

Both of those events name the *subject* — the invoice, the venture — not the record. Two payments against one invoice therefore share a resource, and `has(action, resource)` would let the second one hide behind the first one's evidence. Counting how many events name that invoice catches it.

This is not hypothetical: softening that comparison back to existence is one of the three sabotages below, and the test catches it.

The compliance direction stays one-way while the store is below `MAX_COMPLIANCE_REPORTS`, because at the cap it drops the oldest report and keeps its event — more events than reports is history, not a fault. The tail check stops there for the same reason rather than misfiring on every check from that point on.

`compliance_resource` exists because a report records its subject as `venture` while the event names it `venture:profile`; one function so the two readings cannot drift.

## Test

`integrity_check_covers_decisions_payments_and_compliance_reports` builds all three through the audited API, confirms a clean reconciliation, then forges each into a saved vault (`store.save`, the shape a hand-edited vault produces) and asserts a **critical** finding naming the missing event — restoring to clean between cases so each is judged on its own.

Sabotaged three ways, one per check, each confirmed to fail the test: stop checking approved decisions; compare payments by existence instead of count; stop counting compliance reports.

`./scripts/test_changed.sh` green; clippy clean.
