### PR TITLE
feat(workspace): purge expired authority claims, and withdraw the revocation half

### DIFF
--- a/apps/cli/src/workspace/kernel_exec.rs
+++ b/apps/cli/src/workspace/kernel_exec.rs
@@ -278,10 +278,26 @@ impl Store {
         .map_err(kernel)?
         .with_approval_trust(approval_trust, OWNER_APPROVAL_ISSUER)
         .map_err(kernel)?
-        .with_authority_store(
-            sovereign_authority::AuthorityStore::open(self.root.join("authority"))
-                .map_err(kernel)?,
-        );
+        .with_authority_store({
+            let store = sovereign_authority::AuthorityStore::open(self.root.join("authority"))
+                .map_err(kernel)?;
+            // Consumed claims are kept so a replay is recognised as one, and
+            // they stop being useful the moment the authority they record
+            // has expired — after that they are only growth. Nothing in the
+            // product had ever called this, so every claim a founder's
+            // machine ever made was still on disk.
+            //
+            // Here rather than on workspace open: `Store::open` runs on
+            // every request, and a directory scan per request to tidy
+            // records that age in hours is the wrong trade. A delivery is
+            // rare and already pays for crypto and a sandbox.
+            //
+            // A failed purge does not fail the delivery. Housekeeping is not
+            // a gate, and a store too unhealthy to purge will fail the claims
+            // below on its own — which is the check that matters.
+            let _ = purge_authority_claims(&store, now());
+            store
+        });
         let mut executor = VerifiedSandboxExecutor::new(vec![selector], validator)
             .map_err(kernel)?
             .with_execution_journal(
@@ -442,6 +458,17 @@ fn evaluate_delivery_policy(
         ));
     }
     Ok(decision)
+}
+
+/// Drop claim records whose authority has expired, returning how many went.
+///
+/// Separate from its caller so a test can ask for a horizon: in production
+/// the horizon is simply now, and nothing that has not expired is touched.
+pub(super) fn purge_authority_claims(
+    store: &sovereign_authority::AuthorityStore,
+    now_unix: i64,
+) -> usize {
+    store.purge_expired(now_unix).unwrap_or(0)
 }
 
 /// Assemble the evidence record persisted onto the approval: everything the

--- a/apps/cli/src/workspace/tests.rs
+++ b/apps/cli/src/workspace/tests.rs
@@ -786,6 +786,61 @@ fn command_center_guidance_reports_pending_and_all_clear() {
     assert_eq!(kinds, vec!["all_clear"]);
 }
 
+/// Consumed claims are kept so a replay is recognised as one, and they are
+/// only growth once the authority they record has expired. Nothing in the
+/// product had ever called `purge_expired`, so every claim a founder's
+/// machine ever made stayed on disk for the life of the install.
+///
+/// The horizon is a parameter so this can ask what happens after the claims
+/// age out, rather than waiting an hour; production passes `now()`, which
+/// touches nothing that has not expired.
+#[test]
+fn expired_authority_claims_are_purged_and_live_ones_are_not() {
+    let (dir, store) = store();
+    store.set_venture("Acme", "Landing pages").unwrap();
+    let workspace = store.add_customer("Dr. Tan", "", "expo").unwrap();
+    let customer_id = workspace.customers[0].id;
+    let workspace = store
+        .create_document(DocumentKind::Invoice, customer_id, Some(250_000), "en")
+        .unwrap();
+    let document_id = workspace.documents[0].id;
+    let workspace = store.request_send(document_id).unwrap();
+    store.decide(workspace.approvals[0].id, true).unwrap();
+
+    let authority = dir.path().join("authority");
+    let held = || -> usize {
+        ["tokens", "approvals", "idempotency", "bundles"]
+            .iter()
+            .map(|kind| {
+                std::fs::read_dir(authority.join(kind))
+                    .map(|entries| entries.count())
+                    .unwrap_or(0)
+            })
+            .sum()
+    };
+    let after_delivery = held();
+    assert!(
+        after_delivery >= 4,
+        "the delivery left no durable claims to purge: {after_delivery}"
+    );
+
+    let opened = sovereign_authority::AuthorityStore::open(&authority).unwrap();
+
+    // Now: the claims are live, so a purge must leave every one of them. A
+    // purge that took a live claim would delete the evidence that makes a
+    // replay recognisable.
+    assert_eq!(
+        super::kernel_exec::purge_authority_claims(&opened, super::util::now()),
+        0
+    );
+    assert_eq!(held(), after_delivery, "a live claim was purged");
+
+    // Well past their expiry: they go.
+    let purged = super::kernel_exec::purge_authority_claims(&opened, super::util::now() + 86_400);
+    assert!(purged >= 4, "only {purged} records purged");
+    assert_eq!(held(), 0, "expired claims survived the purge");
+}
+
 /// One hand-edited-vault scenario: the record forged into state, the signed
 /// event whose absence must be reported, and how to forge it.
 struct ForgedRecord {

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -882,18 +882,31 @@ while the controller routes eligible design/review cards to the strong role.
   in `cargo test -p sovereign-cli`, reusing the existing workspace fixtures
   rather than inventing new state.
 
-- [ ] **P2 | `apps/cli/src/workspace/` | Tie delivery revocation to authority revocation and purge expired claims on open.**
-  Blocked on the `crates/capability` entry above. Today `revoke_delivery`
-  (ops.rs:336) removes the outbox file while the underlying capability and
-  approval stay consumable, and `purge_expired` is never called in product
-  code. Wire: revoking a delivery also revokes its capability fingerprint and
-  approval id in the workspace authority store (attached at
-  kernel_exec.rs:281-284) and appends an audit event; workspace open calls
-  `purge_expired` under the amendment's retention rules. Done when: a test
-  revokes a pending delivery and a subsequent dispatch attempt through
-  `execute_in_sandbox` fails closed with the revocation error, a test proves
-  expired records are purged on open, and `cargo test -p sovereign-cli`
-  passes.
+- [x] **P2 | `apps/cli/src/workspace/` | Purge expired authority claims. (Was: also tie delivery revocation to authority revocation.)**
+  Landed 2026-09-11, half implemented and half withdrawn on evidence.
+  **Purging is done.** `purge_expired` had never been called from product
+  code — every claim a founder's machine ever made was still on disk — and
+  the delivery path now purges when it opens the authority store. There
+  rather than on workspace open because `Store::open` runs on every request
+  and a directory scan per request to tidy records that age in hours is the
+  wrong trade; a delivery is rare and already pays for crypto and a sandbox.
+  A failed purge does not fail the delivery: housekeeping is not a gate.
+  `expired_authority_claims_are_purged_and_live_ones_are_not` checks both
+  directions — a purge at `now()` must remove nothing, because deleting a
+  live claim would delete the evidence that makes a replay recognisable.
+  **The revocation half was withdrawn: its premise no longer holds.** The
+  entry says "the underlying capability and approval stay consumable". They
+  do not, since the bundle transaction landed (#90). Probed on a real
+  delivery: the authority store afterwards holds 1 token, 1 approval, 1
+  idempotency and 2 bundle records — all consumed — so a replay already
+  fails as `Replay`/`AlreadyConsumed`, and revoking them after the fact
+  would protect nothing. Revoking the approval would also be the wrong
+  gesture now that a revoked document reopens as a new draft (#93): the
+  founder is withdrawing one send, not their ability to authorise another.
+  The one case where revocation would still bite — a dispatch interrupted
+  between minting the bundle and committing it, resumed after the founder
+  revoked the delivery — belongs with the execution-journal entry below,
+  which is where Indeterminate records are reconciled.
 
 - [ ] **P2 | `tests/adversarial/` | Pin the transactional/revocation security invariants cross-crate.**
   Blocked on everything above. Two invariants as adversarial tests, driven


### PR DESCRIPTION
The P2 "Tie delivery revocation to authority revocation and purge expired claims on open" — one half implemented, one half withdrawn on evidence.

## Implemented: the purge

Consumed claim records are kept so a replay is recognised as one. They stop being useful the moment the authority they record has expired; after that they are only growth. **Nothing in the product had ever called `purge_expired`** — every claim a founder's machine had ever made was still on disk.

The delivery path now purges when it opens the authority store. Not on workspace open, as the entry suggested: `Store::open` runs on every HTTP request, and a directory scan per request to tidy records that age in hours is the wrong trade. A delivery is rare and already pays for crypto and a sandbox.

A failed purge does not fail the delivery. Housekeeping is not a gate, and a store too unhealthy to purge will fail the claims themselves — which is the check that matters.

## Withdrawn: the revocation, because its premise stopped being true

The entry says "`revoke_delivery` removes the outbox file while the underlying capability and approval stay consumable". They do not, since the bundle transaction landed in #90 — which is *after* this entry was written.

Probed on a real delivery, the authority store afterwards holds:

```
tokens: 1   approvals: 1   idempotency: 1   bundles: 2   revoked-*: 0
```

All consumed. A replay already fails as `Replay`/`AlreadyConsumed`, so revoking them after the fact would protect nothing — it would be a security-looking change that secures nothing, which is worse than no change.

It would also be the wrong gesture now. Since #93 a revoked document reopens as a new draft revision: the founder is withdrawing *one send*, not their ability to authorise another, and revoking the approval conflates the two.

The one case where revocation would still bite — a dispatch interrupted between minting the bundle and committing it, then resumed after the founder revoked the delivery — is recorded against the execution-journal P2, which is where Indeterminate records are reconciled. That is where it belongs.

## Test

`expired_authority_claims_are_purged_and_live_ones_are_not` asks **both** directions against a real delivery's records:

- a purge at `now()` must remove **nothing** — deleting a live claim would delete the evidence that makes a replay recognisable;
- a purge past their expiry must remove all of them.

Sabotaged both ways: a purge that does nothing fails the second assertion (`only 0 records purged`), and a purge that ignores its horizon fails the first (`a live claim was purged`).

The horizon is a parameter so the test can ask about expiry without waiting an hour; production passes `now()`.

`./scripts/test_changed.sh` green; clippy clean.
