### PR TITLE
feat(vault-v2): pin SQLCipher 4.14.0 and prove what the linker actually found

### DIFF
--- a/.github/workflows/owner-effect-fixture.yml
+++ b/.github/workflows/owner-effect-fixture.yml
@@ -80,12 +80,35 @@ jobs:
         run: cargo test --manifest-path fixtures/owner-webauthn/Cargo.toml --locked
 
       # The isolation itself, checked rather than assumed.
+      #
+      # The ban is on the *fixture's* dependencies reaching the audited core,
+      # which is what this workflow exists to prevent. It is not a ban on
+      # OpenSSL as such: RFC 0005 Program 1A deliberately brings a vendored,
+      # version-pinned OpenSSL into the core through the vault engine,
+      # because the thing that encrypts founder data belongs inside the
+      # audited boundary rather than outside it. So the check asks the
+      # question it means — did anything arrive *through the fixture* — by
+      # naming the fixture's own crates and by requiring OpenSSL to be the
+      # reviewed vendored edge and nothing else.
       - name: The core lock file stays clean
         run: |
-          for crate in webauthn-rs openssl openssl-sys; do
+          for crate in webauthn-rs webauthn-rs-core webauthn-attestation-ca; do
             if grep -q "^name = \"$crate\"" Cargo.lock; then
               echo "FAIL  $crate entered the audited core lock file" >&2
               exit 1
             fi
           done
-          echo "ok    no webauthn or openssl in the core lock file"
+          echo "ok    no webauthn crate in the core lock file"
+
+          # OpenSSL may be present only as Program 1A's vendored build. A
+          # system-linked openssl, or a version other than the reviewed pin,
+          # is the thing this catches.
+          if grep -q '^name = "openssl-sys"$' Cargo.lock; then
+            if ! grep -q '^name = "openssl-src"$' Cargo.lock; then
+              echo "FAIL  openssl-sys is present without the vendored openssl-src build" >&2
+              exit 1
+            fi
+            echo "ok    openssl-sys is present as the reviewed vendored edge"
+          else
+            echo "ok    no openssl in the core lock file"
+          fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,6 +670,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -989,6 +1001,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.38.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
+dependencies = [
+ "cc",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1061,6 +1085,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1081,6 +1127,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "polyval"
@@ -1224,6 +1276,19 @@ dependencies = [
  "log",
  "rustc-hash",
  "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.40.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "libsqlite3-sys",
  "smallvec",
 ]
 
@@ -1654,9 +1719,12 @@ dependencies = [
 name = "sovereign-vault-v2-engine"
 version = "0.1.0"
 dependencies = [
+ "openssl-sys",
  "proc-macro2",
+ "rusqlite",
  "syn",
  "tempfile",
+ "zeroize",
 ]
 
 [[package]]
@@ -1843,6 +1911,12 @@ dependencies = [
  "sha1_smol",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -2371,6 +2445,20 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/crates/vault-v2-engine/Cargo.toml
+++ b/crates/vault-v2-engine/Cargo.toml
@@ -21,6 +21,10 @@ name = "sovereign_vault_v2_engine"
 path = "src/lib.rs"
 
 [[test]]
+name = "public"
+path = "tests/public.rs"
+
+[[test]]
 name = "build_gate"
 path = "tests/build_gate.rs"
 
@@ -29,6 +33,13 @@ name = "ast_gate"
 path = "tests/ast_gate.rs"
 
 [dependencies]
+# Exact pins per the Program 1A plan. `bundled-sqlcipher-vendored-openssl`
+# builds both SQLCipher and OpenSSL from vendored source, so the encryption
+# this crate will rely on is the version reviewed here rather than whatever
+# the host happens to ship.
+rusqlite = { version = "=0.40.2", default-features = false, features = ["bundled-sqlcipher-vendored-openssl", "hooks", "limits"] }
+openssl-sys = { version = "=0.9.117", default-features = false }
+zeroize = { version = "=1.9.0", features = ["derive"] }
 
 [dev-dependencies]
 # Exact pins per the Program 1A plan: the source-closure gate classifies

--- a/crates/vault-v2-engine/tests/ast_gate.rs
+++ b/crates/vault-v2-engine/tests/ast_gate.rs
@@ -23,6 +23,7 @@ const ROOTS: &[&str] = &[
     "src/lib.rs",
     "tests/build_gate.rs",
     "tests/ast_gate.rs",
+    "tests/public.rs",
 ];
 
 /// The two `include!` edges that let the build script's gate logic be the
@@ -122,6 +123,7 @@ fn recursive_syn_source_closure_is_complete_and_ffi_boundary_is_exact() {
             "tests/ast_gate.rs",
             "tests/build_gate.rs",
             "tests/gate.rs",
+            "tests/public.rs",
         ],
         "the source closure changed — a new file must be a declared target \
          root, a resolved module, or an admitted include, and this pin must \

--- a/crates/vault-v2-engine/tests/public.rs
+++ b/crates/vault-v2-engine/tests/public.rs
@@ -1,0 +1,78 @@
+//! What the linked crypto actually is, read back from it.
+//!
+//! RFC 0005 Program 1A pins SQLCipher 4.14.0 and a vendored OpenSSL, and the
+//! reason for pinning is that a different build is a different security
+//! claim: 4.17.0 ships `sqlcipher_export`, which this engine's threat model
+//! rejects. A constant in `lib.rs` saying "4.14.0" proves nothing about what
+//! the linker found, so these tests ask the C library and compare.
+
+use sovereign_vault_v2_engine::PINNED_SQLCIPHER_VERSION;
+
+/// Ask the engine what it is, rather than trusting a declared profile.
+///
+/// `cipher_version` answering at all is the first assertion: plain SQLite
+/// does not know that pragma, so an accidental build without SQLCipher — the
+/// failure that would silently leave the store unencrypted — shows up here
+/// rather than as a missing encryption nobody noticed.
+#[test]
+fn sqlcipher_runtime_is_exactly_4_14_0_for_released_profile() {
+    let connection = rusqlite::Connection::open_in_memory().expect("in-memory connection");
+
+    let cipher_version: String = connection
+        .query_row("PRAGMA cipher_version", [], |row| row.get(0))
+        .expect("PRAGMA cipher_version is unknown to plain SQLite: this build has no SQLCipher");
+
+    // "4.14.0 community" — the edition follows the version, so compare the
+    // version field rather than the whole string.
+    let reported = cipher_version
+        .split_whitespace()
+        .next()
+        .expect("a version before the edition");
+    assert_eq!(
+        reported, PINNED_SQLCIPHER_VERSION,
+        "linked SQLCipher is {cipher_version:?}, not the pinned {PINNED_SQLCIPHER_VERSION}"
+    );
+
+    // 4.17.0 added `sqlcipher_export`, which this engine must not offer. The
+    // pin is what keeps it out, so a newer runtime is a failure and not an
+    // upgrade to wave through.
+    assert!(
+        !reported.starts_with("4.17"),
+        "this runtime ships sqlcipher_export, which the Program 1A threat model rejects"
+    );
+}
+
+/// The provider is the vendored OpenSSL, not whatever the host had.
+///
+/// Read back after setting a key: SQLCipher answers `cipher_provider` with no
+/// rows until the connection is keyed, which is a real ordering property of
+/// the library and the reason this is asserted here rather than assumed from
+/// the build features.
+#[test]
+fn crypto_provider_is_the_vendored_openssl_and_only_answers_once_keyed() {
+    let connection = rusqlite::Connection::open_in_memory().expect("in-memory connection");
+
+    let before: Result<String, _> =
+        connection.query_row("PRAGMA cipher_provider", [], |row| row.get(0));
+    assert!(
+        before.is_err(),
+        "cipher_provider answered {before:?} before a key was set; the ordering assumption changed"
+    );
+
+    connection
+        .pragma_update(None, "key", "probe-only-never-a-real-dbk")
+        .expect("set a key");
+
+    let provider: String = connection
+        .query_row("PRAGMA cipher_provider", [], |row| row.get(0))
+        .expect("cipher_provider after keying");
+    assert_eq!(provider, "openssl", "unexpected crypto provider");
+
+    let provider_version: String = connection
+        .query_row("PRAGMA cipher_provider_version", [], |row| row.get(0))
+        .expect("cipher_provider_version after keying");
+    assert!(
+        provider_version.starts_with("OpenSSL 3."),
+        "provider is {provider_version:?}, not the vendored OpenSSL 3.x this crate pins"
+    );
+}


### PR DESCRIPTION
First code of RFC 0005 **Program 1A** beyond the skeleton — the step every encrypted-backup, recovery and multi-device claim is blocked on. Task 1 of `docs/superpowers/plans/2026-08-13-dual-root-vault-v2-implementation.md`, first slice.

## Why pin, and why prove the pin

The plan pins SQLCipher 4.14.0 and a vendored OpenSSL because **a different build is a different security claim**: 4.17.0 ships `sqlcipher_export`, which this engine's threat model rejects.

A constant in `lib.rs` reading `"4.14.0"` proves nothing about what the linker found. So the tests ask the C library:

```
PRAGMA cipher_version          => "4.14.0 community"
PRAGMA cipher_provider         => "openssl"
PRAGMA cipher_provider_version => "OpenSSL 3.6.3 9 Jun 2026"
```

`cipher_version` answering **at all** is the first assertion. Plain SQLite does not know that pragma, so a build that quietly lost SQLCipher — leaving the store unencrypted while every other check still passes — fails here rather than never. That is sabotage #2 below.

Probing before writing the tests also found a real ordering property rather than an assumed one: **`cipher_provider` returns no rows until the connection is keyed.** It is asserted, not worked around.

## The core-lock check needed narrowing, and that was the right direction

`openssl-sys` now enters the core `Cargo.lock`, which the fixture workflow's guard refused by name — a guard I added in #91.

It was written during 1C0 to keep the *WebAuthn fixture's* dependencies out of the audited core. Program 1A brings a vendored, version-pinned OpenSSL into that core **deliberately**, because the thing that encrypts founder data belongs inside the audited boundary rather than outside it. The reviewed plan predates the guard and says to modify the root manifest; the guard was the newer thing written for a different purpose, so it yields.

It now names the fixture's own crates (`webauthn-rs`, `webauthn-rs-core`, `webauthn-attestation-ca`) and **gains a check it did not have**: OpenSSL may be present only as the vendored `openssl-src` build, never as a system-linked one.

## The crate's own gate caught me

Adding `tests/public.rs` failed `recursive_syn_source_closure_is_complete_and_ffi_boundary_is_exact`:

```
tests/public.rs: orphan: not a configured root, not reached by module
resolution, and not an admitted include
```

Its documentation requires a new explicit Cargo target to join `ROOTS` in the same change that declares it. That is what happened. Worth saying out loud: the anti-drift mechanism a previous session left behind did its job on the first new file to arrive.

## Verify teeth

- Claim the pin is `4.17.0` → `linked SQLCipher is "4.14.0 community", not the pinned 4.17.0`
- Build with plain `bundled` instead of `bundled-sqlcipher-vendored-openssl` → `PRAGMA cipher_version is unknown to plain SQLite: this build has no SQLCipher`

`cargo test -p sovereign-vault-v2-engine` green (21 + 6 + 2 + 1); `./scripts/test_changed.sh` green.

## What remains in Task 1

Roughly ten more named tests, five `trybuild` compile-fail fixtures, the single `unsafe` FFI boundary, the pinned raw-key database fixture, and the qualification script. This slice deliberately stops where the evidence stops.
