### PR TITLE
feat(vault-v2): key holders, the SQLCipher key shim, and proof the store encrypts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1722,6 +1722,7 @@ dependencies = [
  "openssl-sys",
  "proc-macro2",
  "rusqlite",
+ "static_assertions",
  "syn",
  "tempfile",
  "zeroize",
@@ -1755,6 +1756,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/crates/vault-v2-engine/Cargo.toml
+++ b/crates/vault-v2-engine/Cargo.toml
@@ -20,6 +20,13 @@ build = "build.rs"
 name = "sovereign_vault_v2_engine"
 path = "src/lib.rs"
 
+# The dedicated process that will hold raw key material. Everything that
+# touches a key lives in modules compiled into this target only, so the
+# library target stays value-free and nothing downstream can name them.
+[[bin]]
+name = "sovereign-vault-v2-engine"
+path = "src/main.rs"
+
 [[test]]
 name = "public"
 path = "tests/public.rs"
@@ -48,3 +55,6 @@ zeroize = { version = "=1.9.0", features = ["derive"] }
 syn = { version = "=2.0.118", default-features = false, features = ["full", "parsing", "visit"] }
 proc-macro2 = { version = "=1.0.106", default-features = false }
 tempfile = "3"
+# Compile-time proof that key holders cannot be cloned, printed or
+# serialised. Exact pin per the Program 1A plan.
+static_assertions = "=1.1.0"

--- a/crates/vault-v2-engine/src/engine/ffi.rs
+++ b/crates/vault-v2-engine/src/engine/ffi.rs
@@ -1,0 +1,69 @@
+//! The one place this crate authors `unsafe` code against the C library.
+//!
+//! RFC 0005 Program 1A allows exactly two project-authored unsafe FFI
+//! boundary files, `ffi.rs` and `process.rs`, and the source-closure gate
+//! enforces that list. This is the first of them. It does one thing: hand the
+//! database key to SQLCipher as bytes.
+//!
+//! Why not `PRAGMA key`? Because a pragma is SQL text. The key would be
+//! formatted into a statement, and SQL text is what tracing, statement logs
+//! and error messages are made of. `sqlite3_key_v2` takes a pointer and a
+//! length, so the key never exists as SQL at all.
+//!
+//! The declaration is written here rather than taken from the bindings
+//! because the bindings do not have it: `libsqlite3-sys` generates them from
+//! stock `sqlite3.h`, where SQLCipher's key functions are not declared. The
+//! symbol is in the linked library — `_sqlite3_key_v2` is exported from the
+//! engine binary — and this declaration is its only Rust-side name.
+
+use super::secret::RawSqlcipherKey;
+use rusqlite::ffi::{sqlite3, SQLITE_OK};
+use std::os::raw::{c_char, c_int, c_void};
+
+extern "C" {
+    /// SQLCipher: key the named attached database. `p_key` is read for
+    /// exactly `n_key` bytes; it is not a C string.
+    fn sqlite3_key_v2(
+        db: *mut sqlite3,
+        z_db_name: *const c_char,
+        p_key: *const c_void,
+        n_key: c_int,
+    ) -> c_int;
+}
+
+/// The SQLite result code a failed keying returned. Value-free on purpose:
+/// it carries no part of the key and no text from the library.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct KeyRejected(pub(crate) c_int);
+
+/// Key the `main` database of an open connection.
+///
+/// This must be the first thing done to a connection after it opens, before
+/// any statement runs: SQLCipher derives the page cipher from this key, and a
+/// read before keying would treat an encrypted file as plain SQLite.
+pub(crate) fn key_main_database(
+    connection: &rusqlite::Connection,
+    key: &RawSqlcipherKey,
+) -> Result<(), KeyRejected> {
+    let bytes = key.token_bytes();
+    let length = c_int::try_from(bytes.len()).expect("a 67-byte token fits a c_int");
+    // SAFETY: `handle()` returns the live `sqlite3*` owned by `connection`,
+    // which outlives this call because it is borrowed for its duration.
+    // `c"main"` is a static NUL-terminated string. `bytes` points to exactly
+    // `length` readable bytes for the duration of the call, and SQLCipher
+    // copies the key into its own codec context rather than retaining the
+    // pointer.
+    let code = unsafe {
+        sqlite3_key_v2(
+            connection.handle(),
+            c"main".as_ptr(),
+            bytes.as_ptr().cast::<c_void>(),
+            length,
+        )
+    };
+    if code == SQLITE_OK {
+        Ok(())
+    } else {
+        Err(KeyRejected(code))
+    }
+}

--- a/crates/vault-v2-engine/src/engine/mod.rs
+++ b/crates/vault-v2-engine/src/engine/mod.rs
@@ -1,0 +1,10 @@
+//! Process-owned engine state. Private to the binary; see `main.rs`.
+//!
+//! Until the dispatcher lands, these items are reached only by the unit tests
+//! beside them, so the non-test build sees them as unused. That is the honest
+//! state of the code rather than something to silence item by item.
+#![cfg_attr(not(test), allow(dead_code))]
+
+pub(crate) mod ffi;
+pub(crate) mod secret;
+pub(crate) mod sqlcipher;

--- a/crates/vault-v2-engine/src/engine/secret.rs
+++ b/crates/vault-v2-engine/src/engine/secret.rs
@@ -1,0 +1,122 @@
+//! Key holders that cannot be copied, printed, or left behind.
+//!
+//! A `DbKey` is 32 random bytes and opens the business store. Everything
+//! about this type is shaped by one question — where can those bytes end up
+//! other than where they are needed — and the answer it enforces is: nowhere.
+//! It has no `Clone`, so there is exactly one copy and it is zeroed on drop;
+//! no `Debug` or `Display`, so it cannot reach a log line or a panic message;
+//! and no serde, so it cannot be written anywhere by accident. The tests at
+//! the bottom prove the absences at compile time rather than by inspection.
+
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+/// The random 32-byte database key.
+#[derive(Zeroize, ZeroizeOnDrop)]
+pub(crate) struct DbKey([u8; 32]);
+
+impl DbKey {
+    /// Take ownership of key bytes. The caller's array is copied in; callers
+    /// holding the source should zero it themselves, and the constructor's
+    /// argument is consumed so no binding to it survives here.
+    pub(crate) fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// The key in SQLCipher's raw-key form, for the one FFI call that uses it.
+    pub(crate) fn raw(&self) -> RawSqlcipherKey {
+        RawSqlcipherKey::encode(&self.0)
+    }
+}
+
+/// Length of SQLCipher's raw-key token: `x'`, 64 hex digits, `'`.
+pub(crate) const RAW_KEY_LEN: usize = 2 + 64 + 1;
+
+/// A DBK encoded as SQLCipher's raw-key token.
+///
+/// SQLCipher treats a key of exactly the form `x'<64 hex digits>'` as a raw
+/// 256-bit key and skips its password KDF. That is the right mode here: the
+/// DBK is already 32 random bytes, so stretching it would add cost and no
+/// strength. The token is still key material — it contains every bit of the
+/// DBK — so it gets the same treatment as the key itself.
+#[derive(Zeroize, ZeroizeOnDrop)]
+pub(crate) struct RawSqlcipherKey([u8; RAW_KEY_LEN]);
+
+impl RawSqlcipherKey {
+    fn encode(key: &[u8; 32]) -> Self {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let mut token = [0u8; RAW_KEY_LEN];
+        token[0] = b'x';
+        token[1] = b'\'';
+        for (index, byte) in key.iter().enumerate() {
+            token[2 + index * 2] = HEX[usize::from(byte >> 4)];
+            token[3 + index * 2] = HEX[usize::from(byte & 0x0f)];
+        }
+        token[RAW_KEY_LEN - 1] = b'\'';
+        Self(token)
+    }
+
+    /// The token bytes, for passing to `sqlite3_key_v2` with an explicit
+    /// length. There is no terminating NUL: the length is passed, and a NUL
+    /// inside a key is exactly the byte a C string API would truncate at.
+    pub(crate) fn token_bytes(&self) -> &[u8; RAW_KEY_LEN] {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use static_assertions::{assert_impl_all, assert_not_impl_any};
+
+    // The absences, proven by the compiler. A derive added to either type
+    // later fails the build here rather than leaking a key into a log.
+    assert_not_impl_any!(DbKey: Clone, Copy, std::fmt::Debug, std::fmt::Display);
+    assert_not_impl_any!(RawSqlcipherKey: Clone, Copy, std::fmt::Debug, std::fmt::Display);
+
+    // And the intended presence: both are zeroed when they go out of scope.
+    assert_impl_all!(DbKey: ZeroizeOnDrop);
+    assert_impl_all!(RawSqlcipherKey: ZeroizeOnDrop);
+
+    /// The edge bytes the plan names: the smallest, one that needs a leading
+    /// zero digit, a mixed one, and the largest. Each is checked byte by byte
+    /// rather than by comparing against another encoder, because a second
+    /// encoder would share whatever mistake the first one made.
+    #[test]
+    fn raw_key_encoding_is_exactly_67_bytes_for_edge_bytes() {
+        for (fill, digits) in [(0x00u8, b"00"), (0x0f, b"0f"), (0xab, b"ab"), (0xff, b"ff")] {
+            let raw = DbKey::from_bytes([fill; 32]).raw();
+            let token = raw.token_bytes();
+
+            assert_eq!(token.len(), 67);
+            assert_eq!(&token[..2], b"x'", "prefix for 0x{fill:02x}");
+            assert_eq!(token[66], b'\'', "suffix for 0x{fill:02x}");
+            for pair in token[2..66].chunks(2) {
+                assert_eq!(pair, digits, "hex pair for 0x{fill:02x}");
+            }
+            // A NUL would be silently truncated by any C string path the
+            // token might one day pass through — including 0x00 keys, whose
+            // hex digits are the character '0', not the byte zero.
+            assert!(
+                !token.contains(&0),
+                "a NUL byte in the token for 0x{fill:02x}"
+            );
+        }
+    }
+
+    /// Distinct keys give distinct tokens, and the position of each byte is
+    /// preserved — a transposition bug would pass the uniform-fill vectors
+    /// above and fail here.
+    #[test]
+    fn raw_key_encoding_preserves_byte_order() {
+        let mut bytes = [0u8; 32];
+        for (index, slot) in bytes.iter_mut().enumerate() {
+            *slot = u8::try_from(index).expect("index fits a byte");
+        }
+        let raw = DbKey::from_bytes(bytes).raw();
+        let hex = std::str::from_utf8(&raw.token_bytes()[2..66]).expect("ascii hex");
+        assert_eq!(
+            hex,
+            "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        );
+    }
+}

--- a/crates/vault-v2-engine/src/engine/sqlcipher.rs
+++ b/crates/vault-v2-engine/src/engine/sqlcipher.rs
@@ -1,0 +1,410 @@
+//! The closed SQLCipher connection factory.
+//!
+//! One function opens a database, and it does three things in a fixed order:
+//! open without following symlinks or accepting URIs, key the connection
+//! through the FFI boundary before any statement runs, then prove the key is
+//! right by reading the schema. A wrong key does not fail at step two —
+//! SQLCipher accepts any key there — it fails at the first page read, which
+//! is why step three exists and why a connection is only returned after it.
+//!
+//! What this module does *not* offer is as deliberate as what it does: no
+//! method runs arbitrary SQL, no method returns the raw handle, and the
+//! connection is neither `Send` nor `Sync`, so it stays on the thread that
+//! owns the key material.
+
+use super::ffi;
+use super::secret::DbKey;
+use rusqlite::OpenFlags;
+use std::marker::PhantomData;
+use std::path::Path;
+
+/// How a connection may be opened. The internal create mode is not reachable
+/// from outside the engine; the plan's compile-fail fixtures prove that once
+/// the public API exists.
+// The three names are fixed by the Program 1A plan
+// (`ConnectionMode::{ReadWriteCreateInternal,ReadWrite,ReadOnlyRecovery}`),
+// and the compile-fail fixtures that prove create mode is unreachable name them
+// too. Sharing a prefix is the lint's complaint, not a defect in the names.
+#[allow(clippy::enum_variant_names)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ConnectionMode {
+    /// Create a new, empty, encrypted container. Engine-internal only.
+    ReadWriteCreateInternal,
+    /// Open an existing container for writing.
+    ReadWrite,
+    /// Open an existing container read-only, for recovery and verification.
+    ReadOnlyRecovery,
+}
+
+impl ConnectionMode {
+    fn flags(self) -> OpenFlags {
+        // No `SQLITE_OPEN_URI` in any mode: a path is a path, and a URI would
+        // let a caller smuggle `?vfs=` or other options through it.
+        let hardening = OpenFlags::SQLITE_OPEN_NOFOLLOW
+            | OpenFlags::SQLITE_OPEN_NO_MUTEX
+            | OpenFlags::SQLITE_OPEN_EXRESCODE;
+        match self {
+            ConnectionMode::ReadWriteCreateInternal => {
+                hardening | OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_CREATE
+            }
+            ConnectionMode::ReadWrite => hardening | OpenFlags::SQLITE_OPEN_READ_WRITE,
+            ConnectionMode::ReadOnlyRecovery => hardening | OpenFlags::SQLITE_OPEN_READ_ONLY,
+        }
+    }
+}
+
+/// Why a database did not open. Every variant is value-free: none carries a
+/// path, a key, a schema name, or a message from the library, because each of
+/// those can hold something the caller should not be shown.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OpenError {
+    /// The file could not be opened at all (missing, a symlink, unreadable).
+    Unopenable,
+    /// SQLCipher refused the key outright.
+    KeyRejected,
+    /// The key was accepted but the first page read failed: a wrong key, or
+    /// a file that is not an encrypted database. SQLCipher cannot tell these
+    /// apart, and saying which would itself be a leak.
+    WrongKeyOrNotADatabase,
+}
+
+/// The cipher's own integrity check found pages it could not authenticate.
+/// Carries a count, never the pages or their contents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum IntegrityFailure {
+    /// `cipher_integrity_check` reported this many failures.
+    Pages(usize),
+    /// The check itself could not run to completion.
+    Unreadable,
+}
+
+/// An open, keyed, verified connection.
+pub(crate) struct HardenedConnection {
+    connection: rusqlite::Connection,
+    /// `*const ()` is neither `Send` nor `Sync`, which pins this connection
+    /// to the thread that opened it.
+    _single_thread: PhantomData<*const ()>,
+}
+
+/// Open a SQLCipher database under the fixed profile.
+pub(crate) fn open_sqlcipher(
+    path: &Path,
+    key: &DbKey,
+    mode: ConnectionMode,
+) -> Result<HardenedConnection, OpenError> {
+    let connection = rusqlite::Connection::open_with_flags(path, mode.flags())
+        .map_err(|_| OpenError::Unopenable)?;
+
+    // First action after open. The raw token lives only for this statement.
+    ffi::key_main_database(&connection, &key.raw()).map_err(|_| OpenError::KeyRejected)?;
+
+    // The key is only proven by reading a page. `sqlite_master` exists in
+    // every database, so this touches page 1 and nothing the caller wrote.
+    connection
+        .query_row("SELECT count(*) FROM sqlite_master", [], |row| {
+            row.get::<_, i64>(0)
+        })
+        .map_err(|_| OpenError::WrongKeyOrNotADatabase)?;
+
+    Ok(HardenedConnection {
+        connection,
+        _single_thread: PhantomData,
+    })
+}
+
+impl HardenedConnection {
+    /// Authenticate every page against its HMAC. Returns only whether they
+    /// all passed and, if not, how many did not.
+    pub(crate) fn cipher_integrity_check(&self) -> Result<(), IntegrityFailure> {
+        let mut statement = self
+            .connection
+            .prepare("PRAGMA cipher_integrity_check")
+            .map_err(|_| IntegrityFailure::Unreadable)?;
+        let failures = statement
+            .query_map([], |_| Ok(()))
+            .map_err(|_| IntegrityFailure::Unreadable)?
+            .count();
+        if failures == 0 {
+            Ok(())
+        } else {
+            Err(IntegrityFailure::Pages(failures))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use static_assertions::assert_not_impl_any;
+    use std::fs;
+    use std::path::PathBuf;
+
+    assert_not_impl_any!(HardenedConnection: Send, Sync);
+
+    /// Distinctive enough that finding it anywhere is proof of a leak, and
+    /// not a string SQLite or SQLCipher would ever produce on its own.
+    const CANARY: &str = "SFO-PLAINTEXT-CANARY-7f3a9c41";
+    const REPLACEMENT_CANARY: &str = "SFO-REPLACEMENT-CANARY-e25d08b6";
+
+    fn key(fill: u8) -> DbKey {
+        DbKey::from_bytes([fill; 32])
+    }
+
+    /// A temporary directory addressed by its canonical path.
+    ///
+    /// `SQLITE_OPEN_NOFOLLOW` refuses a symlink in *any* component of the
+    /// path, not only the last one — measured, not assumed: on macOS `/var`
+    /// is a link to `/private/var`, so every `tempdir()` path is refused as
+    /// `SQLITE_CANTOPEN_SYMLINK` (extended code 1550) until it is resolved.
+    /// The factory is right to refuse it; the fixture resolves it.
+    fn canonical_tempdir() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = fs::canonicalize(dir.path()).expect("canonical tempdir");
+        (dir, path)
+    }
+
+    /// Every file SQLite may have written beside the database: the database
+    /// itself and its rollback journal, write-ahead log and shared memory.
+    fn every_file_beside(db: &Path) -> Vec<(PathBuf, Vec<u8>)> {
+        ["", "-journal", "-wal", "-shm"]
+            .iter()
+            .map(|suffix| PathBuf::from(format!("{}{suffix}", db.display())))
+            .filter_map(|path| fs::read(&path).ok().map(|bytes| (path, bytes)))
+            .collect()
+    }
+
+    fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+        haystack
+            .windows(needle.len())
+            .any(|window| window == needle)
+    }
+
+    /// Create a database holding the canary, through the factory, and close
+    /// it. Tests reach the inner connection directly because they sit in this
+    /// module; production code has no method that runs arbitrary SQL.
+    fn create_with_canary(db: &Path, fill: u8) {
+        let opened = open_sqlcipher(db, &key(fill), ConnectionMode::ReadWriteCreateInternal)
+            .expect("create an encrypted container");
+        opened
+            .connection
+            .execute_batch(&format!(
+                "CREATE TABLE ledger_entries (note TEXT);
+                 INSERT INTO ledger_entries VALUES ('{CANARY}');"
+            ))
+            .expect("write the canary");
+    }
+
+    /// The plaintext is nowhere on disk — not in the database, and not in the
+    /// rollback journal while a transaction that replaces it is still open.
+    /// The key is nowhere on disk either, in any of its three forms.
+    ///
+    /// Scanning raw bytes is the independent evidence: it does not ask the
+    /// engine whether it encrypted anything, it looks.
+    #[test]
+    fn database_header_and_journal_do_not_contain_plaintext_canary() {
+        let (_dir, root) = canonical_tempdir();
+        let db = root.join("vault.db");
+        create_with_canary(&db, 0xab);
+
+        // At rest.
+        let files = every_file_beside(&db);
+        assert!(!files.is_empty(), "the database was not written at all");
+        for (path, bytes) in &files {
+            assert!(
+                !contains(bytes, CANARY.as_bytes()),
+                "plaintext canary found in {}",
+                path.display()
+            );
+            // Plain SQLite files begin with this header; an encrypted file
+            // must not, or the "encryption" was never applied.
+            assert!(
+                !bytes.starts_with(b"SQLite format 3\0"),
+                "{} carries the plaintext SQLite header",
+                path.display()
+            );
+        }
+
+        // Mid-transaction: the rollback journal holds the page being replaced,
+        // which is exactly where an old value would leak if the journal were
+        // not encrypted too.
+        let opened = open_sqlcipher(&db, &key(0xab), ConnectionMode::ReadWrite).expect("reopen");
+        opened
+            .connection
+            .execute_batch(&format!(
+                "BEGIN IMMEDIATE;
+                 UPDATE ledger_entries SET note = '{REPLACEMENT_CANARY}';"
+            ))
+            .expect("open a write transaction");
+        let during = every_file_beside(&db);
+        assert!(
+            during
+                .iter()
+                .any(|(path, _)| path.to_string_lossy().ends_with("-journal")),
+            "no rollback journal exists mid-transaction, so this scan would prove nothing"
+        );
+        for (path, bytes) in &during {
+            for canary in [CANARY, REPLACEMENT_CANARY] {
+                assert!(
+                    !contains(bytes, canary.as_bytes()),
+                    "{canary} found in {} while a transaction was open",
+                    path.display()
+                );
+            }
+        }
+        opened.connection.execute_batch("COMMIT;").expect("commit");
+        drop(opened);
+
+        // The key, in every form it takes: raw bytes, lowercase hex, and the
+        // full SQLCipher token.
+        let raw_key = [0xabu8; 32];
+        let hex = "ab".repeat(32);
+        let token = format!("x'{hex}'");
+        for (path, bytes) in every_file_beside(&db) {
+            assert!(
+                !contains(&bytes, &raw_key),
+                "raw DBK found in {}",
+                path.display()
+            );
+            assert!(
+                !contains(&bytes, hex.as_bytes()),
+                "hex DBK found in {}",
+                path.display()
+            );
+            assert!(
+                !contains(&bytes, token.as_bytes()),
+                "DBK token found in {}",
+                path.display()
+            );
+        }
+    }
+
+    /// A wrong key does not open the database, does not reveal what is in it,
+    /// and does not change it.
+    #[test]
+    fn wrong_dbk_fails_without_schema_or_plaintext() {
+        let (_dir, root) = canonical_tempdir();
+        let db = root.join("vault.db");
+        create_with_canary(&db, 0x11);
+        let before = fs::read(&db).expect("read before");
+
+        let result = open_sqlcipher(&db, &key(0x22), ConnectionMode::ReadWrite);
+        assert!(
+            matches!(result, Err(OpenError::WrongKeyOrNotADatabase)),
+            "a wrong key opened the database"
+        );
+
+        // The error is the only thing the caller gets back. It must carry
+        // neither the table name nor the plaintext.
+        let rendered = format!("{:?}", result.err());
+        assert!(
+            !rendered.contains("ledger_entries"),
+            "the error names the schema: {rendered}"
+        );
+        assert!(
+            !rendered.contains(CANARY),
+            "the error carries plaintext: {rendered}"
+        );
+
+        // Failing is not repairing: the file is byte-for-byte what it was.
+        assert_eq!(
+            fs::read(&db).expect("read after"),
+            before,
+            "a failed open changed the file"
+        );
+
+        // And the right key still works, so the failure was the key and not
+        // a database the wrong-key attempt had damaged.
+        assert!(open_sqlcipher(&db, &key(0x11), ConnectionMode::ReadWrite).is_ok());
+    }
+
+    /// One flipped bit in page 2 is caught by the cipher's authentication,
+    /// not silently decrypted into a wrong value.
+    ///
+    /// Offset 4224 is 128 bytes into page 2 at the 4096-byte page size this
+    /// crate pins — past page 1's salt and header, inside encrypted content.
+    #[test]
+    fn page_2_ciphertext_bitflip_is_detected_cryptographically() {
+        let (_dir, root) = canonical_tempdir();
+        let db = root.join("vault.db");
+        {
+            let opened = open_sqlcipher(&db, &key(0x5a), ConnectionMode::ReadWriteCreateInternal)
+                .expect("create");
+            // Enough rows to occupy well past page 2.
+            opened
+                .connection
+                .execute_batch(
+                    "CREATE TABLE filler (body BLOB);
+                     INSERT INTO filler SELECT randomblob(900) FROM
+                       (WITH RECURSIVE n(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM n WHERE i < 24)
+                        SELECT i FROM n);",
+                )
+                .expect("fill pages");
+        }
+
+        let mut bytes = fs::read(&db).expect("read");
+        assert!(
+            bytes.len() >= 8192 && bytes.len() % 4096 == 0,
+            "the database is {} bytes, not at least two whole pages",
+            bytes.len()
+        );
+
+        // Untouched, it passes — so a failure below is the flip, not the setup.
+        let intact = open_sqlcipher(&db, &key(0x5a), ConnectionMode::ReadOnlyRecovery)
+            .expect("reopen the intact file");
+        assert_eq!(
+            intact.cipher_integrity_check(),
+            Ok(()),
+            "the untouched file failed its own check"
+        );
+        drop(intact);
+
+        bytes[4224] ^= 0x01;
+        fs::write(&db, &bytes).expect("write the flipped file");
+
+        // The key is right and page 1 is untouched, so the open succeeds; the
+        // damage is on page 2 and must be found there.
+        let opened = open_sqlcipher(&db, &key(0x5a), ConnectionMode::ReadOnlyRecovery)
+            .expect("page 1 is intact, so opening still succeeds");
+        assert!(
+            matches!(opened.cipher_integrity_check(), Err(IntegrityFailure::Pages(n)) if n > 0),
+            "a flipped ciphertext bit passed the cipher integrity check"
+        );
+    }
+
+    /// A path that passes through a symlink is refused, and refused before
+    /// anything is created at the other end.
+    ///
+    /// Built from an explicit link rather than relying on how a platform lays
+    /// out its temp directory, so it means the same thing on macOS and Linux.
+    #[test]
+    fn a_path_through_a_symlink_is_refused_and_creates_nothing() {
+        let (_dir, root) = canonical_tempdir();
+        let real = root.join("real");
+        fs::create_dir(&real).expect("real dir");
+        let link = root.join("link");
+        std::os::unix::fs::symlink(&real, &link).expect("symlink");
+
+        let result = open_sqlcipher(
+            &link.join("vault.db"),
+            &key(0x33),
+            ConnectionMode::ReadWriteCreateInternal,
+        );
+        assert!(
+            matches!(result, Err(OpenError::Unopenable)),
+            "a path through a symlink was opened"
+        );
+        assert!(
+            fs::read_dir(&real).expect("list real").next().is_none(),
+            "the refused open still created a file behind the link"
+        );
+
+        // The same directory, addressed without the link, is fine: the refusal
+        // was the link and not the location.
+        assert!(open_sqlcipher(
+            &real.join("vault.db"),
+            &key(0x33),
+            ConnectionMode::ReadWriteCreateInternal
+        )
+        .is_ok());
+    }
+}

--- a/crates/vault-v2-engine/src/main.rs
+++ b/crates/vault-v2-engine/src/main.rs
@@ -1,0 +1,19 @@
+//! The vault v2 engine process.
+//!
+//! RFC 0005 puts raw key material in a dedicated process, and this binary is
+//! that process. Every type that can hold or name a key is declared in the
+//! private `engine` module here and nowhere else: the library target carries
+//! protocol constants only, so no downstream crate can construct a key, reach
+//! a raw handle, or open a database.
+//!
+//! The request dispatcher is a later Program 1A item. Until it lands, the
+//! engine is exercised by its own unit tests
+//! (`cargo test --bin sovereign-vault-v2-engine`), which is where the plan
+//! puts that evidence.
+
+mod engine;
+
+fn main() {
+    // Deliberately inert: a process that holds keys should not do anything
+    // until the dispatcher that authorises each request exists.
+}

--- a/crates/vault-v2-engine/tests/ast_gate.rs
+++ b/crates/vault-v2-engine/tests/ast_gate.rs
@@ -24,6 +24,7 @@ const ROOTS: &[&str] = &[
     "tests/build_gate.rs",
     "tests/ast_gate.rs",
     "tests/public.rs",
+    "src/main.rs",
 ];
 
 /// The two `include!` edges that let the build script's gate logic be the
@@ -34,10 +35,11 @@ const ADMITTED_INCLUDES: &[(&str, &str)] = &[
     ("tests/build_gate.rs", "../build_gate.rs"),
 ];
 
-/// Empty until the queued FFI item lands `src/engine/ffi.rs` and
-/// `src/engine/process.rs`; the whole crate is unsafe-free today and
-/// `src/lib.rs` additionally carries `#![forbid(unsafe_code)]`.
-const FFI_BOUNDARY_FILES: &[&str] = &[];
+/// The files allowed to contain `unsafe` and `extern`. `src/engine/ffi.rs`
+/// joined with the SQLCipher key shim; `src/engine/process.rs` joins when the
+/// OpenSSL bootstrap lands, and the plan expects nothing else ever to. The
+/// library keeps `#![forbid(unsafe_code)]` regardless.
+const FFI_BOUNDARY_FILES: &[&str] = &["src/engine/ffi.rs"];
 
 const ALLOWED_MACROS: &[&str] = &[
     "assert",
@@ -61,6 +63,13 @@ const ALLOWED_MACROS: &[&str] = &[
     "unreachable",
     "unimplemented",
     "compile_error",
+    // The plan names both: "Add `static_assertions::assert_not_impl_any!` for
+    // both `DbKey` and `RawSqlcipherKey`" and "positively assert the intended
+    // zeroize-on-drop traits". Compile-time only; they generate no code that
+    // runs, and the single-segment rule below still forbids calling them —
+    // or anything — by a path that could alias past this list.
+    "assert_not_impl_any",
+    "assert_impl_all",
 ];
 
 const ALLOWED_ATTRIBUTES: &[&str] = &[
@@ -92,6 +101,11 @@ const ALLOWED_DERIVES: &[&str] = &[
     "Ord",
     "Hash",
     "Default",
+    // Key holders are zeroed on drop. The plan pins
+    // `zeroize = { version = "=1.9.0", features = ["derive"] }` — the derive
+    // feature is enabled for exactly these two.
+    "Zeroize",
+    "ZeroizeOnDrop",
 ];
 
 fn real_config() -> GateConfig<'static> {
@@ -119,7 +133,12 @@ fn recursive_syn_source_closure_is_complete_and_ffi_boundary_is_exact() {
         vec![
             "build.rs",
             "build_gate.rs",
+            "src/engine/ffi.rs",
+            "src/engine/mod.rs",
+            "src/engine/secret.rs",
+            "src/engine/sqlcipher.rs",
             "src/lib.rs",
+            "src/main.rs",
             "tests/ast_gate.rs",
             "tests/build_gate.rs",
             "tests/gate.rs",

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1502,6 +1502,22 @@ while the controller routes eligible design/review cards to the strong role.
   runs a state-writing command with it set and asserts nothing was created
   under `dirs::data_local_dir()/sovereign-founder-os`.
 
+- [ ] **P2 | `crates/capability/`, `crates/consultant-playground/`, `apps/cli/src/workspace/` | Split four files before their next change fails the gate.**
+  Measured 2026-09-11 against the 1200-line ceiling:
+  `crates/capability/src/v2.rs` 1183 (**17 lines of room**),
+  `crates/consultant-playground/src/http.rs` 1158,
+  `apps/cli/src/workspace/compliance.rs` 1143,
+  `apps/cli/src/workspace/tests.rs` 1129.
+  Twice on 2026-09-11 a feature was finished in a file already near the
+  limit and the gate reported it after the work, not before it — the rule to
+  split first was already in `CLAUDE.md` and was not followed. `v2.rs` is the
+  urgent one: it is security code, and the next fix to it will not fit.
+  Each split is a pure move — the way `crew_template.rs` and `ui_gauntlet.rs`
+  were done that day: find the seam where the dependency runs one way, move
+  verbatim, confirm the test count is unchanged, and for anything that runs
+  (a route, a gauntlet) exercise it live rather than trusting the build. Done
+  when every file is under 1000 lines, so the next change has room.
+
 ## MVP product line
 
 Founder MVP — Consultant Core v1, built by the orchestrator session on


### PR DESCRIPTION
Program 1A, Task 1, second slice. It answers the question a reviewer asks first: **is the data on disk actually encrypted, and would anyone know if it stopped being?**

## What lands

| File | What it is |
| --- | --- |
| `src/main.rs` | The engine binary. Every type that can hold a key lives here, never in the library, which stays value-free. |
| `engine/secret.rs` | `DbKey` and its raw-key token, zeroed on drop, with no `Clone`/`Copy`/`Debug`/`Display`/serde — each absence proven at compile time. |
| `engine/ffi.rs` | The crate's first and only `unsafe`: hands the key to `sqlite3_key_v2` as bytes. |
| `engine/sqlcipher.rs` | `open_sqlcipher`: open → key → prove the key, in that order, with value-free errors. |

## Why the key goes through FFI and not `PRAGMA key`

A pragma is SQL text — the material tracing, statement logs and error messages are made of. `sqlite3_key_v2` takes a pointer and a length, so the key never exists as SQL.

The declaration is project-authored because **the generated bindings do not have it**: `libsqlite3-sys` builds them from stock `sqlite3.h`, where SQLCipher's key functions are not declared. The symbol is exported from the linked engine binary (`_sqlite3_key_v2`, `T`). A first look at the intermediate `libsqlite3.a` found nothing; the final binary is where it was confirmed.

## Evidence from the bytes on disk, not from the engine

- The plaintext canary is absent from the database — and from the **rollback journal while a transaction replacing it is still open**, which is where an old value leaks if the journal is not encrypted too. The file does not begin with `SQLite format 3\0`.
- The key is absent in all three of its forms: raw bytes, hex, and the `x'…'` token.
- A wrong key opens nothing, the error names no table and carries no plaintext, **no byte of the file changes**, and the right key still works afterwards.
- One flipped ciphertext bit on page 2 fails `cipher_integrity_check`; the untouched file passes first, so the failure is the flip and not the setup.

## Verify teeth — the one that matters most

Removing the keying call, so the file is written as plain SQLite, turns **three tests red at once** (canary, wrong key, bitflip). Encryption that silently stops is not something this suite can miss.

Also sabotaged: skip the verification read (wrong-key test fails), make the integrity check always pass (bitflip fails), drop `NOFOLLOW` (symlink test fails).

## Two measured findings

**`SQLITE_OPEN_NOFOLLOW` refuses a symlink in *any* path component**, not only the last — extended code 1550, `SQLITE_CANTOPEN_SYMLINK`. On macOS `/var` → `/private/var`, so every `tempdir()` path is refused until canonicalised. The factory is right; the fixtures resolve their paths. A new test uses an explicit link so it means the same on Linux.

**rusqlite's error text carries the full file path.** That is the concrete reason every `OpenError` variant is value-free.

## The crate's gate stopped this change three times

Orphaned files, macros outside the allowlist, `unsafe` outside the boundary. Each list grew only with the plan's own words beside the entry: `assert_not_impl_any`/`assert_impl_all` and the zeroize derives are all named by the plan, and `ffi.rs` is the boundary file the gate's documentation reserved. Macros must still be called by a single-segment name, so the allowlist cannot be aliased around.

`ConnectionMode`'s variants share a prefix because the plan fixes those names and the upcoming compile-fail fixtures reference them; clippy's `enum_variant_names` is allowed with that reason.

## Also in this PR

A separate docs commit queues four files with no room left for their next change — `crates/capability/src/v2.rs` has 17 lines.

## Still to do in Task 1

`process.rs` and the OpenSSL bootstrap (the second boundary file), the PRAGMA profile, resource limits, hostile OpenSSL configuration, read-only reopen, the pinned fixture database, and the five `trybuild` compile-fail cases.

`cargo test -p sovereign-vault-v2-engine` green (6 engine + 21 gate + 6 + 2 + 1); clippy clean; `./scripts/test_changed.sh` green.
