### PR TITLE
fix(transport): set the read wait before the request, not after the answer

### DIFF
--- a/crates/consultant-playground/tests/support/transport.rs
+++ b/crates/consultant-playground/tests/support/transport.rs
@@ -109,6 +109,11 @@ const READ_WAIT: Duration = Duration::from_secs(1);
 /// Callers that built their own stream use this. `request` does not: it sets
 /// the wait before sending and calls the loop directly, so no socket option is
 /// ever set after bytes are on the wire.
+///
+/// This file is compiled into every test binary that includes it, and only
+/// `server_transport` calls this function directly — `apps/cli`'s binaries
+/// reach the loop through `request` alone, so there it is dead code.
+#[allow(dead_code)]
 pub fn read_response(stream: &mut TcpStream) -> io::Result<Response> {
     stream
         .set_read_timeout(Some(READ_WAIT))

--- a/crates/consultant-playground/tests/support/transport.rs
+++ b/crates/consultant-playground/tests/support/transport.rs
@@ -58,6 +58,19 @@ pub fn raw_request(port: u16, method: &str, target: &str, headers: &str, body: &
 
 pub fn request(port: u16, bytes: &[u8]) -> io::Result<Response> {
     let mut stream = connect(port)?;
+    // Set the read loop's one-second wait *before* the request goes out.
+    //
+    // It used to be set inside `read_response`, after the write — and that
+    // was the syscall failing under the gate: `set_read_timeout(1s): Invalid
+    // argument (os error 22)`, named by the step labels added for exactly
+    // this. It is the same race `shutdown` below already tolerates: the
+    // server answers and closes before we finish, and macOS refuses a socket
+    // option on a connection its peer has closed. Before the write the peer
+    // has nothing to answer, so it has no reason to close, and the call has
+    // nothing to race.
+    stream
+        .set_read_timeout(Some(READ_WAIT))
+        .map_err(|error| step("set_read_timeout(1s)", error))?;
     stream
         .write_all(bytes)
         .map_err(|error| step("write", error))?;
@@ -71,7 +84,7 @@ pub fn request(port: u16, bytes: &[u8]) -> io::Result<Response> {
         Err(error) if peer_is_gone(&error) => {}
         Err(error) => return Err(step("shutdown", error)),
     }
-    read_response(&mut stream).map_err(|error| step("read", error))
+    read_response_prepared(&mut stream).map_err(|error| step("read", error))
 }
 
 /// Whether an error means the connection is gone, under any of the names the
@@ -86,15 +99,28 @@ pub fn peer_is_gone(error: &io::Error) -> bool {
     )
 }
 
+/// The read loop's per-read wait. Whole seconds avoid the fractional-timeout
+/// EINVAL observed on the test host; the absolute deadline in the loop bounds
+/// all retries to under nine seconds.
+const READ_WAIT: Duration = Duration::from_secs(1);
+
+/// Read one response from a stream that has no read wait set yet.
+///
+/// Callers that built their own stream use this. `request` does not: it sets
+/// the wait before sending and calls the loop directly, so no socket option is
+/// ever set after bytes are on the wire.
 pub fn read_response(stream: &mut TcpStream) -> io::Result<Response> {
+    stream
+        .set_read_timeout(Some(READ_WAIT))
+        .map_err(|error| step("set_read_timeout(1s)", error))?;
+    read_response_prepared(stream)
+}
+
+/// The read loop itself, for a stream whose wait was already set.
+fn read_response_prepared(stream: &mut TcpStream) -> io::Result<Response> {
     let deadline = Instant::now() + Duration::from_secs(8);
     let mut raw = Vec::new();
     let mut buf = [0; 4096];
-    // Whole-second socket waits avoid the fractional-timeout EINVAL observed
-    // on the test host. The absolute deadline bounds all retries to <9 seconds.
-    stream
-        .set_read_timeout(Some(Duration::from_secs(1)))
-        .map_err(|error| step("set_read_timeout(1s)", error))?;
     loop {
         if Instant::now() >= deadline {
             return Err(io::ErrorKind::TimedOut.into());

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1581,21 +1581,34 @@ Entries here follow the queue rules above; `lane:codex` does not apply.
   source in both directions, so a route added without a test — or a test left
   behind after a route is removed — fails the suite.
 
-- [ ] **P3 | `crates/consultant-playground/tests/support/transport.rs` | Transport EINVAL under the full gate on the macOS test host.**
+- [x] **P3 | `crates/consultant-playground/tests/support/transport.rs` | Transport EINVAL under the full gate on the macOS test host.**
+  Closed 2026-09-11 by the entry's own condition: the next occurrence named
+  its step, and the step got a targeted fix. It recurred under the gate in
+  `business_demo_startup_and_routes` as
+  `read: set_read_timeout(1s): Invalid argument (os error 22)` — the step
+  labels added for exactly this said which call. Of the three suspects listed
+  below, the `setsockopt` quirk was the right one.
+  The call ran inside `read_response`, **after** the request was written. It
+  is the same race `request` already tolerates for `shutdown`: the server
+  answers and closes before we finish, and macOS refuses a socket option on a
+  connection its peer has closed. `request` now sets the one-second read wait
+  before the write, when the peer has nothing to answer and no reason to
+  close, and reads through a loop that sets nothing; `read_response` keeps its
+  old behaviour for the three callers in `server_transport.rs` that build
+  their own streams.
+  A structural fix rather than a proven one: the flake could not be
+  reproduced on demand, so what is established is that the failing call no
+  longer happens after the send on that path, whatever made it fail. Stressed
+  30/30 and green under a full gate. If it recurs, the step label will name
+  where, and that is a new entry.
+  Original diagnosis, kept for the record:
   `two_cli_roots_have_identical_complete_transcripts_and_no_writes`
   (`apps/cli/tests/playground_isolation.rs:93`) failed twice on 2026-09-10
   under the Stop-hook gate with `Os { code: 22, InvalidInput }` from
   `transport::request`, at the 7th and the 17th exchange of the first root —
-  a server that had just answered. It passed 8/8 standalone and in three
-  background gate runs the same hour, and it touches nothing the day's
-  changes touched. The helper already avoids fractional socket timeouts for
-  a related EINVAL seen on this host; every timeout is whole-second now, so
-  the remaining sources are `connect_timeout`'s poll, `shutdown`, or a
-  `setsockopt` quirk in macOS 26.5. Mitigation in place: `request` names the
-  failing step in its error, and `connect` retries EINVAL up to three times
-  before any byte is sent (never after). Done when: the next occurrence
-  names its step and either the retry absorbs it or the step gets a targeted
-  fix; if it never recurs in a month, close as absorbed.
+  a server that had just answered. Suspected sources then: `connect_timeout`'s
+  poll, `shutdown`, or a `setsockopt` quirk in macOS 26.5.
+
 - [x] **P2 | `apps/cli/src/workspace/` | A rejected or revoked document has a way back to draft.**
   Landed 2026-09-10. Rule chosen: both states happen before anything reaches
   the customer, so an edit reopens the document as a new draft revision

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1517,6 +1517,25 @@ while the controller routes eligible design/review cards to the strong role.
   verbatim, confirm the test count is unchanged, and for anything that runs
   (a route, a gauntlet) exercise it live rather than trusting the build. Done
   when every file is under 1000 lines, so the next change has room.
+- [ ] **P2 | `scripts/test_changed.sh` | The scoped gate cannot see a file included by `#[path]` from another crate.**
+  Found 2026-09-11 when a change passed the local gate and failed CI. The gate
+  maps each changed path to the package that *owns* it, so an edit to
+  `crates/consultant-playground/tests/support/transport.rs` scopes clippy and
+  tests to `sovereign-consultant-playground` alone. But `apps/cli` compiles
+  that file into two of its own test binaries by `#[path]`, with no Cargo
+  edge between them, so the breakage (a helper left dead in those binaries,
+  refused by `-D warnings`) was invisible until CI's workspace-wide clippy.
+  Three such includes exist today, all from `apps/cli/tests/`:
+  `consultant-playground/tests/support/transport.rs` (twice) and
+  `consultant-playground/src/{catalog,domain}.rs` — so a change to the
+  playground's *source*, not only its test support, has the same blind spot.
+  Fix: after mapping paths to packages, resolve every `#[path = "…"]` in the
+  workspace against its including file, and when the target is in the change
+  set add the *including* file's package too. Bash 3.2 has no `realpath -m`,
+  so resolve by joining and normalising in the script or fall back to FULL for
+  any changed file that is a `#[path]` target. Done when a self-test in
+  `scripts/tests/` changes an included file and asserts the including
+  package lands in scope — and a mutation that drops the new mapping fails it.
 
 ## MVP product line
 


### PR DESCRIPTION
The macOS gate flake from #92 recurred — and this time it said where, which is what #92's step labels were for.

```
read: set_read_timeout(1s): Invalid argument (os error 22)
```

## What was actually failing

The call ran inside `read_response`, **after** the request had been written. It is the same race `request` already tolerates for `shutdown` a few lines up: the server answers and closes before we finish, and macOS refuses a socket option on a connection whose peer has closed.

That also explains why #92's fix could not have absorbed it. #92 retries `connect`, which is safe because nothing has been sent. Retrying here, after the request is on the wire, would send it twice.

Of the three suspects the backlog listed (`connect_timeout`'s poll, `shutdown`, a `setsockopt` quirk), the third was right.

## The fix

`request` now sets the one-second read wait **before** the write — when the peer has nothing to answer and no reason to close, so the call has nothing to race — and reads through a loop that sets no socket option at all.

`read_response` is unchanged for its three other callers in `server_transport.rs`, which build their own streams without a wait set.

## What this does and does not prove

A **structural** fix, not a proven one. The flake cannot be reproduced on demand — it appears only under the full gate's load. What is established is that the failing call no longer happens after the send on the `request` path, whatever made it fail there.

- `business_demo_http` passed **30 consecutive runs**
- A full `./scripts/test_changed.sh` passed — the load it appeared under
- All three consumers of the helper pass: `server_transport` (32), `business_demo_http` (8), `playground_isolation` (23)

If it recurs, the step label will name the new place, and that is a new entry.

Closes the backlog P3 **by its own stated condition** — "the next occurrence names its step and … the step gets a targeted fix" — with the original diagnosis kept beneath the close.

Unrelated to #105; separate PR on purpose.


---

## Two more commits, and why the first push failed CI

**`fix(transport): keep read_response compiling where only request uses it`** — the first push failed CI's workspace clippy. `transport.rs` is compiled into every test binary that includes it by `#[path]`; after this PR `request` no longer calls `read_response`, and `apps/cli`'s two binaries never called it directly, so there it became dead code under `-D warnings`. Same lesson as `CLAUDE.md` #6. Fixed with an explained `#[allow(dead_code)]`; verified with both the gate's fixture-featured clippy and CI's workspace clippy.

**Why the local gate let it through** is the more useful finding. `test_changed.sh` scopes clippy to the package that *owns* the changed file, so an edit here scoped only `sovereign-consultant-playground` — and `apps/cli` includes this file by path, with no Cargo edge, so nothing connected the edit to the binaries it broke. CI's workspace-wide run caught it.

**`docs(backlog): record the scoped gate's blind spot`** — queued as its own P2 with a proposed fix and a done-when that requires a self-test plus a mutation that drops the mapping. Three such includes exist today, including two of the playground's *source* files, so the gap is wider than test helpers.
