### PR TITLE
feat(vault-v2): one hardened open, the fixed profile, and limits proven at their edges

### DIFF
--- a/crates/vault-v2-engine/src/engine/ffi.rs
+++ b/crates/vault-v2-engine/src/engine/ffi.rs
@@ -2,23 +2,39 @@
 //!
 //! RFC 0005 Program 1A allows exactly two project-authored unsafe FFI
 //! boundary files, `ffi.rs` and `process.rs`, and the source-closure gate
-//! enforces that list. This is the first of them. It does one thing: hand the
-//! database key to SQLCipher as bytes.
+//! enforces that list. This is the first. It has one entry point, and the
+//! plan is specific about what that entry point owns: it opens the database,
+//! keys it as the very first operation, and turns off both routes by which
+//! SQLite can load native code — reading the second one back to prove it.
 //!
-//! Why not `PRAGMA key`? Because a pragma is SQL text. The key would be
-//! formatted into a statement, and SQL text is what tracing, statement logs
-//! and error messages are made of. `sqlite3_key_v2` takes a pointer and a
-//! length, so the key never exists as SQL at all.
+//! Why open here rather than through rusqlite's safe `open_with_flags`? The
+//! first version did exactly that, and it was a departure from the plan: the
+//! extension-loading off switch `SQLITE_DBCONFIG_ENABLE_LOAD_EXTENSION` (1005)
+//! is absent from rusqlite's safe `DbConfig` — commented out in rusqlite's own
+//! source — and exposing it would mean enabling rusqlite's forbidden
+//! `load_extension` feature. So it has to be set through the raw handle, and
+//! the plan permits no second raw-handle shim. Owning the whole sequence here
+//! is what keeps the unsafe surface to one function.
 //!
-//! The declaration is written here rather than taken from the bindings
-//! because the bindings do not have it: `libsqlite3-sys` generates them from
-//! stock `sqlite3.h`, where SQLCipher's key functions are not declared. The
-//! symbol is in the linked library — `_sqlite3_key_v2` is exported from the
-//! engine binary — and this declaration is its only Rust-side name.
+//! Why the key goes in as bytes rather than `PRAGMA key`: a pragma is SQL
+//! text, and SQL text is what tracing, statement logs and error messages are
+//! made of. `sqlite3_key_v2` takes a pointer and a length.
+//!
+//! `sqlite3_key_v2` is declared here because the generated bindings do not
+//! have it — `libsqlite3-sys` builds them from stock `sqlite3.h`, where
+//! SQLCipher's key functions are not declared. Everything else comes from the
+//! bindings.
 
 use super::secret::RawSqlcipherKey;
-use rusqlite::ffi::{sqlite3, SQLITE_OK};
+use rusqlite::ffi::{
+    sqlite3, sqlite3_close, sqlite3_db_config, sqlite3_enable_load_extension, sqlite3_open_v2,
+    SQLITE_DBCONFIG_ENABLE_LOAD_EXTENSION, SQLITE_OK,
+};
+use std::ffi::CString;
 use std::os::raw::{c_char, c_int, c_void};
+use std::os::unix::ffi::OsStrExt;
+use std::path::Path;
+use std::ptr;
 
 extern "C" {
     /// SQLCipher: key the named attached database. `p_key` is read for
@@ -31,39 +47,104 @@ extern "C" {
     ) -> c_int;
 }
 
-/// The SQLite result code a failed keying returned. Value-free on purpose:
-/// it carries no part of the key and no text from the library.
+/// Why the hardened open failed. Value-free: no path, no key, no text from
+/// the library.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct KeyRejected(pub(crate) c_int);
+pub(crate) enum HardeningFailure {
+    /// The path contains a NUL byte and cannot be handed to C.
+    PathNotRepresentable,
+    /// `sqlite3_open_v2` refused the path (missing, a symlink, unreadable).
+    Unopenable,
+    /// SQLCipher refused the key.
+    KeyRejected,
+    /// A native-code loading route could not be shown to be off.
+    ExtensionLoadingNotDisabled,
+}
 
-/// Key the `main` database of an open connection.
+/// Open, key, and disable native-code loading, in that order, and hand back a
+/// connection that owns the handle.
 ///
-/// This must be the first thing done to a connection after it opens, before
-/// any statement runs: SQLCipher derives the page cipher from this key, and a
-/// read before keying would treat an encrypted file as plain SQLite.
-pub(crate) fn key_main_database(
-    connection: &rusqlite::Connection,
+/// Nothing touches a page here: the key is set before any statement exists,
+/// and the extension switches are connection configuration. The caller
+/// applies the remaining no-page settings and only then reads a page.
+pub(crate) fn open_keyed_hardened(
+    path: &Path,
+    flags: c_int,
     key: &RawSqlcipherKey,
-) -> Result<(), KeyRejected> {
-    let bytes = key.token_bytes();
-    let length = c_int::try_from(bytes.len()).expect("a 67-byte token fits a c_int");
-    // SAFETY: `handle()` returns the live `sqlite3*` owned by `connection`,
-    // which outlives this call because it is borrowed for its duration.
-    // `c"main"` is a static NUL-terminated string. `bytes` points to exactly
-    // `length` readable bytes for the duration of the call, and SQLCipher
-    // copies the key into its own codec context rather than retaining the
-    // pointer.
-    let code = unsafe {
-        sqlite3_key_v2(
-            connection.handle(),
+) -> Result<rusqlite::Connection, HardeningFailure> {
+    let c_path = CString::new(path.as_os_str().as_bytes())
+        .map_err(|_| HardeningFailure::PathNotRepresentable)?;
+    let token = key.token_bytes();
+    let token_len = c_int::try_from(token.len()).expect("a 67-byte token fits a c_int");
+    let mut db: *mut sqlite3 = ptr::null_mut();
+
+    // SAFETY: `c_path` and `c"main"` are NUL-terminated and outlive every
+    // call that reads them. `db` is written only by `sqlite3_open_v2` and is
+    // closed exactly once on every failure path below, before it could be
+    // adopted. `sqlite3_close` rather than `_v2`: no statement has been
+    // prepared on any of those paths, so the two behave the same, and
+    // `_close_v2` is not in the generated bindings — using it would mean a
+    // second project-authored symbol declaration for no gain. `token`
+    // points to exactly `token_len` readable bytes for the duration of
+    // `sqlite3_key_v2`, and SQLCipher copies the key into its own
+    // codec context rather than keeping the pointer. `now_enabled` is a live
+    // `c_int` for the `sqlite3_db_config` call that writes it, and the
+    // variadic arguments match the documented signature for option 1005:
+    // `(int onoff, int *pOut)`. On success the handle is adopted by
+    // `from_handle_owned`, which closes it on drop, so it is never closed
+    // here after that point.
+    unsafe {
+        if sqlite3_open_v2(c_path.as_ptr(), &mut db, flags, ptr::null()) != SQLITE_OK {
+            // `sqlite3_open_v2` can allocate a handle even when it fails, and
+            // that handle still has to be released.
+            if !db.is_null() {
+                sqlite3_close(db);
+            }
+            return Err(HardeningFailure::Unopenable);
+        }
+
+        // The first operation on the new connection.
+        if sqlite3_key_v2(
+            db,
             c"main".as_ptr(),
-            bytes.as_ptr().cast::<c_void>(),
-            length,
-        )
-    };
-    if code == SQLITE_OK {
-        Ok(())
-    } else {
-        Err(KeyRejected(code))
+            token.as_ptr().cast::<c_void>(),
+            token_len,
+        ) != SQLITE_OK
+        {
+            sqlite3_close(db);
+            return Err(HardeningFailure::KeyRejected);
+        }
+
+        // Route one: the switch behind the `load_extension()` SQL function.
+        //
+        // It has no readback, and its effect cannot be observed on any
+        // connection this factory returns — measured, not assumed: the SQL
+        // function is refused if *either* this switch or route two is off,
+        // and only loads when both are on. Route two is read back below, so
+        // on a returned connection it is always off, and it alone produces the
+        // refusal a test sees. This call is therefore defence in depth, and
+        // the evidence for it is structural: `tests/ast_gate.rs` pins that it
+        // is made, once, with the literal `0`.
+        if sqlite3_enable_load_extension(db, 0) != SQLITE_OK {
+            sqlite3_close(db);
+            return Err(HardeningFailure::ExtensionLoadingNotDisabled);
+        }
+
+        // Route two: the C API `sqlite3_load_extension`. Set off, then read
+        // the value SQLite reports back rather than trusting the call.
+        let mut now_enabled: c_int = -1;
+        let set = sqlite3_db_config(
+            db,
+            SQLITE_DBCONFIG_ENABLE_LOAD_EXTENSION,
+            0 as c_int,
+            &mut now_enabled as *mut c_int,
+        );
+        if set != SQLITE_OK || now_enabled != 0 {
+            sqlite3_close(db);
+            return Err(HardeningFailure::ExtensionLoadingNotDisabled);
+        }
+
+        // Adopted: from here the connection owns and closes the handle.
+        rusqlite::Connection::from_handle_owned(db).map_err(|_| HardeningFailure::Unopenable)
     }
 }

--- a/crates/vault-v2-engine/src/engine/sqlcipher.rs
+++ b/crates/vault-v2-engine/src/engine/sqlcipher.rs
@@ -12,11 +12,42 @@
 //! connection is neither `Send` nor `Sync`, so it stays on the thread that
 //! owns the key material.
 
-use super::ffi;
+use super::ffi::{self, HardeningFailure};
 use super::secret::DbKey;
+use rusqlite::config::DbConfig;
+use rusqlite::limits::Limit;
 use rusqlite::OpenFlags;
 use std::marker::PhantomData;
 use std::path::Path;
+
+/// The runtime limits RFC 0005 Program 1A fixes, in the order the plan lists
+/// them. Each is set before the first page is read and then read back from
+/// the C library, because SQLite silently clamps a limit to its compile-time
+/// maximum and a clamped value would otherwise pass unnoticed.
+pub(crate) const FIXED_LIMITS: [(Limit, i32); 10] = [
+    (Limit::SQLITE_LIMIT_SQL_LENGTH, 64 * 1024),
+    (Limit::SQLITE_LIMIT_LENGTH, 16 * 1024 * 1024),
+    (Limit::SQLITE_LIMIT_COLUMN, 128),
+    (Limit::SQLITE_LIMIT_EXPR_DEPTH, 32),
+    (Limit::SQLITE_LIMIT_COMPOUND_SELECT, 16),
+    (Limit::SQLITE_LIMIT_VARIABLE_NUMBER, 999),
+    (Limit::SQLITE_LIMIT_TRIGGER_DEPTH, 0),
+    (Limit::SQLITE_LIMIT_ATTACHED, 0),
+    (Limit::SQLITE_LIMIT_LIKE_PATTERN_LENGTH, 256),
+    (Limit::SQLITE_LIMIT_WORKER_THREADS, 0),
+];
+
+/// Connection safety switches the plan requires, with the value each must
+/// hold. `DEFENSIVE` stops `writable_schema` from being used to corrupt the
+/// schema; `TRUSTED_SCHEMA` off stops SQL functions from running inside
+/// schema objects; the two `DQS` switches stop a double-quoted identifier
+/// from being silently reinterpreted as a string literal.
+const SAFETY_SWITCHES: [(DbConfig, bool); 4] = [
+    (DbConfig::SQLITE_DBCONFIG_DEFENSIVE, true),
+    (DbConfig::SQLITE_DBCONFIG_TRUSTED_SCHEMA, false),
+    (DbConfig::SQLITE_DBCONFIG_DQS_DML, false),
+    (DbConfig::SQLITE_DBCONFIG_DQS_DDL, false),
+];
 
 /// How a connection may be opened. The internal create mode is not reachable
 /// from outside the engine; the plan's compile-fail fixtures prove that once
@@ -66,6 +97,11 @@ pub(crate) enum OpenError {
     /// a file that is not an encrypted database. SQLCipher cannot tell these
     /// apart, and saying which would itself be a leak.
     WrongKeyOrNotADatabase,
+    /// A required setting did not take: native-code loading could not be
+    /// shown off, a safety switch did not hold, or a limit read back as
+    /// something other than the value set. The connection is refused rather
+    /// than returned half-hardened.
+    ProfileNotApplied,
 }
 
 /// The cipher's own integrity check found pages it could not authenticate.
@@ -92,16 +128,47 @@ pub(crate) fn open_sqlcipher(
     key: &DbKey,
     mode: ConnectionMode,
 ) -> Result<HardenedConnection, OpenError> {
-    let connection = rusqlite::Connection::open_with_flags(path, mode.flags())
-        .map_err(|_| OpenError::Unopenable)?;
+    // Open, key first, and switch off native-code loading — one audited
+    // unsafe entry point. The raw token lives only for this call.
+    let connection =
+        ffi::open_keyed_hardened(path, mode.flags().bits(), &key.raw()).map_err(|failure| {
+            match failure {
+                HardeningFailure::PathNotRepresentable | HardeningFailure::Unopenable => {
+                    OpenError::Unopenable
+                }
+                HardeningFailure::KeyRejected => OpenError::KeyRejected,
+                HardeningFailure::ExtensionLoadingNotDisabled => OpenError::ProfileNotApplied,
+            }
+        })?;
 
-    // First action after open. The raw token lives only for this statement.
-    ffi::key_main_database(&connection, &key.raw()).map_err(|_| OpenError::KeyRejected)?;
+    // The remaining no-page settings, each confirmed by what SQLite reports
+    // back rather than by the call having returned.
+    for (switch, required) in SAFETY_SWITCHES {
+        let held = connection
+            .set_db_config(switch, required)
+            .map_err(|_| OpenError::ProfileNotApplied)?;
+        if held != required {
+            return Err(OpenError::ProfileNotApplied);
+        }
+    }
+    for (limit, value) in FIXED_LIMITS {
+        connection
+            .set_limit(limit, value)
+            .map_err(|_| OpenError::ProfileNotApplied)?;
+        if connection
+            .limit(limit)
+            .map_err(|_| OpenError::ProfileNotApplied)?
+            != value
+        {
+            return Err(OpenError::ProfileNotApplied);
+        }
+    }
 
-    // The key is only proven by reading a page. `sqlite_master` exists in
-    // every database, so this touches page 1 and nothing the caller wrote.
+    // Only now is a page read, and the read is what proves the key.
+    // `sqlite_schema` exists in every database, so this touches page 1 and
+    // nothing the caller wrote.
     connection
-        .query_row("SELECT count(*) FROM sqlite_master", [], |row| {
+        .query_row("SELECT count(*) FROM sqlite_schema", [], |row| {
             row.get::<_, i64>(0)
         })
         .map_err(|_| OpenError::WrongKeyOrNotADatabase)?;
@@ -406,5 +473,220 @@ mod tests {
             ConnectionMode::ReadWriteCreateInternal
         )
         .is_ok());
+    }
+
+    /// Prepare *and step* a statement, returning SQLite's refusal if any.
+    ///
+    /// Stepping matters. Some limits are enforced when a statement compiles —
+    /// expression depth, SQL length, columns, compound terms, variable numbers
+    /// — and others only when it runs: LIKE patterns, value length, ATTACH,
+    /// extension loading, triggers. A helper that only prepared would report
+    /// the runtime ones as passing whatever their size, which is exactly the
+    /// false green a first probe of this code produced.
+    fn run(connection: &rusqlite::Connection, sql: &str) -> Result<(), String> {
+        let mut statement = connection.prepare(sql).map_err(|error| error.to_string())?;
+        let mut rows = statement.raw_query();
+        rows.next().map(|_| ()).map_err(|error| error.to_string())
+    }
+
+    /// Refused, and refused for the stated reason. A boundary-plus-one case
+    /// that failed on a typo in the constructed SQL would prove nothing, so
+    /// every refusal is matched against the message of the limit it tests.
+    fn assert_refused(connection: &rusqlite::Connection, sql: &str, because: &str) {
+        match run(connection, sql) {
+            Ok(()) => panic!("accepted past the limit: {} bytes of SQL", sql.len()),
+            Err(message) => assert!(
+                message.contains(because),
+                "refused, but not by the limit under test — expected {because:?}, got {message:?}"
+            ),
+        }
+    }
+
+    fn assert_accepted(connection: &rusqlite::Connection, sql: &str, what: &str) {
+        if let Err(message) = run(connection, sql) {
+            panic!("{what} at its boundary was refused: {message}");
+        }
+    }
+
+    /// Every fixed limit, read back from the C library and then exercised at
+    /// its boundary and one past it.
+    #[test]
+    fn oversized_values_and_sql_fail_at_fixed_limits() {
+        let (_dir, root) = canonical_tempdir();
+        let opened = open_sqlcipher(
+            &root.join("vault.db"),
+            &key(0x44),
+            ConnectionMode::ReadWriteCreateInternal,
+        )
+        .expect("open");
+        let connection = &opened.connection;
+
+        // What SQLite reports, not what was requested: a limit clamped to a
+        // compile-time maximum would show up here.
+        for (limit, value) in FIXED_LIMITS {
+            assert_eq!(
+                connection.limit(limit).expect("read a limit back"),
+                value,
+                "{limit:?} is not the fixed value"
+            );
+        }
+
+        // SQL text: 64 KiB. The statement is padded inside a comment so its
+        // length can be set to the byte.
+        let sql_of = |length: usize| {
+            let (head, tail) = ("SELECT 1 /*", "*/");
+            format!(
+                "{head}{}{tail}",
+                "x".repeat(length - head.len() - tail.len())
+            )
+        };
+        assert_accepted(connection, &sql_of(64 * 1024), "SQL of 64 KiB");
+        assert_refused(connection, &sql_of(64 * 1024 + 1), "statement too long");
+
+        // One value: 16 MiB.
+        assert_accepted(connection, "SELECT zeroblob(16777216)", "a 16 MiB value");
+        assert_refused(
+            connection,
+            "SELECT zeroblob(16777217)",
+            "string or blob too big",
+        );
+
+        // Columns: 128.
+        let columns = |count: usize| {
+            let list: Vec<String> = (0..count).map(|index| index.to_string()).collect();
+            format!("SELECT {}", list.join(","))
+        };
+        assert_accepted(connection, &columns(128), "128 columns");
+        assert_refused(connection, &columns(129), "too many columns");
+
+        // Expression depth: 32. A literal is depth one and each unary minus
+        // adds one, so 31 nested minuses is depth 32 exactly.
+        let nested = |depth: usize| format!("SELECT {}1{}", "-(".repeat(depth), ")".repeat(depth));
+        assert_accepted(connection, &nested(31), "expression depth 32");
+        assert_refused(connection, &nested(32), "Expression tree is too large");
+
+        // Compound terms: 16.
+        let compound = |terms: usize| vec!["SELECT 1"; terms].join(" UNION ALL ");
+        assert_accepted(connection, &compound(16), "16 compound terms");
+        assert_refused(
+            connection,
+            &compound(17),
+            "too many terms in compound SELECT",
+        );
+
+        // Variables: 999.
+        assert_accepted(connection, "SELECT ?999", "variable ?999");
+        assert_refused(
+            connection,
+            "SELECT ?1000",
+            "variable number must be between ?1 and ?999",
+        );
+
+        // LIKE pattern: 256 bytes.
+        let like = |length: usize| format!("SELECT 'a' LIKE '{}'", "a".repeat(length));
+        assert_accepted(connection, &like(256), "a 256-byte LIKE pattern");
+        assert_refused(connection, &like(257), "LIKE or GLOB pattern too complex");
+
+        // Attached databases: 0. The boundary is the connection as it stands;
+        // one attachment is past it.
+        assert_refused(
+            connection,
+            "ATTACH DATABASE ':memory:' AS other",
+            "too many attached databases",
+        );
+
+        // Trigger depth: 0, so no trigger may fire at all. The boundary is a
+        // write that fires none; one past it is a write that fires one.
+        connection
+            .execute_batch(
+                "CREATE TABLE fired (x);
+                 CREATE TABLE plain (x);
+                 CREATE TRIGGER on_fired AFTER INSERT ON fired
+                   BEGIN INSERT INTO plain VALUES (new.x); END;",
+            )
+            .expect("create the tables and the trigger");
+        assert_accepted(
+            connection,
+            "INSERT INTO plain VALUES (1)",
+            "a write that fires no trigger",
+        );
+        assert_refused(
+            connection,
+            "INSERT INTO fired VALUES (1)",
+            "too many levels of trigger recursion",
+        );
+
+        // Worker threads: 0. There is no statement that behaves differently at
+        // one past it — the limit governs how many helper threads a sort may
+        // start — so the readback above is the whole of the evidence.
+    }
+
+    /// Every route by which a connection could reach outside its own file is
+    /// shut: native code, another database, and the schema itself.
+    ///
+    /// "No dynamic SQL path" in the plan is a property of this module's API —
+    /// `HardenedConnection` has no method that takes SQL text — and it is the
+    /// source-closure gate's to prove once the public boundary exists, not a
+    /// runtime check. What runs here is everything that can be observed.
+    #[test]
+    fn extensions_attach_writable_schema_and_dynamic_sql_are_denied() {
+        let (_dir, root) = canonical_tempdir();
+        let opened = open_sqlcipher(
+            &root.join("vault.db"),
+            &key(0x55),
+            ConnectionMode::ReadWriteCreateInternal,
+        )
+        .expect("open");
+        let connection = &opened.connection;
+
+        // Native code. "not authorized" means the call was refused before any
+        // load was attempted; with loading enabled SQLite instead calls dlopen,
+        // fails on the missing file, and reports every path it searched —
+        // a different message, and a disclosure of its own.
+        //
+        // What this proves is that the SQL function is refused, not which of
+        // the two switches refused it: either one alone is enough, and the
+        // factory reads route two back and will not return a connection with it
+        // on. Route one's disable is pinned in source by `tests/ast_gate.rs`,
+        // which is the only place its presence can be shown.
+        assert_refused(
+            connection,
+            "SELECT load_extension('/no/such/library')",
+            "not authorized",
+        );
+
+        // Another database.
+        assert_refused(
+            connection,
+            "ATTACH DATABASE ':memory:' AS elsewhere",
+            "too many attached databases",
+        );
+
+        // The schema. Defensive mode is what makes `writable_schema` harmless:
+        // the pragma may be accepted, but the schema must not change. That is
+        // checked on the schema itself rather than on an error message.
+        connection
+            .execute_batch("CREATE TABLE records (x);")
+            .expect("create a table");
+        let before: String = connection
+            .query_row(
+                "SELECT sql FROM sqlite_schema WHERE name = 'records'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read the schema");
+        let _ = connection.execute_batch("PRAGMA writable_schema = ON;");
+        let tamper = connection.execute_batch(
+            "UPDATE sqlite_schema SET sql = 'CREATE TABLE records (x, smuggled)' WHERE name = 'records';",
+        );
+        assert!(tamper.is_err(), "the schema table accepted a write");
+        let after: String = connection
+            .query_row(
+                "SELECT sql FROM sqlite_schema WHERE name = 'records'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read the schema again");
+        assert_eq!(after, before, "the schema changed under writable_schema");
     }
 }

--- a/crates/vault-v2-engine/tests/ast_gate.rs
+++ b/crates/vault-v2-engine/tests/ast_gate.rs
@@ -438,3 +438,58 @@ fn a_symlink_in_the_crate_tree_is_rejected() {
         outcome.violations
     );
 }
+
+/// The one switch in the FFI boundary that has no readback.
+///
+/// `sqlite3_enable_load_extension(db, 0)` turns off the switch behind the
+/// `load_extension()` SQL function. On a connection the factory returns, its
+/// effect cannot be observed: that SQL function is refused if either this
+/// switch or `SQLITE_DBCONFIG_ENABLE_LOAD_EXTENSION` is off, and the factory
+/// reads the second one back and refuses any connection with it on. So no
+/// runtime test can tell whether this call was made with `0`, with `1`, or at
+/// all — and changing it to `1` was measured to leave every runtime test green.
+///
+/// Its evidence is therefore here, in the parsed source: exactly one call,
+/// whose second argument is the integer literal `0`.
+#[test]
+fn extension_loading_route_one_is_switched_off_in_source() {
+    use syn::visit::Visit;
+
+    struct Calls(Vec<Option<u64>>);
+    impl<'ast> Visit<'ast> for Calls {
+        fn visit_expr_call(&mut self, call: &'ast syn::ExprCall) {
+            let named = matches!(
+                &*call.func,
+                syn::Expr::Path(path)
+                    if path.path.segments.last().is_some_and(|segment| {
+                        segment.ident == "sqlite3_enable_load_extension"
+                    })
+            );
+            if named {
+                let second = call.args.iter().nth(1).and_then(|argument| match argument {
+                    syn::Expr::Lit(syn::ExprLit {
+                        lit: syn::Lit::Int(value),
+                        ..
+                    }) => value.base10_parse::<u64>().ok(),
+                    _ => None,
+                });
+                self.0.push(second);
+            }
+            syn::visit::visit_expr_call(self, call);
+        }
+    }
+
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/engine/ffi.rs");
+    let source = std::fs::read_to_string(&path).expect("read ffi.rs");
+    let file = syn::parse_file(&source).expect("parse ffi.rs");
+    let mut calls = Calls(Vec::new());
+    calls.visit_file(&file);
+
+    assert_eq!(
+        calls.0,
+        vec![Some(0)],
+        "sqlite3_enable_load_extension must be called exactly once, with the literal 0 \
+         (None means the argument is not an integer literal): found {:?}",
+        calls.0
+    );
+}


### PR DESCRIPTION
Program 1A, Task 1, third slice. It corrects a departure from the plan in #105, applies the fixed connection profile before the first page read, and gives every fixed limit a boundary and a boundary-plus-one test.

## A correction to #105

#105 opened the database through rusqlite's safe `open_with_flags` and put only the keying in the FFI boundary. The plan's global constraints say otherwise: the one audited unsafe entry point **owns `sqlite3_open_v2`**. The reason is concrete — the off switch for native-code loading, `SQLITE_DBCONFIG_ENABLE_LOAD_EXTENSION` (1005), is **commented out of rusqlite's safe `DbConfig`** (in rusqlite's own source), exposing it would take the forbidden `load_extension` feature, and the plan permits no second raw-handle shim.

`open_keyed_hardened` now opens → keys as the first operation → turns off both native-code loading routes and reads the second back → hands the handle to rusqlite. Still one `unsafe` block, in the one boundary file.

## The fixed profile, before any page is read

Four safety switches (DEFENSIVE on, TRUSTED_SCHEMA off, both DQS off) and the ten limits from the plan, **each confirmed by what SQLite reports back** — SQLite clamps a limit to its compile-time maximum silently. Anything that does not hold refuses the connection as `ProfileNotApplied`.

## Every limit, at its edge

Each of the ten is read back from the C library, then exercised at its boundary and one past it:

| limit | boundary ✓ | boundary+1 ✗ |
| --- | --- | --- |
| SQL text | 64 KiB | `statement too long` |
| one value | 16 MiB | `string or blob too big` |
| columns | 128 | `too many columns` |
| expression depth | 32 | `Expression tree is too large` |
| compound terms | 16 | `too many terms in compound SELECT` |
| variables | `?999` | `variable number must be between ?1 and ?999` |
| LIKE pattern | 256 B | `LIKE or GLOB pattern too complex` |
| attached | 0 | `too many attached databases` |
| trigger depth | 0 (no trigger fires) | `too many levels of trigger recursion` |
| worker threads | readback only — no statement behaves differently past it |

Every refusal is matched to **its own limit's message**, because a boundary-plus-one case that failed on a typo in its own SQL would prove nothing.

**Probing first caught a trap.** Some limits are checked when a statement compiles; others only when it runs. A first probe that prepared without stepping reported LIKE length, value length, ATTACH and extension loading as passing at *any* size. The test helper steps, and says why.

## An overclaim this slice found in its own comment

The comment had said the `load_extension()` SQL-function route was proven by calling it and requiring a refusal. **Switching that route on left every runtime test green.** Measured outside the crate:

| route one | route two | SQL `load_extension()` |
| --- | --- | --- |
| off | off | refused |
| on | off | refused |
| off | on | refused |
| on | on | calls `dlopen` |

Either switch alone refuses. The factory never returns a connection with route two on, so **route one's effect cannot be observed at runtime at all.** The comments now say exactly that, and its evidence moves to where it can exist: `extension_loading_route_one_is_switched_off_in_source` parses `ffi.rs` with `syn` and requires exactly one call with the literal `0`. Switching it on now fails (`found [Some(1)]`); deleting it fails (`found []`).

Also measured: with both switches on, SQLite's error lists **every filesystem path it searched** for the library — a disclosure of its own, and one more reason both stay off.

## Verify teeth

- route two on → the factory refuses every connection (6 tests fail)
- no limits applied → the limits test fails
- DEFENSIVE off → the writable-schema test fails (the schema is checked directly, not via an error message)
- route one on, or deleted → the structural pin fails

Writable schema is judged on `sqlite_schema` itself: under DEFENSIVE the pragma may be accepted, but the schema must not change. "No dynamic SQL path" is a property of the API, left to the source-closure gate once the public boundary exists — the test says so rather than implying a runtime check.

`cargo test -p sovereign-vault-v2-engine` green (8 engine + 22 gate + 6 + 2 + 1); clippy clean; `./scripts/test_changed.sh` ALL GREEN.

## Still to do in Task 1

`process.rs` and the OpenSSL bootstrap (the second boundary file), the cipher/journal/synchronous PRAGMA readback, `max_page_count`, read-only reopen, the pinned fixture database, and the five `trybuild` compile-fail cases.
