### PR TITLE
fix(owner): read the guard's test requests in blocking mode

### DIFF
--- a/crates/owner/tests/cross_port_attacks.rs
+++ b/crates/owner/tests/cross_port_attacks.rs
@@ -91,6 +91,27 @@ impl Drop for Guarded {
 /// Parse one request and answer with the guard's verdict. Headers are kept in
 /// order with repeats, because that is what the guard needs to see.
 fn serve_one(mut stream: TcpStream) {
+    // An accepted socket inherits the listener's non-blocking flag on macOS
+    // and the BSDs, though not on Linux — measured on the macOS test host,
+    // where `read` on a freshly accepted socket with no data yet returns
+    // `WouldBlock`. The listener is non-blocking only so the accept loop can
+    // poll its shutdown flag. If the connection inherited that, `read_line`
+    // returned `WouldBlock` whenever the request had not landed yet, this
+    // function returned without reading it, and closing a socket with unread
+    // data sends a reset: the client saw `Connection reset by peer`. That was
+    // an intermittent macOS-only failure of this file (1 in 30 standalone),
+    // and why CI on Linux never saw it.
+    //
+    // The production broker already does exactly this after `accept`
+    // (`crates/authority/src/broker/listener.rs`). The timeout stops a caller
+    // that connects and never sends from wedging this single-threaded server.
+    if stream.set_nonblocking(false).is_err()
+        || stream
+            .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+            .is_err()
+    {
+        return;
+    }
     let mut reader = BufReader::new(stream.try_clone().unwrap());
     let mut request_line = String::new();
     if reader.read_line(&mut request_line).is_err() {
@@ -107,8 +128,13 @@ fn serve_one(mut stream: TcpStream) {
     let mut raw_headers = Vec::new();
     loop {
         let mut line = String::new();
-        if reader.read_line(&mut line).unwrap_or(0) == 0 {
-            break;
+        // A read error is not the end of the headers. Treating it as one would
+        // hand the guard a request it never fully received — and this file
+        // exists to attack that guard. Abandon the connection instead.
+        match reader.read_line(&mut line) {
+            Ok(0) => break,
+            Ok(_) => {}
+            Err(_) => return,
         }
         let line = line.trim_end().to_owned();
         if line.is_empty() {


### PR DESCRIPTION
The gate stopped on `only_the_pre_session_routes_answer_without_credentials` with `Connection reset by peer`. It is unrelated to the vault work in #108 — and it is not the guard's fault either.

## It was flaky from birth

- **1 in 30** standalone runs on macOS failed, before any change.
- The test has not been touched since it was written.
- It has **never** failed on Linux CI.

## The cause is in the test server

The listener is non-blocking so the accept loop can poll a shutdown flag. **On macOS and the BSDs, an accepted socket inherits that flag; on Linux it does not.** Measured on the host rather than assumed — `read` on a freshly accepted socket with no data yet:

```
macos: accepted socket INHERITED non-blocking (read returned WouldBlock with no data)
```

So whenever a request had not landed by the time `serve_one` read its first line, `read_line` returned `WouldBlock`, the function returned **without reading the request**, and closing a socket with unread data sends a reset. That is the macOS-only failure, and why CI never saw it.

## The fix

`serve_one` puts the connection back into blocking mode, with a five-second read timeout. This is **exactly what the production broker already does after `accept`** in `crates/authority/src/broker/listener.rs` — the test server was the outlier. The timeout keeps a caller that connects and never sends from wedging a single-threaded server.

## A second defect in the same function

A read error in the header loop was treated as end-of-headers (`read_line(...).unwrap_or(0)`), so **the guard could be handed a request it never fully received**. In a file whose purpose is to attack that guard, that is not acceptable even as an edge case. A read error now abandons the connection. No test sends a truncated request, so nothing depended on the old behaviour.

## What I deliberately did not do

Tolerate the reset on the client side. It would have made the symptom disappear and left the guard judging partial requests. Every assertion still compares a status line the server actually wrote.

## Evidence

The whole file (7 tests) passed **100 consecutive runs**, against 1 failure in 30 before — together with the measured root cause.
