### PR TITLE
fix(workspace): state what the customer owes in every composed message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,6 +1536,7 @@ dependencies = [
 name = "sovereign-cli"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "chrono",
  "clap",
  "dirs",

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -36,6 +36,7 @@ sovereign-privacy = { workspace = true }
 sovereign-sandbox = { workspace = true }
 sovereign-vault = { workspace = true }
 sovereign-workflow = { workspace = true }
+base64 = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 hex = { workspace = true }

--- a/apps/cli/assets/app.js
+++ b/apps/cli/assets/app.js
@@ -223,7 +223,7 @@ function renderState() {
       [t("th_time"), t("th_customer"), t("th_provider"), t("th_where"), t("th_class"), t("th_failover")],
       dl.map(d => [
         new Date(d.at * 1000).toLocaleString(locale()),
-        d.customer,
+        d.customer == null ? t("disclosure_company") : d.customer,
         d.provider + " (" + d.provider_trust + ")",
         d.stayed_local ? badge("good", t("stayed_local")) : badge("warn", t("left_device")),
         d.data_class,

--- a/apps/cli/assets/i18n.js
+++ b/apps/cli/assets/i18n.js
@@ -118,6 +118,7 @@ const STRINGS = {
     sec_disclosures: "Data disclosures — every time a model saw your customer data",
     sec_disclosures_note: "Your right to know who processed your data. Each row is one call to the drafting assistant: which provider answered, whether the provider claims the data never left this device — its own report, which this app does not verify — and which providers were skipped on the way. The suggestion itself is never stored — only the disclosure.",
     disclosures_empty: "No model has been shown customer data yet.",
+    disclosure_company: "Company profile (no customer)",
     th_provider: "Provider", th_where: "Where", th_class: "Data class", th_failover: "Skipped",
     skip_reason: (r) => ({
       unhealthy: "not answering",
@@ -267,6 +268,7 @@ const STRINGS = {
     sec_disclosures: "数据披露 —— 每一次模型接触你的客户数据",
     sec_disclosures_note: "你有权知道谁处理了你的数据。每一行对应一次调用起草助手:哪个提供方作出应答、提供方自称数据是否留在本机(这是它自己的说法,本应用不做验证)、以及沿途跳过了哪些提供方。建议内容本身从不存储 —— 只记录披露事实。",
     disclosures_empty: "尚无模型接触过客户数据。",
+    disclosure_company: "公司资料(不涉及客户)",
     th_provider: "提供方", th_where: "位置", th_class: "数据分级", th_failover: "已跳过",
     skip_reason: (r) => ({
       unhealthy: "没有应答",

--- a/apps/cli/src/ui.rs
+++ b/apps/cli/src/ui.rs
@@ -536,13 +536,21 @@ fn disclosures_json(root: &Path) -> serde_json::Value {
         Ok(workspace) => workspace,
         Err(_) => return serde_json::json!([]),
     };
-    let named = |id| {
-        workspace
-            .customers
-            .iter()
-            .find(|customer| customer.id == id)
-            .map(|customer| customer.name.clone())
-            .unwrap_or_else(|| "(unknown)".into())
+    // A nil customer is a company-level call (a compliance check of the
+    // profile): `null`, which the page names in the founder's language. A
+    // customer that has since been removed stays "(unknown)".
+    let named = |id: uuid::Uuid| {
+        if id.is_nil() {
+            return serde_json::Value::Null;
+        }
+        serde_json::Value::String(
+            workspace
+                .customers
+                .iter()
+                .find(|customer| customer.id == id)
+                .map(|customer| customer.name.clone())
+                .unwrap_or_else(|| "(unknown)".into()),
+        )
     };
     let mut entries: Vec<serde_json::Value> = workspace
         .disclosures

--- a/apps/cli/src/workspace/compliance.rs
+++ b/apps/cli/src/workspace/compliance.rs
@@ -1050,11 +1050,16 @@ impl Store {
                     }
                 }
                 let provider_trust = format!("{:?}", disclosure.provider_trust).to_lowercase();
+                // The findings shown to the model are about one invoice's
+                // customer, or about the company alone. Name that subject:
+                // a nil customer on the chain says "a customer" and names no
+                // one, which is not what happened in either case.
+                let disclosed_customer = document.map(|document| document.customer_id);
                 disclosure_event = Some((
                     ModelDisclosure {
                         id: Uuid::new_v4(),
                         at: now_unix,
-                        customer_id: Uuid::nil(),
+                        customer_id: disclosed_customer.unwrap_or(Uuid::nil()),
                         task: "crew.compliance_checker".into(),
                         provider_id: provider_id.clone(),
                         stayed_local: provider_trust == "local",
@@ -1069,7 +1074,9 @@ impl Store {
                     },
                     AuditEntry {
                         action: "model.drafted".into(),
-                        resource: format!("customer:{}", Uuid::nil()),
+                        resource: disclosed_customer
+                            .map(|id| format!("customer:{id}"))
+                            .unwrap_or_else(|| "venture:profile".to_owned()),
                         payload: serde_json::json!({
                             "task": "crew.compliance_checker",
                             "provider": provider_id,

--- a/apps/cli/src/workspace/compliance_tests.rs
+++ b/apps/cli/src/workspace/compliance_tests.rs
@@ -19,6 +19,20 @@ fn actions(dir: &tempfile::TempDir) -> Vec<String> {
     ledger.events().iter().map(|e| e.action.clone()).collect()
 }
 
+/// The subject the chain names for the latest model call.
+fn last_model_resource(dir: &tempfile::TempDir) -> String {
+    let device = DeviceIdentity::load(&dir.path().join("device.json")).unwrap();
+    let ledger =
+        AuditLedger::load(&dir.path().join("ledger.json"), device.public_key_b64()).unwrap();
+    ledger
+        .events()
+        .iter()
+        .rev()
+        .find(|e| e.action == "model.drafted")
+        .map(|e| e.resource.clone())
+        .unwrap()
+}
+
 fn profile(
     jurisdiction: &str,
     gst: bool,
@@ -186,6 +200,10 @@ fn a_singapore_company_report_checks_gst_pdpa_contracts_and_deadlines() {
         &events[events.len() - 2..],
         ["model.drafted", "compliance.checked"]
     );
+    // A company check shows the model the company's findings, not any one
+    // customer's record: the chain says so instead of naming a nil customer.
+    assert_eq!(last_model_resource(&dir), "venture:profile");
+    assert!(workspace.disclosures.last().unwrap().customer_id.is_nil());
 
     // Recording consent and registering for GST changes the facts and the
     // verdicts; the digest changes with them.
@@ -214,7 +232,7 @@ fn a_singapore_company_report_checks_gst_pdpa_contracts_and_deadlines() {
 
 #[test]
 fn an_invoice_subject_checks_essentials_and_gst_particulars() {
-    let (_dir, store) = store();
+    let (dir, store) = store();
     store
         .update_venture_profile(profile("SG", true, None, Some(1_705_276_800)))
         .unwrap();
@@ -236,6 +254,19 @@ fn an_invoice_subject_checks_essentials_and_gst_particulars() {
         )
         .unwrap();
     assert_eq!(report.subject, format!("document:{invoice_id}"));
+    // The model saw this invoice's findings: the disclosure names its
+    // customer, on the chain and in the founder's log.
+    assert_eq!(last_model_resource(&dir), format!("customer:{customer_id}"));
+    assert_eq!(
+        store
+            .load()
+            .unwrap()
+            .disclosures
+            .last()
+            .unwrap()
+            .customer_id,
+        customer_id
+    );
     // Document reports carry only document-level rules.
     let ids: Vec<&str> = report.findings.iter().map(|f| f.rule_id.as_str()).collect();
     assert!(ids.contains(&"SG-INV-01") && ids.contains(&"SG-GST-02"));

--- a/apps/cli/src/workspace/compose.rs
+++ b/apps/cli/src/workspace/compose.rs
@@ -1,4 +1,4 @@
-use super::util::now;
+use super::util::{has_chinese, local_date, now};
 use super::*;
 
 use uuid::Uuid;
@@ -54,7 +54,7 @@ pub(super) fn render_document(
                 "INVOICE (DRAFT)\n\nFrom: {}\nBill to: {}\nAmount: {}\n\nPayment terms to be confirmed.\nThis draft was generated locally by Sovereign Founder OS and has not been issued.",
                 venture.name,
                 customer.name,
-                format_amount(amount_cents.unwrap_or(0)),
+                format_money(&venture.currency, amount_cents.unwrap_or(0)),
             ),
         ),
         (DocumentKind::Invoice, true) => (
@@ -63,7 +63,7 @@ pub(super) fn render_document(
                 "发票(草稿)\n\n开票方:{}\n客户:{}\n金额:{}\n\n付款条款待确认。\n本草稿由 Sovereign Founder OS 在本地生成,尚未开具。",
                 venture.name,
                 customer.name,
-                format_amount(amount_cents.unwrap_or(0)),
+                format_money(&venture.currency, amount_cents.unwrap_or(0)),
             ),
         ),
     };
@@ -84,8 +84,113 @@ pub(super) fn render_document(
     }
 }
 
-fn format_amount(cents: u64) -> String {
-    format!("$ {}.{:02}", cents / 100, cents % 100)
+/// `SGD 8,000.00`: the company's own currency code and grouped digits. The
+/// code comes from the profile rather than a symbol, because `$` alone is
+/// five different currencies in the markets this product covers.
+pub(super) fn format_money(currency: &str, cents: u64) -> String {
+    let whole = (cents / 100).to_string();
+    let mut grouped = String::with_capacity(whole.len() + whole.len() / 3);
+    for (index, digit) in whole.chars().enumerate() {
+        if index > 0 && (whole.len() - index).is_multiple_of(3) {
+            grouped.push(',');
+        }
+        grouped.push(digit);
+    }
+    let code = currency.trim();
+    if code.is_empty() {
+        format!("{grouped}.{:02}", cents % 100)
+    } else {
+        format!("{code} {grouped}.{:02}", cents % 100)
+    }
+}
+
+/// Whether a document is written in Chinese. The composed message has no
+/// language field to consult, and the right language for the lines the
+/// system adds is the one the founder wrote (or approved) the document in.
+fn written_in_chinese(document: &Document) -> bool {
+    has_chinese(&document.title) || has_chinese(&document.body)
+}
+
+/// The facts a customer needs to act on, stated by the system from the
+/// approved record rather than left to the body text.
+///
+/// A drafted body is prose — an AI employee's, or the founder's own edit —
+/// and nothing guarantees it repeats the amount, still matches it after the
+/// amount field was edited, or says when payment is due. These lines are
+/// rendered from the fields the founder saw on the card and approved, so the
+/// message cannot ask for a number the record does not hold.
+fn outgoing_facts(venture: Option<&Venture>, document: &Document, zh: bool) -> Vec<String> {
+    if document.amount_cents.is_none() && document.due_at.is_none() {
+        return Vec::new();
+    }
+    let invoice = document.kind == DocumentKind::Invoice;
+    let currency = venture
+        .map(|venture| venture.currency.as_str())
+        .unwrap_or("");
+    let mut lines = Vec::new();
+    if let Some(cents) = document.amount_cents {
+        let label = match (invoice, zh) {
+            (true, true) => "应付金额",
+            (true, false) => "Amount due",
+            (false, true) => "报价金额",
+            (false, false) => "Quoted amount",
+        };
+        lines.push(format!(
+            "{label}{}{}",
+            if zh { ":" } else { ": " },
+            format_money(currency, cents)
+        ));
+    }
+    if let (true, Some(due_at)) = (invoice, document.due_at) {
+        let date = local_date(due_at);
+        lines.push(if zh {
+            format!("付款期限:{date}")
+        } else {
+            format!("Payment due: {date}")
+        });
+    }
+    if let Some(venture) = venture {
+        let issuer = if venture.uen.trim().is_empty() {
+            venture.name.clone()
+        } else if zh {
+            format!("{}(UEN {})", venture.name, venture.uen.trim())
+        } else {
+            format!("{} (UEN {})", venture.name, venture.uen.trim())
+        };
+        lines.push(match (invoice, zh) {
+            (true, true) => format!("开票方:{issuer}"),
+            (true, false) => format!("Issued by: {issuer}"),
+            (false, true) => format!("报价方:{issuer}"),
+            (false, false) => format!("From: {issuer}"),
+        });
+    }
+    let reference = document.id.simple().to_string()[..8].to_ascii_uppercase();
+    lines.push(if zh {
+        format!("参考编号:{reference}")
+    } else {
+        format!("Reference: {reference}")
+    });
+    lines
+}
+
+/// The subject names the document's kind, so an invoice titled after its
+/// project still reads as an invoice in the customer's inbox — unless the
+/// title already says so.
+fn subject_line(document: &Document, zh: bool) -> String {
+    let (label, words): (&str, &[&str]) = match (document.kind, zh) {
+        (DocumentKind::Invoice, true) => ("发票", &["发票", "invoice"]),
+        (DocumentKind::Invoice, false) => ("Invoice", &["invoice", "发票"]),
+        (DocumentKind::Offer, true) => ("报价", &["报价", "方案", "提案", "offer", "proposal"]),
+        (DocumentKind::Offer, false) => ("Offer", &["offer", "proposal", "quote", "报价"]),
+    };
+    let lowered = document.title.to_lowercase();
+    if words.iter().any(|word| lowered.contains(word)) {
+        document.title.clone()
+    } else if zh {
+        format!("{label}:{}", document.title)
+    } else {
+        format!("{label}: {}", document.title)
+    }
 }
 
 /// Compose a well-formed RFC 5322 message for an approved document. The result
@@ -94,11 +199,13 @@ fn format_amount(cents: u64) -> String {
 /// placeholder the founder must replace before sending. Header values come from
 /// validated fields (names carry no control characters, emails no CR/LF or
 /// separators), and are re-sanitized here, so no field can inject a header.
+/// Non-ASCII header text is carried as RFC 2047 encoded-words.
 pub(super) fn compose_email(
     venture: Option<&Venture>,
     customer: Option<&Customer>,
     document: &Document,
 ) -> String {
+    let zh = written_in_chinese(document);
     let sender_name = venture
         .map(|venture| venture.name.as_str())
         .unwrap_or("Sovereign Founder");
@@ -114,15 +221,17 @@ pub(super) fn compose_email(
 
     let mut message = String::new();
     message.push_str(&format!(
-        "From: {} <founder@example.invalid>\r\n",
-        encode_display_name(sender_name)
+        "From: {}\r\n",
+        mailbox(sender_name, "founder@example.invalid")
     ));
     message.push_str(&format!(
-        "To: {} <{}>\r\n",
-        encode_display_name(recipient_name),
-        header_safe(&recipient_addr)
+        "To: {}\r\n",
+        mailbox(recipient_name, &header_safe(&recipient_addr))
     ));
-    message.push_str(&format!("Subject: {}\r\n", header_safe(&document.title)));
+    message.push_str(&format!(
+        "Subject: {}\r\n",
+        encode_unstructured(&header_safe(&subject_line(document, zh)))
+    ));
     message.push_str(&format!("Date: {}\r\n", chrono::Utc::now().to_rfc2822()));
     message.push_str(&format!(
         "Message-ID: <{}@sovereign-founder-os.invalid>\r\n",
@@ -130,6 +239,8 @@ pub(super) fn compose_email(
     ));
     message.push_str("MIME-Version: 1.0\r\n");
     message.push_str("Content-Type: text/plain; charset=utf-8\r\n");
+    // The body is raw UTF-8; without this line MIME reads it as 7-bit.
+    message.push_str("Content-Transfer-Encoding: 8bit\r\n");
     message.push_str(
         "X-Sovereign-Composed: composed locally by Sovereign Founder OS; not transmitted\r\n",
     );
@@ -139,20 +250,89 @@ pub(super) fn compose_email(
         );
     }
     message.push_str("\r\n");
-    for line in document.body.split('\n') {
+    for line in document.body.trim_end().split('\n') {
         message.push_str(line.trim_end_matches('\r'));
         message.push_str("\r\n");
+    }
+    let facts = outgoing_facts(venture, document, zh);
+    if !facts.is_empty() {
+        message.push_str("\r\n--\r\n");
+        for line in facts {
+            message.push_str(&line);
+            message.push_str("\r\n");
+        }
     }
     message
 }
 
-/// Render an RFC 5322 display-name: kept bare when it is a safe atom, otherwise
-/// a quoted-string with `\\` and `"` escaped. CR/LF are stripped defensively.
+/// Longest encoded-word written here, delimiters included. RFC 2047 caps a
+/// word at 75 and any line holding one at 76; 60 leaves room on the first
+/// line for the longest header name this module writes (`Subject: `).
+const MAX_ENCODED_WORD: usize = 60;
+
+/// Carry non-ASCII header text as RFC 2047 `B` (base64) encoded-words,
+/// folded one word per line. Plain ASCII passes through untouched. Each word
+/// holds whole characters — the RFC forbids splitting one across words.
+///
+/// `B` rather than `Q`: a Chinese character costs 4 characters here and 9 in
+/// `Q`, so a company or customer name fits in one word. That matters beyond
+/// length. The RFC says the space between two adjacent words is ignored, and
+/// not every reader honours it — Python's parser, measured, renders a name
+/// split across two words with a space in the middle.
+fn encode_unstructured(text: &str) -> String {
+    use base64::Engine as _;
+    if text.is_ascii() {
+        return text.to_owned();
+    }
+    const PREFIX: &str = "=?UTF-8?B?";
+    const SUFFIX: &str = "?=";
+    // Base64 turns every 3 bytes into 4 characters.
+    let byte_budget = (MAX_ENCODED_WORD - PREFIX.len() - SUFFIX.len()) / 4 * 3;
+    let mut chunks: Vec<String> = Vec::new();
+    let mut current = String::new();
+    for ch in text.chars() {
+        if current.len() + ch.len_utf8() > byte_budget {
+            chunks.push(std::mem::take(&mut current));
+        }
+        current.push(ch);
+    }
+    if !current.is_empty() {
+        chunks.push(current);
+    }
+    chunks
+        .iter()
+        .map(|chunk| {
+            let encoded = base64::engine::general_purpose::STANDARD.encode(chunk.as_bytes());
+            format!("{PREFIX}{encoded}{SUFFIX}")
+        })
+        .collect::<Vec<_>>()
+        .join("\r\n ")
+}
+
+/// `name <address>`. An encoded name folds before the address, so the line
+/// holding the encoded-words stays within RFC 2047's limit however long the
+/// address is.
+fn mailbox(name: &str, address: &str) -> String {
+    let display = encode_display_name(name);
+    if !name.is_ascii() {
+        format!("{display}\r\n <{address}>")
+    } else {
+        format!("{display} <{address}>")
+    }
+}
+
+/// Render an RFC 5322 display-name: kept bare when it is a safe atom, a
+/// quoted-string with `\\` and `"` escaped when it is other ASCII, and
+/// encoded-words when it is not ASCII (an encoded-word may not sit inside a
+/// quoted-string). CR/LF are stripped defensively.
 fn encode_display_name(name: &str) -> String {
     let sanitized: String = name
         .chars()
         .filter(|ch| *ch != '\r' && *ch != '\n')
         .collect();
+    if !sanitized.is_ascii() {
+        return encode_unstructured(&sanitized);
+    }
     let needs_quoting = sanitized.is_empty()
         || sanitized
             .chars()

--- a/apps/cli/src/workspace/compose_tests.rs
+++ b/apps/cli/src/workspace/compose_tests.rs
@@ -1,0 +1,238 @@
+//! What the customer receives. The composed `.eml` is the one artefact of
+//! this product that leaves the founder's hands, so these tests read it the
+//! way a mail client and a customer would: the header block must decode, and
+//! the body must state what to pay and by when from the approved record.
+
+use super::compose::{compose_email, format_money};
+use super::util::local_date;
+use super::*;
+use chrono::TimeZone;
+use uuid::Uuid;
+
+fn venture(name: &str, currency: &str, uen: &str) -> Venture {
+    Venture {
+        name: name.into(),
+        service: "Order-flow consulting".into(),
+        currency: currency.into(),
+        uen: uen.into(),
+        ..Venture::blank()
+    }
+}
+
+fn customer(name: &str, email: &str) -> Customer {
+    Customer {
+        id: Uuid::new_v4(),
+        name: name.into(),
+        email: email.into(),
+        notes: String::new(),
+        created_at: 0,
+        stage: CustomerStage::Customer,
+        discovery_notes: String::new(),
+        jurisdiction: String::new(),
+        personal_data_consent: true,
+        updated_at: 0,
+    }
+}
+
+fn document(kind: DocumentKind, title: &str, body: &str, amount: Option<u64>) -> Document {
+    Document {
+        id: Uuid::new_v4(),
+        kind,
+        customer_id: Uuid::new_v4(),
+        title: title.into(),
+        body: body.into(),
+        amount_cents: amount,
+        status: DocumentStatus::PendingApproval,
+        created_at: 0,
+        updated_at: 0,
+        revision: 1,
+        due_at: None,
+        project_id: None,
+        accepted_at: None,
+    }
+}
+
+fn split(message: &str) -> (&str, &str) {
+    message
+        .split_once("\r\n\r\n")
+        .expect("a header block and a body")
+}
+
+/// The unfolded value of one header.
+fn header(message: &str, name: &str) -> String {
+    let (headers, _) = split(message);
+    let unfolded = headers.replace("\r\n ", " ");
+    unfolded
+        .split("\r\n")
+        .find_map(|line| line.strip_prefix(&format!("{name}: ")))
+        .unwrap_or_else(|| panic!("no {name} header"))
+        .to_owned()
+}
+
+/// Decode RFC 2047 `B` words the way a mail client does — rather than
+/// comparing against a second encoder, which would share any mistake.
+fn decode_words(value: &str) -> String {
+    use base64::Engine as _;
+    let mut bytes = Vec::new();
+    for word in value.split(' ') {
+        let payload = word
+            .strip_prefix("=?UTF-8?B?")
+            .and_then(|rest| rest.strip_suffix("?="))
+            .unwrap_or_else(|| panic!("not an encoded-word: {word}"));
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(payload)
+            .expect("valid base64");
+        // Each word must hold whole characters on its own.
+        assert!(
+            std::str::from_utf8(&decoded).is_ok(),
+            "a split character in {word}"
+        );
+        bytes.extend(decoded);
+    }
+    String::from_utf8(bytes).expect("words decode to whole UTF-8 characters")
+}
+
+fn local_noon(year: i32, month: u32, day: u32) -> i64 {
+    chrono::Local
+        .with_ymd_and_hms(year, month, day, 12, 0, 0)
+        .single()
+        .unwrap()
+        .timestamp()
+}
+
+/// The defect found by using the product: an invoice drafted by an AI
+/// employee has a one-line description for a body, and the amount and due
+/// date lived only in fields — so the customer was asked to pay nothing, by
+/// no date. The system now states both, from the record, in the document's
+/// language.
+#[test]
+fn an_invoice_states_the_approved_amount_due_date_and_issuer() {
+    let company = venture("晓岸咨询", "SGD", "202412345K");
+    let buyer = customer("翠林饮品有限公司", "ops@cuilin.example");
+    let mut invoice = document(
+        DocumentKind::Invoice,
+        "订单系统迁移项目",
+        "为客户提供数字化转型咨询和流程梳理",
+        Some(800_000),
+    );
+    invoice.due_at = Some(local_noon(2026, 10, 12));
+
+    let message = compose_email(Some(&company), Some(&buyer), &invoice);
+    let (_, body) = split(&message);
+    let reference = invoice.id.simple().to_string()[..8].to_ascii_uppercase();
+    assert!(body.starts_with("为客户提供数字化转型咨询和流程梳理\r\n"));
+    for line in [
+        "应付金额:SGD 8,000.00".to_owned(),
+        "付款期限:2026-10-12".to_owned(),
+        "开票方:晓岸咨询(UEN 202412345K)".to_owned(),
+        format!("参考编号:{reference}"),
+    ] {
+        assert!(body.contains(&format!("{line}\r\n")), "missing {line:?}");
+    }
+    // The subject says what it is: the title names only the project.
+    assert_eq!(
+        decode_words(&header(&message, "Subject")),
+        "发票:订单系统迁移项目"
+    );
+}
+
+/// The amount line is rendered from the approved field, never copied from
+/// prose: a body that still quotes an old figure cannot override it.
+#[test]
+fn the_stated_amount_follows_the_record_not_the_body() {
+    let company = venture("Acme", "USD", "");
+    let offer = document(
+        DocumentKind::Offer,
+        "Website refresh",
+        "Scope as discussed. Earlier we said 2,000.",
+        Some(250_000),
+    );
+    let message = compose_email(
+        Some(&company),
+        Some(&customer("Dr. Tan", "t@x.example")),
+        &offer,
+    );
+    let (_, body) = split(&message);
+    assert!(body.contains("\r\n--\r\nQuoted amount: USD 2,500.00\r\nFrom: Acme\r\n"));
+    // Offers carry no payment due date; no UEN means none is claimed.
+    assert!(!body.contains("Payment due"));
+    assert!(!body.contains("UEN"));
+    assert_eq!(header(&message, "Subject"), "Offer: Website refresh");
+}
+
+#[test]
+fn a_document_with_no_amount_or_due_date_gets_no_facts_block() {
+    let offer = document(DocumentKind::Offer, "Proposal — Acme", "Hello.\n", None);
+    let message = compose_email(Some(&venture("Acme", "SGD", "")), None, &offer);
+    let (_, body) = split(&message);
+    assert_eq!(body, "Hello.\r\n");
+    // "Proposal" already names an offer; no prefix is added.
+    assert_eq!(
+        decode_words(&header(&message, "Subject")),
+        "Proposal — Acme"
+    );
+}
+
+/// Raw UTF-8 in a header is not RFC 5322. Every header line must be ASCII,
+/// every encoded-word within the RFC's length, every line foldable, and the
+/// words must decode to exactly the names and title the founder wrote.
+#[test]
+fn non_ascii_headers_are_encoded_words_that_round_trip() {
+    let long_title =
+        "晓岸咨询为翠林饮品有限公司提供的订单系统迁移、流程梳理与上线培训服务".repeat(2);
+    let company = venture("晓岸咨询", "SGD", "");
+    let buyer = customer("翠林饮品有限公司", "ops@cuilin.example");
+    let invoice = document(DocumentKind::Invoice, &long_title, "说明", Some(100));
+    let message = compose_email(Some(&company), Some(&buyer), &invoice);
+    let (headers, _) = split(&message);
+
+    assert!(headers.is_ascii(), "a raw non-ASCII byte in the headers");
+    // The body is raw UTF-8, so the message must say it is 8-bit.
+    assert!(headers.contains("\r\nContent-Transfer-Encoding: 8bit\r\n"));
+    let mut encoded_lines = 0;
+    for line in headers.split("\r\n").filter(|line| line.contains("=?")) {
+        encoded_lines += 1;
+        // RFC 2047: a line holding an encoded-word is at most 76 chars.
+        assert!(line.len() <= 76, "header line over 76 chars: {line}");
+        for word in line.split(' ').filter(|w| w.starts_with("=?")) {
+            assert!(word.len() <= 75, "encoded-word over 75 chars: {word}");
+        }
+    }
+    // The long title really did fold: the check above inspected something.
+    assert!(encoded_lines > 4, "only {encoded_lines} encoded lines");
+    // A name is one word: a reader that keeps the space between adjacent
+    // words would otherwise split the name in two.
+    for name_header in ["From", "To"] {
+        let value = header(&message, name_header);
+        assert_eq!(value.matches("=?").count(), 1, "{name_header}: {value}");
+    }
+    let from = header(&message, "From");
+    let (from_name, from_addr) = from.rsplit_once(' ').unwrap();
+    assert_eq!(decode_words(from_name), "晓岸咨询");
+    assert_eq!(from_addr, "<founder@example.invalid>");
+    let to = header(&message, "To");
+    let (to_name, to_addr) = to.rsplit_once(' ').unwrap();
+    assert_eq!(decode_words(to_name), "翠林饮品有限公司");
+    assert_eq!(to_addr, "<ops@cuilin.example>");
+    assert_eq!(
+        decode_words(&header(&message, "Subject")),
+        format!("发票:{long_title}")
+    );
+}
+
+#[test]
+fn money_uses_the_company_currency_and_groups_digits() {
+    assert_eq!(format_money("SGD", 0), "SGD 0.00");
+    assert_eq!(format_money("SGD", 99), "SGD 0.99");
+    assert_eq!(format_money("SGD", 100_000), "SGD 1,000.00");
+    assert_eq!(format_money("MYR", 123_456_789), "MYR 1,234,567.89");
+    assert_eq!(format_money("", 100_000), "1,000.00");
+}
+
+/// Dates the system writes into the founder's notes and messages are
+/// calendar dates where the founder is, not in UTC.
+#[test]
+fn local_date_is_the_founders_calendar_date() {
+    assert_eq!(local_date(local_noon(2026, 9, 12)), "2026-09-12");
+    assert_eq!(local_date(local_noon(2026, 1, 1)), "2026-01-01");
+}

--- a/apps/cli/src/workspace/crew_ops.rs
+++ b/apps/cli/src/workspace/crew_ops.rs
@@ -10,7 +10,7 @@ use super::crew_template::{deterministic_change, summarize_change};
 use super::crew_types::*;
 use super::model_config::providers_for;
 use super::store::AuditEntry;
-use super::util::{clean_text, now};
+use super::util::{clean_text, has_chinese, local_date, now};
 use super::*;
 
 use sovereign_contracts::{AutomationLevel, DataClass};
@@ -614,20 +614,41 @@ fn apply_change(
             open_questions,
             assumptions,
         } => {
-            let date = chrono::DateTime::from_timestamp(at, 0)
-                .map(|stamp| stamp.format("%Y-%m-%d").to_string())
-                .unwrap_or_default();
-            let mut section = format!("\n\n--- Discovery summary (AI Analyst, {date}) ---\n");
-            for (heading, items) in [
-                ("Problems", problems),
-                ("Constraints", constraints),
-                ("Open questions", open_questions),
-                ("Assumptions", assumptions),
-            ] {
+            let date = local_date(at);
+            // The summary lands in the founder's own notes, so its headings
+            // follow the language the content came back in.
+            let zh = [problems, constraints, open_questions, assumptions]
+                .into_iter()
+                .flatten()
+                .chain(std::iter::once(budget))
+                .any(|text| has_chinese(text));
+            let (title, headings, none, budget_label) = if zh {
+                (
+                    format!("需求整理(AI 需求分析员,{date})"),
+                    ["问题", "约束", "待澄清", "假设"],
+                    "(无)",
+                    "预算",
+                )
+            } else {
+                (
+                    format!("Discovery summary (AI Analyst, {date})"),
+                    ["Problems", "Constraints", "Open questions", "Assumptions"],
+                    "(none)",
+                    "Budget",
+                )
+            };
+            let mut section = format!("\n\n--- {title} ---\n");
+            for (heading, items) in
+                headings
+                    .into_iter()
+                    .zip([problems, constraints, open_questions, assumptions])
+            {
                 section.push_str(heading);
                 section.push_str(":\n");
                 if items.is_empty() {
-                    section.push_str("- (none)\n");
+                    section.push_str("- ");
+                    section.push_str(none);
+                    section.push('\n');
                 }
                 for item in items {
                     section.push_str("- ");
@@ -635,7 +656,8 @@ fn apply_change(
                     section.push('\n');
                 }
             }
-            section.push_str("Budget: ");
+            section.push_str(budget_label);
+            section.push_str(if zh { ":" } else { ": " });
             section.push_str(budget);
             section.push('\n');
             let customer = workspace.customer_mut(*customer_id)?;

--- a/apps/cli/src/workspace/crew_tests.rs
+++ b/apps/cli/src/workspace/crew_tests.rs
@@ -188,6 +188,37 @@ fn analyst_run_creates_a_pending_decision_with_a_disclosure_and_no_state_change(
         .any(|g| g.kind == "decide_proposals" && g.count == 1));
 }
 
+/// The summary lands in the founder's own notes, so it is written in the
+/// language the notes are in — not English headings around Chinese items.
+#[test]
+fn a_chinese_discovery_summary_gets_chinese_headings() {
+    let (_dir, store, customer_id) = seeded();
+    store
+        .update_customer(
+            customer_id,
+            CustomerInput {
+                name: "Acme Ltd".into(),
+                email: "alex@example.com".into(),
+                discovery_notes: "目前订单靠 Excel 对账,每月漏单约 5%。预算大约 8000 新元。".into(),
+                jurisdiction: "SG".into(),
+                personal_data_consent: true,
+                ..CustomerInput::default()
+            },
+        )
+        .unwrap();
+    let employee_id = hired(&store, RoleId::Analyst);
+    let decision = store
+        .run_employee(employee_id, customer_subject(customer_id), "zh")
+        .unwrap();
+    let workspace = store.decide_proposal(decision.id, true).unwrap();
+    let notes = &workspace.customers[0].discovery_notes;
+    assert!(notes.contains("--- 需求整理(AI 需求分析员,"), "{notes}");
+    for heading in ["问题:\n", "约束:\n", "待澄清:\n", "假设:\n", "预算:"] {
+        assert!(notes.contains(heading), "missing {heading:?} in {notes}");
+    }
+    assert!(!notes.contains("Budget: ") && !notes.contains("Problems:"));
+}
+
 #[test]
 fn approving_a_discovery_summary_appends_notes_and_is_audited() {
     let (dir, store, customer_id) = seeded();

--- a/apps/cli/src/workspace/mod.rs
+++ b/apps/cli/src/workspace/mod.rs
@@ -49,6 +49,8 @@ mod verify;
 #[cfg(test)]
 mod compliance_tests;
 #[cfg(test)]
+mod compose_tests;
+#[cfg(test)]
 mod crew_tests;
 #[cfg(test)]
 mod erp_tests;

--- a/apps/cli/src/workspace/tests.rs
+++ b/apps/cli/src/workspace/tests.rs
@@ -559,7 +559,9 @@ fn compose_email_is_wellformed_and_injection_safe() {
     let message = compose_email(Some(&venture), Some(&with_email), &document);
     assert!(message.contains("From: Acme <founder@example.invalid>"));
     assert!(message.contains("To: \"Dr. Tan\" <dr.tan@example.com>"));
-    assert!(message.contains("Subject: Offer — Acme"));
+    // The em dash makes the subject non-ASCII: it travels as an RFC 2047
+    // word (`compose_tests.rs` decodes these), never as raw UTF-8.
+    assert!(message.contains("Subject: =?UTF-8?B?T2ZmZXIg4oCUIEFjbWU=?=\r\n"));
     assert!(message.contains("Message-ID: <"));
     assert!(message.contains("X-Sovereign-Composed:"));
     assert!(!message.contains("placeholder"));

--- a/apps/cli/src/workspace/util.rs
+++ b/apps/cli/src/workspace/util.rs
@@ -86,6 +86,28 @@ pub(super) fn now() -> i64 {
     chrono::Utc::now().timestamp()
 }
 
+/// Whether text contains Chinese characters. Used where the system writes
+/// lines into content that has no language field of its own, so those lines
+/// match the language the content is already in.
+pub(super) fn has_chinese(text: &str) -> bool {
+    text.chars()
+        .any(|ch| ('\u{4e00}'..='\u{9fff}').contains(&ch))
+}
+
+/// A unix time as the founder's calendar date. This is a local-first app:
+/// the machine's own time zone is the founder's, and a UTC date written into
+/// their notes reads as yesterday for half the world after midnight.
+pub(super) fn local_date(unix: i64) -> String {
+    chrono::DateTime::from_timestamp(unix, 0)
+        .map(|stamp| {
+            stamp
+                .with_timezone(&chrono::Local)
+                .format("%Y-%m-%d")
+                .to_string()
+        })
+        .unwrap_or_default()
+}
+
 pub(super) fn storage(error: impl std::fmt::Display) -> WorkspaceError {
     WorkspaceError::Storage(error.to_string())
 }


### PR DESCRIPTION
## Why

Found by using the workbench the way a founder would — a real local model (`qwen2.5:7b`), an empty workspace, all the way to a paid invoice.

**The invoice an AI employee drafted reached the outbox asking the customer to pay nothing, by no date.** The model's body was one line of description; the amount and due date lived only in fields, and the composed `.eml` carried the body alone:

```
Subject: 晓岸咨询翠林饮品有限公司订单系统迁移项目

为客户提供数字化转型咨询和流程梳理
```

## What changes

**The message states the facts from the record.** Every offer or invoice with an amount or due date now ends with system-written lines in the document's language — amount in the company's currency, payment due date (invoices), issuer and UEN, a reference. They are rendered from the fields the founder saw and approved, never copied from prose, so a body still quoting an old figure cannot override the record.

Same message, after:

```
Subject: =?UTF-8?B?5Y+R56WoOuiuouWNleezu+e7n+i/geenu+mhueebrg==?=     → 发票:订单系统迁移项目

为客户提供数字化转型咨询和流程梳理

--
应付金额:SGD 8,000.00
开票方:晓岸咨询
参考编号:17A9740C
```

Around it:

| | Before | After |
|---|---|---|
| Subject | bare title | names the kind (发票 / Offer…) unless the title already does |
| Non-ASCII headers | raw UTF-8 (not RFC 5322) | RFC 2047 base64 words, ≤ 76-char lines, a name kept in one word |
| Body encoding | undeclared (MIME default 7bit) | `Content-Transfer-Encoding: 8bit` |
| Amounts | hard-coded `$` | profile currency code, grouped digits |
| Company compliance check | `model.drafted customer:00000000-…` on the signed chain, "(unknown)" in the log | `venture:profile`; invoice checks name the invoice's customer; log says "company profile" |
| Approved discovery summary | UTC date (yesterday after local midnight), English headings around Chinese items | local date, headings in the content's language |

Why base64 rather than `Q`: a name split over two encoded-words should render joined (RFC 2047 §6.2), but Python's parser — measured on the composed file — renders `翠林饮品有 限公司`. `B` fits a Chinese name in one word. `base64` was already a workspace dependency (identity, vault); this adds the edge only.

## Evidence

- New `compose_tests.rs` reads the message as a mail client does: every header line ASCII, encoded lines ≤ 76, words ≤ 75, names one word, and an independent base64 decode reproduces the exact names and subject.
- Each fix sabotaged in turn, each caught: facts block removed · RFC 2047 bypassed · 75-char words · subject prefix removed · English summary headings · nil disclosure subject.
- Live: rebuilt, approved an invoice through the UI, and parsed the outbox file with Python's `email` (policy.default): subject, from and to decode cleanly with no defects.
- `./scripts/test_changed.sh`: ALL GREEN (exit 0).

## Not in this PR

Found in the same walkthrough, landing separately: previewing/downloading the exact `.eml`, and a frontend pass over copy, i18n leaks and layout. Backend validation messages are English-only (50 of them) — needs error codes; going to the backlog.
