### PR TITLE
docs: report the founder walkthrough and queue what it left open

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1558,6 +1558,37 @@ Entries here follow the queue rules above; `lane:codex` does not apply.
   acceptance records which version, a change after acceptance produces a new version
   that must be reviewed again, and the timeline shows all of it.
 
+- [ ] **P2 | `apps/cli/src/workspace/`, `apps/cli/assets/` | Backend refusals reach a Chinese-speaking founder in English.**
+  Found 2026-09-12 using the workbench in Chinese from an empty workspace to a paid
+  invoice (report: `docs/handoff/reports/2026-09-12-founder-walkthrough.md`). Every
+  `WorkspaceError` message is an English sentence the page shows verbatim —
+  "payment exceeds the invoice amount" on an overpayment, "finish every task before
+  closing the project". There are 50 distinct ones. #111 stopped offering the two
+  controls that could only fail; the rest remain. Done when: every refusal a founder
+  can reach carries a stable code, the frontend renders it from a catalogue in both
+  languages with the English sentence as fallback, and a test enumerates the codes
+  against the catalogue so a new refusal without an entry fails.
+
+- [ ] **P2 | `apps/cli/src/workspace/` | The founder's own address is not recorded; every composed message is From: `founder@example.invalid`.**
+  Found 2026-09-12. The company profile has no sender email, so `compose.rs` writes a
+  reserved placeholder and the preview (#112) has to say so. Done when: the profile
+  has an optional sender address validated like a customer's, `compose_email` uses it
+  when set, `MessagePreview.from_is_placeholder` follows it, and tests cover set and
+  unset.
+
+- [ ] **P3 | `apps/cli/src/workspace/compose.rs` | A template draft sent unedited tells the customer it is a draft.**
+  Found 2026-09-12. The deterministic offer and invoice templates write "(草稿)/(DRAFT)"
+  and "尚未开具/has not been issued" into the *body*, and the title of a template invoice
+  is "发票草稿 — …". Approve without editing and the customer receives an invoice that
+  calls itself unissued. Done when one of: the templates stop writing status into the
+  body (status lives on the card), or the approval warns when the body still carries a
+  template's draft markers — decided, and tested either way.
+
+- [ ] **P3 | `apps/cli/src/workspace/compliance_pack.rs` | The pack's review-status note is English-only and shown verbatim in Chinese reports.**
+  Found 2026-09-12. `review_status` is one English sentence stored into every report.
+  Done when the pack declares it in both languages and a report stores the one for the
+  language the check ran in.
+
 - [x] **P1 | `apps/cli/src/workspace/` | Business graph: stages, discovery, editing, projects, tasks, follow-ups, payments, receivables, timeline (workspace v2).** Landed 2026-09-10 (`erp_types.rs`, `erp_ops.rs`, `erp_tests.rs`).
 - [x] **P1 | `crates/model/`, `apps/cli/src/workspace/` | Experimental loopback Ollama provider and per-device `model.json`.** Landed 2026-09-10.
 - [x] **P1 | `apps/cli/src/workspace/` | Six hireable AI employees that propose; founder decisions apply the exact change.** Landed 2026-09-10 (`crew_*`).

--- a/docs/handoff/reports/2026-09-12-founder-walkthrough.md
+++ b/docs/handoff/reports/2026-09-12-founder-walkthrough.md
@@ -1,0 +1,83 @@
+# Using the workbench as a founder would
+
+- **Outcome:** three pull requests (#110–#112, merged), four backlog
+  entries
+- **Base:** `caa1bb8` · **Machine:** the founder's Mac, macOS 26.5 arm64,
+  Ollama with `qwen2.5:7b`
+- **Method:** an empty workspace, the Chinese UI, a real local model, and the
+  whole path a consultant takes — name the company, add a lead with notes,
+  hire AI employees, approve their proposals, send an offer, record the
+  acceptance, plan and finish the project, invoice, record payment, run a
+  compliance check, read the Security Center — clicking through the pages
+  rather than calling the API.
+
+## The one thing to read first
+
+**The invoice an AI employee drafted reached the outbox asking the customer
+to pay nothing, by no date.** The model wrote a one-line description as the
+body; the amount and due date lived only in fields, and the composed `.eml`
+carried the body alone. Every screen the founder saw showed `SGD 8,000.00`
+and a due date on the card. The message did not.
+
+Nothing in the test suite could have caught it: the tests checked that the
+message was well-formed and injection-safe, and it was. What it said to the
+customer was never read. #110 makes the system state the amount, due date,
+issuer and a reference from the approved record, in the document's
+language, and never from prose — a body still quoting an old figure cannot
+override the field.
+
+## What landed
+
+| PR | What it changes |
+| --- | --- |
+| #110 | The composed message states what is owed. Subject names the kind; non-ASCII headers are RFC 2047 words; `8bit` declared; currency from the profile instead of `$`. A company compliance check no longer records its model call against a nil customer on the signed chain; discovery summaries are dated locally, with headings in the content's language. |
+| #111 | What the founder reads: a "sent" count that counted unsent files, a model-status failure that read as "no model configured", a finish button that could only fail, pending proposals with no buttons, role cards half in English, internal codes shown as words, and the layout defects (grey script-built inputs, wrapped amounts, a section-gap rule that removed the gap after every panel). |
+| #112 | The founder reads the exact message before approving it and downloads the file after — served only when a signed receipt names it and its bytes still match that receipt. |
+
+## Measured, not assumed
+
+- Model runs took 4–14 s per employee on this machine; the page had said
+  "…" for all of it. It now says 5–30 s.
+- Adding a customer took 17 ms. It *looked* like a second because the
+  in-app browser's screenshots lag a frame — see below.
+- Python's `email` parser renders a display name split across two RFC 2047
+  words with a space in the middle (`翠林饮品有 限公司`), although the RFC says
+  that space is to be ignored. Base64 words fit a Chinese name in one word,
+  which is why #110 uses `B`, not `Q`.
+
+## Patterns worth reusing
+
+**Read the artefact the way its reader will.** The `.eml` was tested as
+bytes and never as a message. Parsing the composed file with an independent
+reader (Python's `email`, policy `default`) found the split name; reading
+its body as a customer would found the missing amount.
+
+**Serve evidence-backed files only while they match the evidence.** The
+download route could have served any well-formed name in the outbox. It
+serves a file a signed receipt names, and refuses one whose hash no longer
+matches (409). A file changed after approval is not what was approved.
+
+**A check must say whether it inspected anything.** The header-length test
+first asserted every line, then only lines holding encoded-words — and then
+that there were more than four of those, so a title that stopped folding
+would fail it rather than pass vacuously.
+
+## Not the product's fault (for the next person driving the pane)
+
+- The in-app browser's screenshots lag one frame: the sidebar highlight, a
+  toast, an open dialog can show the *previous* state. Confirm with a DOM
+  read before calling it a bug — three "bugs" this session were this.
+- `ref`-based clicks land in the 1024-wide viewport frame while screenshots
+  are 800 wide; click by screenshot coordinates or by script.
+- Starting the server and navigating in the same batch races: the first load
+  can fail its first status request. Restarting the server under an open tab
+  can leave a request pending on a dead socket (a blank page). Reload.
+
+## What is still not verified
+
+- The download in a real mail client. The route and bytes are tested; the
+  file was not opened in Mail.app, to avoid acting on the owner's desktop.
+- The Tauri shell: downloads from its webview were not exercised.
+- Everything in the backlog entries this session added — English backend
+  refusals, the placeholder sender address, template drafts that call
+  themselves drafts, the English pack review note.


### PR DESCRIPTION
Documentation only.

**`docs/handoff/reports/2026-09-12-founder-walkthrough.md`** — using the workbench the way a founder would (Chinese UI, real local model, empty workspace to a paid invoice): what was found, what #110–#112 changed, what was measured, the patterns worth reusing, the in-app browser's traps that look like bugs and aren't, and what is still not verified.

**`docs/backlog.md`** — four entries the walkthrough found and did not fix, each with done-criteria a test can check:
- P2: 50 backend refusals reach a Chinese-speaking founder in English (needs error codes + a catalogue).
- P2: no founder sender address, so every composed message is From `founder@example.invalid`.
- P3: a template draft sent unedited tells the customer it is a draft.
- P3: the compliance pack's review note is English-only.