### PR TITLE
docs(codex): freeze the model-connection decisions and record why the cards stay closed

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -493,6 +493,19 @@ while the controller routes eligible design/review cards to the strong role.
   Resolve real-egress/Exact Effect and actual owner/authority dependencies
   before releasing bounded Keychain, dispatch and connection-acceptance cards.
   Reuse existing core tasks; synthetic input does not waive real-effect gates.
+  2026-09-12, still open: the owner froze four direction decisions and the
+  wiring was audited against §7.1 — written up in
+  [S3-M00](handoff/codex/cards/S3-M00.md). The card does **not** freeze the
+  protocol and does **not** release S3-M01/M02/M03, because the audit found
+  the prerequisites deeper than the stage assumed: no egress broker exists
+  (`crates/effects`), the model path bypasses the mediated chain entirely
+  (`crates/model` depends on none of effects/capability/authority; safe today
+  only because the Ollama adapter structurally refuses non-loopback hosts),
+  Program 1C0 does not exist and RFC 0004:498 says the application-created
+  signer cannot satisfy that gate, and RFC 0004:183 requires a real-egress RFC
+  to fix canonical encoding and coordinator storage *before any adapter is
+  enabled* — that RFC does not exist. The card lists the ordered dependencies
+  and the exact release condition.
 
 - [ ] **P2 | `docs/product/, docs/handoff/codex/, rfcs/` | S3-L00 — Freeze legal RAG, jurisdiction facts, assistance outputs, and synthetic rule enforcement.** `lane:codex` `needs:fable`
   Definition and done criteria: [S3 legal extension](handoff/codex/milestones.md#legal-extension).

--- a/docs/handoff/codex/cards/S3-M00.md
+++ b/docs/handoff/codex/cards/S3-M00.md
@@ -1,0 +1,101 @@
+# S3-M00 — 真实模型连接：协议、凭据契约与前置依赖（架构卡）
+
+**2026-09-12。**本卡按[里程碑 S3-M](../milestones.md#model-connection)的定义产出：真实
+egress / Exact Effect 协议与模型目标绑定、凭据保管与调用契约、**必须先落地的核心依赖清单**。
+决定由仓库所有者在本轮会话中作出并记录于此；草拟由会话完成，接口不由执行方自行决定。
+队列状态只在 [backlog](../../../backlog.md) 维护。本地条目录入约定见
+[provider-setup](../provider-setup.md)，产品方向见[蓝图 §7.1](../../../product/founder-os-execution-blueprint.zh-CN.md#provider-boundary)。
+
+**结论先行：本卡不冻结协议，也不释放 S3-M01/M02/M03。**核对表明先决条件缺口比阶段假设的
+大，且 RFC 0004 要求真实 egress 的协议由一份独立 RFC 冻结，而该 RFC 不存在。本卡的价值是
+把决定和缺口记下来，使下一轮不必重新发现。
+
+## 一、已冻结的决定
+
+以下四条由所有者批准，作为后续 RFC 与实现卡的输入。**这些是方向决定，不是放行。**
+
+| 编号 | 决定 |
+| --- | --- |
+| **D1** | 真实模型调用**是**一次受管制的外部效果，走与 `.eml` 发送相同的通道：策略判定 → 签名批准 → Capability V2 → 授权消费 → 执行记录 → 签名证据。不得新建第二条授权或凭据机制。 |
+| **D2** | 授权粒度为**限时、限次、可撤销的常驻授权**，每次调用消费一次并留证；不要求逐次人工批准。逐次批准对一次 employee run 即一次调用的现实不可用。 |
+| **D3** | 真实提供者失败**一律硬失败**，不静默回退到本地模板或其他提供者。无凭据、钥匙串锁定、访问被拒、凭据失效、超时、超限、`Indeterminate` 必须彼此可区分。 |
+| **D4** | 首版只允许**合成输入**；真实客户资料默认禁止出门，需要显式开关（按蓝图 §7.1 推到 S4/S5）。 |
+
+D1–D3 与 RFC 0004 一致，且 RFC 的要求**更严**：`Indeterminate` 永不自动重试，重试策略不得
+静默替换另一个身份（RFC 0004:176–178）；批准之外的提供者需要新的本地预览与 1C0 批准
+（RFC 0004:174–176）。D4 亦不豁免——蓝图 §7.1 明写"即使输入是合成数据……真实 API 请求仍是
+RFC 0004 所定义的外部效果；S3 编号不构成豁免"。
+
+## 二、现状核对（本卡的核心产出）
+
+§7.1 要求核对实际接线而非假设。逐项结果：
+
+| 检查项 | 证据 | 状态 |
+| --- | --- | --- |
+| 真实 egress broker | `crates/effects/src/lib.rs:28`：「**local filesystem** effect only. No network, DNS, or egress broker exists」 | **不存在** |
+| 模型调用受策略/能力约束 | `crates/model/Cargo.toml` 依赖仅 serde / serde_json / contracts / thiserror；`ollama.rs:91` 直接 `TcpStream::connect_timeout` | **绕过**整条受管制通道 |
+| 回环约束 | `ollama.rs:121` `parse_loopback_base_url`，测试 `only_loopback_base_urls_are_accepted` | **成立**——这是当前绕过可接受的唯一理由 |
+| 模型调用的证据 | `ModelDisclosure` 由调用方 `crew_ops` 事后写入 | **记账**，非边界强制 |
+| Program 1C0（真实 owner 会话与一次性批准签发者） | RFC 0004:496–499；实现不存在；应用内安全中心自述「本地接口没有 owner 会话:任何以你的身份运行的程序都能读取和批准」 | **不存在**，且 RFC 明写「The application-created signer does not satisfy this gate」 |
+| `ProviderTargetV1` 闭合身份元组与受保护协调状态 | RFC 0004:180–195 定义；实现不存在 | **不存在** |
+| 真实 egress 协议 RFC | `rfcs/` 仅 0001–0007；0006 是**合成** owner 会话 fixture | **不存在** |
+| 投影编译器 | `crates/privacy/src/compile.rs`、`transform.rs`、`response.rs` | 存在；成熟度未在本卡核实 |
+| RFC 0005 Program 1A | `crates/vault-v2-engine`（`publish = false`，无产品路径） | **进行中** |
+
+**结构性结论：**Anthropic 提供者不能作为 `ollama.rs` 的兄弟实现。同一路径一旦允许公网地址，
+就成为无策略检查、无能力令牌、无授权消费、网络行为本身无签名证据的裸出网。当前形态之所以
+安全，靠的是适配器在构造时结构性拒绝非回环地址，而不是靠通道本身。
+
+## 三、协议为何不能在本卡冻结
+
+RFC 0004:180–184：
+
+> For real egress, a closed `ProviderTargetV1` identity tuple binds provider ID, adapter artifact
+> digest, endpoint origin/audience, account/tenant, credential-handle ID, model ID, and immutable
+> model/version descriptor. **The real-egress RFC MUST fix its canonical encoding and authenticated
+> coordinator storage before any adapter is enabled.**
+
+该 RFC 不存在。因此本卡不产出冻结协议，而是列出这份 RFC 必须解决的问题：
+
+1. `ProviderTargetV1` 的规范编码，以及受保护协调状态的存储与认证方式。
+2. 随机 `provider_target_id` 的分配、密封与不可重分配；证据只携带随机 ID、尝试结果和被独立
+   注册表标为 approved-public 的描述符；账户、租户、credential-handle、私有端点不得以明文或
+   确定性摘要进入账本（RFC 0004:190–196）。
+3. D2 的常驻授权如何表达为 durable authority 的预留与消费，及其撤销与过期语义。
+4. 出网效果与现有 `.eml` Exact Effect 的关系：沙箱在现链中是见证而非执行者（宿主在链通过后
+   执行效果，见 `kernel_exec.rs` 的 `execute_signed_approval`），出网应沿用同一形态。
+5. D3 的失败分类如何在不回显 provider 原始错误的前提下保持可区分。
+
+## 四、必须先落地的依赖（有序）
+
+依据 RFC 0004「Rollout order」及本卡核对。**顺序不可跳**：
+
+1. **RFC 0005 Program 1A** — 进行中（`crates/vault-v2-engine`）。
+2. **Program 1C0** — 独立准入、限期的 owner 会话与一次性批准签发者；随后用同一授权实现本地
+   outbox 的 Exact Effect。RFC 明写应用自建签名者不满足此门槛，RFC 0006 的合成 fixture 亦不构成
+   放行。
+3. **Program 1B0 / 1C1** — 可与第 2 步并行。
+4. **Program 1D** — owner 授权激活至 `ActiveV2`。
+5. **关闭 legacy 模型出网**，再加入纯投影编译器、固定的 no-network 投影、严格校验与 value-free
+   证据。注意：当前的 Ollama 集成即第 5 步所指的 legacy 模型出网。
+6. **real-egress RFC（新建，暂记 RFC-0008）** — 冻结第三节列出的五项。
+7. 其后才是 S3-M01 / M02 / M03。
+
+## 五、S3-M01 / M02 / M03 的释放条件
+
+三张卡**保持未释放**。释放条件：第四节第 2、6 项完成并独立审阅通过，且第 5 项的投影编译器
+路径可用于 D4 所限定的合成输入。在此之前：
+
+- 不得实现读取真实钥匙串条目的代码路径；
+- 不得新增任何允许非回环地址的模型适配器；
+- 不得以环境变量、SDK 直连或 CI secret 注入绕过上述通道。
+
+`sovereign-founder-os.anthropic.mvp` 条目已由创始人存入本机钥匙串（2026-09-08）。**已保存不等于
+已连接**；本卡不改变该状态，也不要求重新录入。
+
+## 六、现在允许做什么
+
+- 本地 Ollama 路径不受本卡限制，继续作为唯一真实模型来源。
+- 需要更多模型能力时，正确方向是推进第四节的顺序，而不是绕过它。
+- 若所有者决定提前接入，那是一次**对 RFC 0004 rollout order 的显式修订**，必须以 RFC 修订记录
+  在案，不能由实现卡默认取得。本卡不提议这样做。


### PR DESCRIPTION
Documentation only. Answers S3-M00 — and answers it with "not yet", on evidence.

## What was asked

S3-M00 (`lane:codex`, `needs:fable`) asks for the real-egress / Exact Effect protocol, the credential and call contract, and **the list of core dependencies that must land first** — blueprint §7.1 requires auditing actual wiring rather than assuming it.

## Decisions the owner froze

| | |
| --- | --- |
| **D1** | A real model call **is** a mediated external effect, on the same chain as the `.eml` send (policy → signed approval → Capability V2 → authority consumption → execution record → signed evidence). No second credential or authority mechanism. |
| **D2** | Authority is a **time- and count-bound, revocable standing grant**, consumed per call with evidence — not per-call human approval, which is unusable when one employee run is one call. |
| **D3** | A real provider failure is a **hard failure**; never a silent fallback. No-credential / locked keychain / denied ACL / invalid credential / timeout / over-limit / `Indeterminate` stay distinguishable. |
| **D4** | First version admits **synthetic input only**; real customer data stays off the wire behind an explicit switch. |

These match RFC 0004, which is stricter still (`Indeterminate` never auto-retried; a provider outside the approved ordered set needs a new preview and 1C0 approval).

## What the audit found

| Check | Evidence | State |
| --- | --- | --- |
| Egress broker | `crates/effects/src/lib.rs:28` — "local filesystem effect only. No network, DNS, or egress broker exists" | **absent** |
| Model calls under policy/capability | `crates/model` depends on none of effects/capability/authority; `ollama.rs:91` opens a raw `TcpStream` | **bypasses the chain** |
| Why that is safe today | `ollama.rs:121` `parse_loopback_base_url` + its test structurally refuse non-loopback hosts | holds — but it is the *only* thing holding |
| Model evidence | `ModelDisclosure` written by `crew_ops` after the fact | bookkeeping, not boundary enforcement |
| Program 1C0 | RFC 0004:498 — "The application-created signer does not satisfy this gate" | **absent** |
| `ProviderTargetV1` + protected coordinator state | RFC 0004:180–195 | **absent** |
| A real-egress RFC | `rfcs/` holds 0001–0007; 0006 is a *synthetic* owner-session fixture | **absent** |

RFC 0004:183: the real-egress RFC **must** fix canonical encoding and authenticated coordinator storage *before any adapter is enabled*.

## Therefore

The card **freezes no protocol and releases no card**. It lists what that missing RFC must settle, the ordered dependencies (Program 1A → 1C0 → 1B0/1C1 → 1D → close legacy model egress with the projection compiler → real-egress RFC → S3-M01/M02/M03), and the exact release condition.

Practical consequences recorded in the card: no code may read a real keychain item, no adapter may accept a non-loopback host, and no env var / SDK direct call / CI secret may route around the chain. The `sovereign-founder-os.anthropic.mvp` item the founder stored on 2026-09-08 stays as it is — **saved is not connected**. Connecting a provider earlier would be an explicit revision of RFC 0004's rollout order, and the card says so rather than letting an implementation card assume it.

Local Ollama is unaffected and remains the only real model source.

`./scripts/test_changed.sh`: ALL GREEN (exit 0).