### PR TITLE
feat(vault-v2): own this process's OpenSSL initialisation before any key exists

### DIFF
--- a/crates/vault-v2-engine/src/engine/ffi.rs
+++ b/crates/vault-v2-engine/src/engine/ffi.rs
@@ -25,10 +25,11 @@
 //! SQLCipher's key functions are not declared. Everything else comes from the
 //! bindings.
 
+use super::process::CryptoProcessOwner;
 use super::secret::RawSqlcipherKey;
 use rusqlite::ffi::{
     sqlite3, sqlite3_close, sqlite3_db_config, sqlite3_enable_load_extension, sqlite3_open_v2,
-    SQLITE_DBCONFIG_ENABLE_LOAD_EXTENSION, SQLITE_OK,
+    sqlite3_threadsafe, SQLITE_DBCONFIG_ENABLE_LOAD_EXTENSION, SQLITE_OK,
 };
 use std::ffi::CString;
 use std::os::raw::{c_char, c_int, c_void};
@@ -59,6 +60,8 @@ pub(crate) enum HardeningFailure {
     KeyRejected,
     /// A native-code loading route could not be shown to be off.
     ExtensionLoadingNotDisabled,
+    /// The linked SQLite was not built in the admitted threading mode.
+    ThreadingModeNotAdmitted,
 }
 
 /// Open, key, and disable native-code loading, in that order, and hand back a
@@ -67,7 +70,16 @@ pub(crate) enum HardeningFailure {
 /// Nothing touches a page here: the key is set before any statement exists,
 /// and the extension switches are connection configuration. The caller
 /// applies the remaining no-page settings and only then reads a page.
+///
+/// `_owner` is read by the compiler, not at runtime: it carries no data, and
+/// the only way a caller can name one is to have gone through
+/// [`bootstrap_crypto_process`](super::process::bootstrap_crypto_process). A
+/// database opened in a process that never initialised OpenSSL itself — and so
+/// might be running on providers an `OPENSSL_CONF` file chose — therefore does
+/// not compile, which is a stronger guarantee than a flag this function could
+/// have checked.
 pub(crate) fn open_keyed_hardened(
+    _owner: &CryptoProcessOwner,
     path: &Path,
     flags: c_int,
     key: &RawSqlcipherKey,
@@ -94,6 +106,15 @@ pub(crate) fn open_keyed_hardened(
     // `from_handle_owned`, which closes it on drop, so it is never closed
     // here after that point.
     unsafe {
+        // Compile-time property of the linked library, so it is checked before
+        // a handle exists: this process opens connections with `NO_MUTEX` and
+        // keeps each one on its own thread, which is only sound if the library
+        // itself was built thread-safe. A library built single-threaded would
+        // accept the same calls and corrupt state instead of refusing.
+        if sqlite3_threadsafe() != 1 {
+            return Err(HardeningFailure::ThreadingModeNotAdmitted);
+        }
+
         if sqlite3_open_v2(c_path.as_ptr(), &mut db, flags, ptr::null()) != SQLITE_OK {
             // `sqlite3_open_v2` can allocate a handle even when it fails, and
             // that handle still has to be released.

--- a/crates/vault-v2-engine/src/engine/mod.rs
+++ b/crates/vault-v2-engine/src/engine/mod.rs
@@ -6,5 +6,6 @@
 #![cfg_attr(not(test), allow(dead_code))]
 
 pub(crate) mod ffi;
+pub(crate) mod process;
 pub(crate) mod secret;
 pub(crate) mod sqlcipher;

--- a/crates/vault-v2-engine/src/engine/process.rs
+++ b/crates/vault-v2-engine/src/engine/process.rs
@@ -1,0 +1,110 @@
+//! The process-wide crypto bootstrap: the second and last place this crate
+//! authors `unsafe` code against a C library.
+//!
+//! RFC 0005 Program 1A is a dedicated process, and this is the first thing
+//! that process does. OpenSSL will, on first use, read a configuration file
+//! named by `OPENSSL_CONF` and load whatever providers and engines it names.
+//! That is a reasonable default for a general-purpose program and the wrong
+//! one for a process that exists to hold a database key: it lets anything
+//! that can set an environment variable for this process choose the code that
+//! performs its cryptography. `OPENSSL_INIT_NO_LOAD_CONFIG` initialises the
+//! library and skips that file.
+//!
+//! The plan is specific about how: "the bootstrap declares the exact official
+//! C ABI and the pinned `OPENSSL_INIT_NO_LOAD_CONFIG` constant locally because
+//! `openssl-sys 0.9.117` does not expose them, calls
+//! `OPENSSL_init_crypto(..., NULL)`, and requires return value `1`". Both
+//! absences were checked against this build rather than assumed: the constant
+//! appears only in the vendored header (`crypto.h`, `OPENSSL_INIT_NO_LOAD_CONFIG
+//! 0x00000080L`), and `openssl-sys 0.9.117` declares neither it nor
+//! `OPENSSL_init_crypto`. The exact `openssl-sys` dependency is still what
+//! supplies the reviewed link and version boundary; this file only calls into
+//! what that boundary already links.
+//!
+//! Why a token type rather than a "did we initialise" flag: a flag is
+//! something later code must remember to check. `CryptoProcessOwner` cannot be
+//! constructed anywhere else, and `open_sqlcipher` takes a reference to one,
+//! so a database open that skipped this bootstrap does not compile.
+
+use std::os::raw::{c_int, c_void};
+use std::ptr;
+use std::sync::OnceLock;
+
+extern "C" {
+    /// OpenSSL 3.x: `int OPENSSL_init_crypto(uint64_t opts, const
+    /// OPENSSL_INIT_SETTINGS *settings)`. Declared here because the generated
+    /// `openssl-sys` bindings for the pinned version do not carry it.
+    fn OPENSSL_init_crypto(opts: u64, settings: *const c_void) -> c_int;
+}
+
+/// `OPENSSL_INIT_NO_LOAD_CONFIG` from the vendored `crypto.h`. Pinned here as
+/// a literal for the same reason the function is declared here.
+const OPENSSL_INIT_NO_LOAD_CONFIG: u64 = 0x0000_0080;
+
+/// Proof that this process initialised OpenSSL itself, with configuration
+/// loading off. It carries no data and has no public constructor: the only
+/// way to hold one is to have called [`bootstrap_crypto_process`].
+pub(crate) struct CryptoProcessOwner {
+    /// Blocks construction by struct literal outside this module.
+    _process_owned: (),
+}
+
+/// Why the bootstrap could not vouch for this process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BootstrapFailure {
+    /// `OPENSSL_init_crypto` returned something other than `1`.
+    OpenSslInitRefused,
+}
+
+/// The one owner of this process, so the initialisation happens once however
+/// many times the bootstrap is called.
+static OWNER: OnceLock<CryptoProcessOwner> = OnceLock::new();
+
+/// Initialise OpenSSL for this process with configuration loading off, and
+/// return the token every database open requires.
+///
+/// Calling this again returns the same owner: OpenSSL's initialisation is
+/// process-wide, so a second call must not be able to produce a second,
+/// differently-configured "owner" of it.
+pub(crate) fn bootstrap_crypto_process() -> Result<&'static CryptoProcessOwner, BootstrapFailure> {
+    if let Some(owner) = OWNER.get() {
+        return Ok(owner);
+    }
+
+    // SAFETY: `OPENSSL_init_crypto` takes an option bitmask and an optional
+    // settings pointer. The mask is the single pinned constant above, and the
+    // settings pointer is null, which the OpenSSL API documents as "no
+    // settings" — there is nothing for the call to read through it. The call
+    // touches no memory this program owns, returns an `int`, and is safe to
+    // make from multiple threads: OpenSSL guards its own initialisation, so
+    // the race two callers can lose here is a second harmless call, never a
+    // second initialisation.
+    let initialised = unsafe { OPENSSL_init_crypto(OPENSSL_INIT_NO_LOAD_CONFIG, ptr::null()) };
+    if initialised != 1 {
+        return Err(BootstrapFailure::OpenSslInitRefused);
+    }
+
+    Ok(OWNER.get_or_init(|| CryptoProcessOwner { _process_owned: () }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use static_assertions::assert_not_impl_any;
+
+    // The token is evidence, not data: copying one would let code that never
+    // bootstrapped hold "proof" that something else did.
+    assert_not_impl_any!(CryptoProcessOwner: Clone, Copy, std::fmt::Debug, std::fmt::Display);
+
+    /// The bootstrap succeeds against the linked OpenSSL, and a second call
+    /// hands back the very same owner rather than initialising again.
+    #[test]
+    fn the_process_has_exactly_one_crypto_owner() {
+        let first = bootstrap_crypto_process().expect("OpenSSL initialises with config off");
+        let second = bootstrap_crypto_process().expect("a second call is the same owner");
+        assert!(
+            ptr::eq(first, second),
+            "a second bootstrap produced a different owner"
+        );
+    }
+}

--- a/crates/vault-v2-engine/src/engine/sqlcipher.rs
+++ b/crates/vault-v2-engine/src/engine/sqlcipher.rs
@@ -13,6 +13,7 @@
 //! owns the key material.
 
 use super::ffi::{self, HardeningFailure};
+use super::process::CryptoProcessOwner;
 use super::secret::DbKey;
 use rusqlite::config::DbConfig;
 use rusqlite::limits::Limit;
@@ -124,21 +125,21 @@ pub(crate) struct HardenedConnection {
 
 /// Open a SQLCipher database under the fixed profile.
 pub(crate) fn open_sqlcipher(
+    owner: &CryptoProcessOwner,
     path: &Path,
     key: &DbKey,
     mode: ConnectionMode,
 ) -> Result<HardenedConnection, OpenError> {
     // Open, key first, and switch off native-code loading — one audited
     // unsafe entry point. The raw token lives only for this call.
-    let connection =
-        ffi::open_keyed_hardened(path, mode.flags().bits(), &key.raw()).map_err(|failure| {
-            match failure {
-                HardeningFailure::PathNotRepresentable | HardeningFailure::Unopenable => {
-                    OpenError::Unopenable
-                }
-                HardeningFailure::KeyRejected => OpenError::KeyRejected,
-                HardeningFailure::ExtensionLoadingNotDisabled => OpenError::ProfileNotApplied,
+    let connection = ffi::open_keyed_hardened(owner, path, mode.flags().bits(), &key.raw())
+        .map_err(|failure| match failure {
+            HardeningFailure::PathNotRepresentable | HardeningFailure::Unopenable => {
+                OpenError::Unopenable
             }
+            HardeningFailure::KeyRejected => OpenError::KeyRejected,
+            HardeningFailure::ExtensionLoadingNotDisabled
+            | HardeningFailure::ThreadingModeNotAdmitted => OpenError::ProfileNotApplied,
         })?;
 
     // The remaining no-page settings, each confirmed by what SQLite reports
@@ -208,6 +209,12 @@ mod tests {
 
     assert_not_impl_any!(HardenedConnection: Send, Sync);
 
+    /// Every open needs the process bootstrap; the tests run in one process,
+    /// which is exactly what the owner represents.
+    fn owner() -> &'static CryptoProcessOwner {
+        super::super::process::bootstrap_crypto_process().expect("OpenSSL initialises")
+    }
+
     /// Distinctive enough that finding it anywhere is proof of a leak, and
     /// not a string SQLite or SQLCipher would ever produce on its own.
     const CANARY: &str = "SFO-PLAINTEXT-CANARY-7f3a9c41";
@@ -250,8 +257,13 @@ mod tests {
     /// it. Tests reach the inner connection directly because they sit in this
     /// module; production code has no method that runs arbitrary SQL.
     fn create_with_canary(db: &Path, fill: u8) {
-        let opened = open_sqlcipher(db, &key(fill), ConnectionMode::ReadWriteCreateInternal)
-            .expect("create an encrypted container");
+        let opened = open_sqlcipher(
+            owner(),
+            db,
+            &key(fill),
+            ConnectionMode::ReadWriteCreateInternal,
+        )
+        .expect("create an encrypted container");
         opened
             .connection
             .execute_batch(&format!(
@@ -294,7 +306,8 @@ mod tests {
         // Mid-transaction: the rollback journal holds the page being replaced,
         // which is exactly where an old value would leak if the journal were
         // not encrypted too.
-        let opened = open_sqlcipher(&db, &key(0xab), ConnectionMode::ReadWrite).expect("reopen");
+        let opened =
+            open_sqlcipher(owner(), &db, &key(0xab), ConnectionMode::ReadWrite).expect("reopen");
         opened
             .connection
             .execute_batch(&format!(
@@ -354,7 +367,7 @@ mod tests {
         create_with_canary(&db, 0x11);
         let before = fs::read(&db).expect("read before");
 
-        let result = open_sqlcipher(&db, &key(0x22), ConnectionMode::ReadWrite);
+        let result = open_sqlcipher(owner(), &db, &key(0x22), ConnectionMode::ReadWrite);
         assert!(
             matches!(result, Err(OpenError::WrongKeyOrNotADatabase)),
             "a wrong key opened the database"
@@ -381,7 +394,7 @@ mod tests {
 
         // And the right key still works, so the failure was the key and not
         // a database the wrong-key attempt had damaged.
-        assert!(open_sqlcipher(&db, &key(0x11), ConnectionMode::ReadWrite).is_ok());
+        assert!(open_sqlcipher(owner(), &db, &key(0x11), ConnectionMode::ReadWrite).is_ok());
     }
 
     /// One flipped bit in page 2 is caught by the cipher's authentication,
@@ -394,8 +407,13 @@ mod tests {
         let (_dir, root) = canonical_tempdir();
         let db = root.join("vault.db");
         {
-            let opened = open_sqlcipher(&db, &key(0x5a), ConnectionMode::ReadWriteCreateInternal)
-                .expect("create");
+            let opened = open_sqlcipher(
+                owner(),
+                &db,
+                &key(0x5a),
+                ConnectionMode::ReadWriteCreateInternal,
+            )
+            .expect("create");
             // Enough rows to occupy well past page 2.
             opened
                 .connection
@@ -416,7 +434,7 @@ mod tests {
         );
 
         // Untouched, it passes — so a failure below is the flip, not the setup.
-        let intact = open_sqlcipher(&db, &key(0x5a), ConnectionMode::ReadOnlyRecovery)
+        let intact = open_sqlcipher(owner(), &db, &key(0x5a), ConnectionMode::ReadOnlyRecovery)
             .expect("reopen the intact file");
         assert_eq!(
             intact.cipher_integrity_check(),
@@ -430,7 +448,7 @@ mod tests {
 
         // The key is right and page 1 is untouched, so the open succeeds; the
         // damage is on page 2 and must be found there.
-        let opened = open_sqlcipher(&db, &key(0x5a), ConnectionMode::ReadOnlyRecovery)
+        let opened = open_sqlcipher(owner(), &db, &key(0x5a), ConnectionMode::ReadOnlyRecovery)
             .expect("page 1 is intact, so opening still succeeds");
         assert!(
             matches!(opened.cipher_integrity_check(), Err(IntegrityFailure::Pages(n)) if n > 0),
@@ -452,6 +470,7 @@ mod tests {
         std::os::unix::fs::symlink(&real, &link).expect("symlink");
 
         let result = open_sqlcipher(
+            owner(),
             &link.join("vault.db"),
             &key(0x33),
             ConnectionMode::ReadWriteCreateInternal,
@@ -468,6 +487,7 @@ mod tests {
         // The same directory, addressed without the link, is fine: the refusal
         // was the link and not the location.
         assert!(open_sqlcipher(
+            owner(),
             &real.join("vault.db"),
             &key(0x33),
             ConnectionMode::ReadWriteCreateInternal
@@ -514,6 +534,7 @@ mod tests {
     fn oversized_values_and_sql_fail_at_fixed_limits() {
         let (_dir, root) = canonical_tempdir();
         let opened = open_sqlcipher(
+            owner(),
             &root.join("vault.db"),
             &key(0x44),
             ConnectionMode::ReadWriteCreateInternal,
@@ -632,6 +653,7 @@ mod tests {
     fn extensions_attach_writable_schema_and_dynamic_sql_are_denied() {
         let (_dir, root) = canonical_tempdir();
         let opened = open_sqlcipher(
+            owner(),
             &root.join("vault.db"),
             &key(0x55),
             ConnectionMode::ReadWriteCreateInternal,

--- a/crates/vault-v2-engine/src/main.rs
+++ b/crates/vault-v2-engine/src/main.rs
@@ -14,6 +14,15 @@
 mod engine;
 
 fn main() {
-    // Deliberately inert: a process that holds keys should not do anything
-    // until the dispatcher that authorises each request exists.
+    // The first project-controlled crypto action in this process: initialise
+    // OpenSSL with configuration loading switched off, before anything can
+    // ask for a database. A process that cannot do that stops here rather
+    // than continuing on whatever configuration its environment chose.
+    if engine::process::bootstrap_crypto_process().is_err() {
+        eprintln!("vault-v2-engine: OpenSSL refused to initialise; not continuing");
+        std::process::exit(1);
+    }
+
+    // Otherwise deliberately inert: a process that holds keys should not do
+    // anything until the dispatcher that authorises each request exists.
 }

--- a/crates/vault-v2-engine/tests/ast_gate.rs
+++ b/crates/vault-v2-engine/tests/ast_gate.rs
@@ -6,9 +6,8 @@
 //!
 //! - a new explicit Cargo target must join `ROOTS` in the same change that
 //!   declares it in `Cargo.toml`;
-//! - the queued FFI item adds exactly `src/engine/ffi.rs` and
-//!   `src/engine/process.rs` to `FFI_BOUNDARY_FILES` when it creates them —
-//!   nothing else is expected to ever join that list;
+//! - `FFI_BOUNDARY_FILES` holds exactly `src/engine/ffi.rs` and
+//!   `src/engine/process.rs`; nothing else is expected to ever join it;
 //! - the exactly-two-entry-points proof and the five `tests/ui/` compile-fail
 //!   fixtures are a separate queued item that tightens this gate once the
 //!   engine API exists.
@@ -36,10 +35,10 @@ const ADMITTED_INCLUDES: &[(&str, &str)] = &[
 ];
 
 /// The files allowed to contain `unsafe` and `extern`. `src/engine/ffi.rs`
-/// joined with the SQLCipher key shim; `src/engine/process.rs` joins when the
-/// OpenSSL bootstrap lands, and the plan expects nothing else ever to. The
-/// library keeps `#![forbid(unsafe_code)]` regardless.
-const FFI_BOUNDARY_FILES: &[&str] = &["src/engine/ffi.rs"];
+/// joined with the SQLCipher key shim and `src/engine/process.rs` with the
+/// OpenSSL bootstrap. That is the pair the plan names, and it expects nothing
+/// else ever to join. The library keeps `#![forbid(unsafe_code)]` regardless.
+const FFI_BOUNDARY_FILES: &[&str] = &["src/engine/ffi.rs", "src/engine/process.rs"];
 
 const ALLOWED_MACROS: &[&str] = &[
     "assert",
@@ -135,6 +134,7 @@ fn recursive_syn_source_closure_is_complete_and_ffi_boundary_is_exact() {
             "build_gate.rs",
             "src/engine/ffi.rs",
             "src/engine/mod.rs",
+            "src/engine/process.rs",
             "src/engine/secret.rs",
             "src/engine/sqlcipher.rs",
             "src/lib.rs",
@@ -490,6 +490,191 @@ fn extension_loading_route_one_is_switched_off_in_source() {
         vec![Some(0)],
         "sqlite3_enable_load_extension must be called exactly once, with the literal 0 \
          (None means the argument is not an integer literal): found {:?}",
+        calls.0
+    );
+}
+
+/// The bootstrap is one call, and it is the one that switches configuration
+/// loading off.
+///
+/// Like the extension switch above, this cannot be proven by running the
+/// program: `OPENSSL_init_crypto` returns 1 either way, and a process that
+/// loaded a hostile `OPENSSL_CONF` looks identical from the inside until
+/// something asks the provider what it is. The fresh-process qualification
+/// that asks is a separate queued item; the constant itself stays structural
+/// evidence even after it lands.
+#[test]
+fn the_openssl_bootstrap_is_one_call_with_config_loading_off() {
+    use syn::visit::Visit;
+
+    struct Calls(Vec<Option<String>>);
+    impl<'ast> Visit<'ast> for Calls {
+        fn visit_expr_call(&mut self, call: &'ast syn::ExprCall) {
+            let named = matches!(
+                &*call.func,
+                syn::Expr::Path(path)
+                    if path.path.segments.last().is_some_and(|segment| {
+                        segment.ident == "OPENSSL_init_crypto"
+                    })
+            );
+            if named {
+                let first = call.args.iter().next().and_then(|argument| match argument {
+                    syn::Expr::Path(path) => path
+                        .path
+                        .segments
+                        .last()
+                        .map(|segment| segment.ident.to_string()),
+                    _ => None,
+                });
+                self.0.push(first);
+            }
+            syn::visit::visit_expr_call(self, call);
+        }
+    }
+
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/engine/process.rs");
+    let source = std::fs::read_to_string(&path).expect("read process.rs");
+    let file = syn::parse_file(&source).expect("parse process.rs");
+    let mut calls = Calls(Vec::new());
+    calls.visit_file(&file);
+
+    assert_eq!(
+        calls.0,
+        vec![Some("OPENSSL_INIT_NO_LOAD_CONFIG".to_owned())],
+        "OPENSSL_init_crypto must be called exactly once, with the pinned \
+         no-load-config constant (None means the argument is not a plain \
+         constant): found {:?}",
+        calls.0
+    );
+
+    // And that constant holds the value the vendored header gives, so the
+    // call cannot be pointed at a differently-named constant holding 0.
+    let mut pinned = None;
+    for item in &file.items {
+        if let syn::Item::Const(constant) = item {
+            assert_ne!(
+                constant.ident, "OPENSSL_INIT_LOAD_CONFIG",
+                "the config-loading constant may not be declared in production source"
+            );
+            if constant.ident == "OPENSSL_INIT_NO_LOAD_CONFIG" {
+                if let syn::Expr::Lit(syn::ExprLit {
+                    lit: syn::Lit::Int(value),
+                    ..
+                }) = &*constant.expr
+                {
+                    pinned = value.base10_parse::<u64>().ok();
+                }
+            }
+        }
+    }
+    assert_eq!(
+        pinned,
+        Some(0x0000_0080),
+        "OPENSSL_INIT_NO_LOAD_CONFIG must be the vendored header's 0x00000080"
+    );
+}
+
+/// The linked SQLite's threading mode is checked once, against the value the
+/// plan admits. Unfalsifiable at runtime for the same reason: this build
+/// answers 1, so deleting the check changes no test's outcome.
+#[test]
+fn the_threading_mode_is_checked_against_the_admitted_value() {
+    use syn::visit::Visit;
+
+    fn operator(op: &syn::BinOp) -> &'static str {
+        match op {
+            syn::BinOp::Ne(_) => "!=",
+            syn::BinOp::Eq(_) => "==",
+            _ => "other",
+        }
+    }
+
+    struct Comparisons(Vec<(String, Option<u64>)>);
+    impl<'ast> Visit<'ast> for Comparisons {
+        fn visit_expr_binary(&mut self, binary: &'ast syn::ExprBinary) {
+            let calls_threadsafe = matches!(
+                &*binary.left,
+                syn::Expr::Call(call) if matches!(
+                    &*call.func,
+                    syn::Expr::Path(path)
+                        if path.path.segments.last().is_some_and(|segment| {
+                            segment.ident == "sqlite3_threadsafe"
+                        })
+                )
+            );
+            if calls_threadsafe {
+                let against = match &*binary.right {
+                    syn::Expr::Lit(syn::ExprLit {
+                        lit: syn::Lit::Int(value),
+                        ..
+                    }) => value.base10_parse::<u64>().ok(),
+                    _ => None,
+                };
+                self.0.push((operator(&binary.op).to_owned(), against));
+            }
+            syn::visit::visit_expr_binary(self, binary);
+        }
+    }
+
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/engine/ffi.rs");
+    let source = std::fs::read_to_string(&path).expect("read ffi.rs");
+    let file = syn::parse_file(&source).expect("parse ffi.rs");
+    let mut comparisons = Comparisons(Vec::new());
+    comparisons.visit_file(&file);
+
+    assert_eq!(
+        comparisons.0,
+        vec![("!=".to_owned(), Some(1))],
+        "sqlite3_threadsafe must be compared exactly once, against the literal 1: found {:?}",
+        comparisons.0
+    );
+}
+
+/// `main` bootstraps before it does anything else.
+///
+/// The plan's wording is "immediately obtains a private, non-constructible
+/// `CryptoProcessOwner` from the sole unsafe bootstrap **before dispatching
+/// any command**". Today `main` has nothing else in it, so nothing would
+/// notice if the call moved; the dispatcher this file is waiting for is
+/// exactly when that stops being true.
+#[test]
+fn main_bootstraps_the_crypto_process_first() {
+    use syn::visit::Visit;
+
+    struct Calls(Vec<String>);
+    impl<'ast> Visit<'ast> for Calls {
+        fn visit_expr_call(&mut self, call: &'ast syn::ExprCall) {
+            if let syn::Expr::Path(path) = &*call.func {
+                if let Some(segment) = path.path.segments.last() {
+                    self.0.push(segment.ident.to_string());
+                }
+            }
+            syn::visit::visit_expr_call(self, call);
+        }
+    }
+
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/main.rs");
+    let source = std::fs::read_to_string(&path).expect("read main.rs");
+    let file = syn::parse_file(&source).expect("parse main.rs");
+
+    let main = file
+        .items
+        .iter()
+        .find_map(|item| match item {
+            syn::Item::Fn(function) if function.sig.ident == "main" => Some(function),
+            _ => None,
+        })
+        .expect("the binary declares fn main");
+
+    let first = main.block.stmts.first().expect("fn main is not empty");
+    let mut calls = Calls(Vec::new());
+    calls.visit_stmt(first);
+    assert!(
+        calls
+            .0
+            .iter()
+            .any(|call| call == "bootstrap_crypto_process"),
+        "the first statement of main must be the crypto bootstrap; its calls are {:?}",
         calls.0
     );
 }


### PR DESCRIPTION
Program 1A, Task 1 Step 3 — the second and last FFI boundary file. Continues #108 (the hardened open).

## Why

OpenSSL reads the file named by `OPENSSL_CONF` on first use and loads whatever providers and engines it names. That is a reasonable default for a general-purpose program and the wrong one for a process whose only job is to hold a database key: it lets anything that can set an environment variable for this process choose the code that performs its cryptography.

`bootstrap_crypto_process` calls `OPENSSL_init_crypto(OPENSSL_INIT_NO_LOAD_CONFIG, NULL)`, requires return value `1`, and hands back a `CryptoProcessOwner`.

## The owner is evidence, not a flag

A flag is something later code must remember to check. `CryptoProcessOwner` holds no data, has no constructor outside its module, and is neither `Clone` nor `Copy`; `open_sqlcipher` takes `&CryptoProcessOwner`. **A database opened in a process that never initialised OpenSSL itself does not compile** — verified by forging one from `sqlcipher.rs`:

```
error[E0451]: field `_process_owned` of struct `CryptoProcessOwner` is private
```

Bootstrap is idempotent through a `OnceLock`, so however many times it is called there is exactly one owner of a process-wide initialisation.

## Also in this slice

`sqlite3_threadsafe()` is checked against the admitted value `1` before a handle exists: this process opens with `NO_MUTEX` and keeps each connection on one thread, which is only sound if the library itself was built thread-safe. Measured: this build answers 1.

## Evidence

Neither new check can be falsified by running this build — `OPENSSL_init_crypto` returns 1 either way, and `sqlite3_threadsafe` is already 1. So the evidence is structural, the same answer as the extension switch in #108. Three `syn` pins in `tests/ast_gate.rs`:

| Pin | Sabotage | Result |
| --- | --- | --- |
| exactly one `OPENSSL_init_crypto` call, carrying the pinned constant, whose value is `0x00000080`, and no `OPENSSL_INIT_LOAD_CONFIG` declared in production source | constant changed to `0x40`; call given a literal `0` | both **caught** |
| `sqlite3_threadsafe` compared exactly once against literal `1` | check deleted | **caught** |
| `main`'s first statement is the bootstrap | an `eprintln!` put before it | **caught** |

Facts checked against this build rather than assumed: `openssl-sys 0.9.117` declares neither `OPENSSL_init_crypto` nor the constant (hence the local declarations the plan calls for), and the constant appears in the vendored `crypto.h` as `OPENSSL_INIT_NO_LOAD_CONFIG 0x00000080L`.

`process.rs` joins `ffi.rs` in `FFI_BOUNDARY_FILES` and in the source-closure pin — the pair the plan names, with nothing else expected to join.

`./scripts/test_changed.sh`: ALL GREEN (exit 0). Engine suite: 43 tests across its targets.

## Not in this slice

The fresh-process hostile-environment qualification (`OPENSSL_CONF`, `OPENSSL_CONF_INCLUDE`, `OPENSSL_ENGINES`, `OPENSSL_MODULES` set hostile, identical admitted provider/profile required) and the test-only `LOAD_CONFIG` adversary. Both need a self-re-executing worker so OpenSSL's process-global state is not shared between cases, and the adversary needs the profile gate to be what refuses it — a boolean marker is explicitly not accepted as evidence. That is the next slice. The forge attempt above is also a candidate for the five queued `tests/ui/` compile-fail fixtures.