### PR TITLE
test(vault-v2): prove the bootstrap defends against a configuration that really breaks crypto

### DIFF
--- a/crates/vault-v2-engine/src/engine/process.rs
+++ b/crates/vault-v2-engine/src/engine/process.rs
@@ -107,4 +107,163 @@ mod tests {
             "a second bootstrap produced a different owner"
         );
     }
+
+    // -----------------------------------------------------------------
+    // Fresh-process qualification.
+    //
+    // OpenSSL's initialisation is process-global, so these cases cannot
+    // share a process with each other or with the tests above: whichever
+    // ran first would decide the answer for the rest. Each therefore runs
+    // in a worker — this same test binary, re-executed for exactly one
+    // `#[ignore]`d case — and the parent reads what the worker reports.
+    //
+    // The evidence is the provider SQLCipher actually used and whether the
+    // open succeeded, never a flag a worker set for itself.
+    // -----------------------------------------------------------------
+
+    /// A configuration file that activates OpenSSL's `null` provider and
+    /// nothing else. Measured against this build before it was written into
+    /// a test: with it loaded, keying fails and `cipher_provider` answers
+    /// nothing — so it is a real adversary and not a decorative one.
+    const HOSTILE_OPENSSL_CONF: &str = "\
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+null = null_sect
+
+[null_sect]
+activate = 1
+";
+
+    /// `OPENSSL_INIT_LOAD_CONFIG` from the same vendored header as the
+    /// constant the bootstrap pins. Test-only: this is the negative control
+    /// the plan admits, and the source gate allows exactly this one extra
+    /// call because it is inside `#[cfg(test)]`.
+    const OPENSSL_INIT_LOAD_CONFIG: u64 = 0x0000_0040;
+
+    /// Do what an unprotected process does on first use: read the
+    /// configuration file the environment names and load what it says.
+    fn load_configuration_from_the_environment() -> c_int {
+        // SAFETY: identical contract to the bootstrap — a pinned option
+        // bitmask and a null settings pointer, reading no memory this
+        // program owns.
+        unsafe { OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, ptr::null()) }
+    }
+
+    /// Open a database the way the engine does and report what the crypto
+    /// provider turned out to be. Shared by both workers so the two differ
+    /// in exactly one thing: whether the hostile configuration was loaded
+    /// first.
+    fn report_profile_of_a_real_open() {
+        use super::super::secret::DbKey;
+        use super::super::sqlcipher::{open_sqlcipher, ConnectionMode};
+
+        let owner = bootstrap_crypto_process().expect("bootstrap");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(dir.path()).expect("canonical tempdir");
+        match open_sqlcipher(
+            owner,
+            &root.join("vault.db"),
+            &DbKey::from_bytes([0x5a; 32]),
+            ConnectionMode::ReadWriteCreateInternal,
+        ) {
+            Ok(connection) => {
+                let (provider, version) = connection
+                    .cipher_profile()
+                    .expect("an opened connection reports its provider");
+                println!("WORKER opened provider={provider} version={version}");
+            }
+            Err(error) => println!("WORKER refused {error:?}"),
+        }
+    }
+
+    #[test]
+    #[ignore = "re-executed as a fresh process by its parent test"]
+    fn worker_opens_under_a_hostile_environment() {
+        report_profile_of_a_real_open();
+    }
+
+    #[test]
+    #[ignore = "re-executed as a fresh process by its parent test"]
+    fn worker_loads_the_hostile_configuration_before_bootstrapping() {
+        // The one thing this worker does differently, and it happens first.
+        println!(
+            "WORKER load_config={}",
+            load_configuration_from_the_environment()
+        );
+        report_profile_of_a_real_open();
+    }
+
+    /// Run one `#[ignore]`d worker in a fresh process with the hostile
+    /// environment set, and hand back everything it printed.
+    fn run_worker(name: &str) -> String {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let conf = directory.path().join("hostile.cnf");
+        std::fs::write(&conf, HOSTILE_OPENSSL_CONF).expect("write hostile config");
+        let absent = directory.path().join("no-such-directory");
+
+        let output = std::process::Command::new(
+            std::env::current_exe().expect("this test binary's own path"),
+        )
+        .args(["--exact", name, "--ignored", "--nocapture"])
+        // Every environment variable the plan names, all hostile.
+        .env("OPENSSL_CONF", &conf)
+        .env("OPENSSL_CONF_INCLUDE", &absent)
+        .env("OPENSSL_ENGINES", &absent)
+        .env("OPENSSL_MODULES", &absent)
+        .output()
+        .expect("run the worker");
+
+        let text = String::from_utf8_lossy(&output.stdout).into_owned();
+        assert!(
+            output.status.success(),
+            "worker {name} failed: {text}{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        text
+    }
+
+    /// A fresh process with every OpenSSL environment variable pointed
+    /// somewhere hostile still opens under the admitted provider, because it
+    /// initialised the library itself before anything could read them.
+    #[test]
+    fn fresh_process_ignores_hostile_openssl_configuration() {
+        let reported =
+            run_worker("engine::process::tests::worker_opens_under_a_hostile_environment");
+        assert!(
+            reported.contains("WORKER opened provider=openssl"),
+            "the hostile configuration reached the provider: {reported}"
+        );
+        assert!(
+            reported.contains("version=OpenSSL 3."),
+            "unexpected provider version: {reported}"
+        );
+    }
+
+    /// And the same process, if it lets the configuration load first, is
+    /// refused rather than quietly running on whatever that configuration
+    /// chose. This is what makes the test above mean something: the hostile
+    /// file is effective, so ignoring it is an achievement rather than a
+    /// no-op.
+    #[test]
+    fn prior_load_config_process_is_rejected_by_profile_gate() {
+        let reported = run_worker(
+            "engine::process::tests::worker_loads_the_hostile_configuration_before_bootstrapping",
+        );
+        assert!(
+            reported.contains("WORKER load_config=1"),
+            "the negative control did not load the configuration: {reported}"
+        );
+        assert!(
+            reported.contains("WORKER refused"),
+            "a process that loaded the hostile configuration still opened a database: {reported}"
+        );
+        assert!(
+            !reported.contains("WORKER opened"),
+            "the open succeeded under the hostile provider: {reported}"
+        );
+    }
 }

--- a/crates/vault-v2-engine/src/engine/sqlcipher.rs
+++ b/crates/vault-v2-engine/src/engine/sqlcipher.rs
@@ -181,6 +181,27 @@ pub(crate) fn open_sqlcipher(
 }
 
 impl HardenedConnection {
+    /// Which crypto provider SQLCipher is actually using on this connection,
+    /// and its version — read from the library rather than inferred from the
+    /// build features.
+    ///
+    /// SQLCipher answers these only once a connection is keyed, which is why
+    /// this is a method on an opened connection. Both values are the
+    /// library's own strings; neither is derived from the key.
+    pub(crate) fn cipher_profile(&self) -> Option<(String, String)> {
+        let provider = self
+            .connection
+            .query_row("PRAGMA cipher_provider", [], |row| row.get::<_, String>(0))
+            .ok()?;
+        let version = self
+            .connection
+            .query_row("PRAGMA cipher_provider_version", [], |row| {
+                row.get::<_, String>(0)
+            })
+            .ok()?;
+        Some((provider, version))
+    }
+
     /// Authenticate every page against its HMAC. Returns only whether they
     /// all passed and, if not, how many did not.
     pub(crate) fn cipher_integrity_check(&self) -> Result<(), IntegrityFailure> {

--- a/crates/vault-v2-engine/tests/ast_gate.rs
+++ b/crates/vault-v2-engine/tests/ast_gate.rs
@@ -495,14 +495,13 @@ fn extension_loading_route_one_is_switched_off_in_source() {
 }
 
 /// The bootstrap is one call, and it is the one that switches configuration
-/// loading off.
+/// loading off. The negative control is one call, and it is the only other
+/// one — inside `#[cfg(test)]`, which is what keeps it out of the binary.
 ///
-/// Like the extension switch above, this cannot be proven by running the
-/// program: `OPENSSL_init_crypto` returns 1 either way, and a process that
-/// loaded a hostile `OPENSSL_CONF` looks identical from the inside until
-/// something asks the provider what it is. The fresh-process qualification
-/// that asks is a separate queued item; the constant itself stays structural
-/// evidence even after it lands.
+/// The constant itself cannot be checked by running this build: OpenSSL
+/// answers 1 to either option, and the fresh-process qualification beside it
+/// proves the *behaviour*. This proves the value the plan pins and that
+/// production code has exactly one way in.
 #[test]
 fn the_openssl_bootstrap_is_one_call_with_config_loading_off() {
     use syn::visit::Visit;
@@ -532,29 +531,55 @@ fn the_openssl_bootstrap_is_one_call_with_config_loading_off() {
         }
     }
 
+    fn is_cfg_test(attribute: &syn::Attribute) -> bool {
+        attribute.path().is_ident("cfg")
+            && attribute
+                .parse_args::<syn::Path>()
+                .is_ok_and(|path| path.is_ident("test"))
+    }
+
+    fn calls_in<'a>(items: impl Iterator<Item = &'a syn::Item>) -> Vec<Option<String>> {
+        let mut calls = Calls(Vec::new());
+        for item in items {
+            calls.visit_item(item);
+        }
+        calls.0
+    }
+
     let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/engine/process.rs");
     let source = std::fs::read_to_string(&path).expect("read process.rs");
     let file = syn::parse_file(&source).expect("parse process.rs");
-    let mut calls = Calls(Vec::new());
-    calls.visit_file(&file);
+
+    // Anything carrying `#[cfg(test)]` is compiled out of the binary; the
+    // rest is what the process actually runs.
+    let (test_only, production): (Vec<&syn::Item>, Vec<&syn::Item>) =
+        file.items.iter().partition(|item| match item {
+            syn::Item::Mod(module) => module.attrs.iter().any(is_cfg_test),
+            syn::Item::Fn(function) => function.attrs.iter().any(is_cfg_test),
+            _ => false,
+        });
 
     assert_eq!(
-        calls.0,
+        calls_in(production.into_iter()),
         vec![Some("OPENSSL_INIT_NO_LOAD_CONFIG".to_owned())],
-        "OPENSSL_init_crypto must be called exactly once, with the pinned \
-         no-load-config constant (None means the argument is not a plain \
-         constant): found {:?}",
-        calls.0
+        "production code must call OPENSSL_init_crypto exactly once, with the pinned \
+         no-load-config constant (None means the argument is not a plain constant)"
+    );
+    assert_eq!(
+        calls_in(test_only.into_iter()),
+        vec![Some("OPENSSL_INIT_LOAD_CONFIG".to_owned())],
+        "the test-only negative control is exactly one call, loading the configuration \
+         the bootstrap refuses to"
     );
 
-    // And that constant holds the value the vendored header gives, so the
-    // call cannot be pointed at a differently-named constant holding 0.
+    // And the pinned constant holds the value the vendored header gives, so
+    // the production call cannot be pointed at a differently-named constant.
     let mut pinned = None;
     for item in &file.items {
         if let syn::Item::Const(constant) = item {
             assert_ne!(
                 constant.ident, "OPENSSL_INIT_LOAD_CONFIG",
-                "the config-loading constant may not be declared in production source"
+                "the config-loading constant may not be declared outside `#[cfg(test)]`"
             );
             if constant.ident == "OPENSSL_INIT_NO_LOAD_CONFIG" {
                 if let syn::Expr::Lit(syn::ExprLit {


### PR DESCRIPTION
Program 1A, Task 1 Step 3 — the behavioural half of #115. That PR landed the bootstrap with **structural evidence only**, because nothing about this build could falsify it: `OPENSSL_init_crypto` returns 1 for either option. This adds the fresh-process qualification the plan asks for.

## Measured before anything was written

The risk in a test like this is writing a hostile configuration that does nothing and calling the result a defence. So the first step was a measurement matrix against this build, not a test:

| `OPENSSL_CONF` | bootstrap | keyed | `cipher_provider` |
| --- | --- | --- | --- |
| none | any | yes | openssl 3.6.3 |
| unparsable file | any | yes | openssl 3.6.3 — **no effect** |
| null-provider-only | none | **no** | **none** |
| null-provider-only | `NO_LOAD_CONFIG` | yes | openssl 3.6.3 |
| null-provider-only | `LOAD_CONFIG` | **no** | **none** |

A configuration activating only OpenSSL's `null` provider really does break the cipher, and initialising with configuration loading off really does prevent it. An unparsable file changes nothing — which is why the adversary here is the null provider and not a corrupt file, and why this matrix is quoted in the source beside the constant.

## The two cases

Each re-executes this test binary for exactly one `#[ignore]`d worker. OpenSSL's initialisation is process-global, so these cannot share a process with each other or with the existing tests: whichever ran first would decide the answer for the rest.

- **`fresh_process_ignores_hostile_openssl_configuration`** — sets `OPENSSL_CONF`, `OPENSSL_CONF_INCLUDE`, `OPENSSL_ENGINES` and `OPENSSL_MODULES` hostile, and requires the admitted provider and version from a real keyed open through `open_sqlcipher`.
- **`prior_load_config_process_is_rejected_by_profile_gate`** — lets the same configuration load first (the test-only negative control the plan admits) and requires the open to be **refused**.

The second is what makes the first mean anything: it shows the hostile file is effective, so ignoring it is an achievement rather than a no-op. In both, the evidence is the provider SQLCipher actually used and whether the open succeeded — never a flag a worker set for itself, which the plan explicitly does not accept.

## Teeth

Sabotaged, each failing **only its own** case:

| Sabotage | First case | Second case |
| --- | --- | --- |
| bootstrap pointed at `LOAD_CONFIG` | **FAILED** | ok |
| negative control stops actually loading the configuration | ok | **FAILED** |

Plus the source pin, now split by `#[cfg(test)]`: production calls `OPENSSL_init_crypto` exactly once with the pinned constant; the negative control is the one other call and lives behind `cfg(test)`; the config-loading constant may not be declared outside it. Adding a second bootstrap path — what the plan forbids as an "alternate bootstrap" — is caught. Removing the `cfg(test)` guard outright does not even compile, since the dev-dependencies are absent from a normal build.

`HardenedConnection` gains `cipher_profile()`, reading the provider from the library rather than inferring it from build features.

`./scripts/test_changed.sh`: ALL GREEN (exit 0).

## Still open in Task 1

The PRAGMA profile readback, `max_page_count`, the read-only reopen, the pinned fixture database, the busy timeout, the closed authorizer, and the five `tests/ui/` compile-fail fixtures. The binary-level proof that the negative control is absent from a release build belongs with that last, queued item; today it rests on rustc's `cfg(test)` exclusion plus the source pin.